### PR TITLE
Remove detect_tag function call

### DIFF
--- a/deploy/kubedb.sh
+++ b/deploy/kubedb.sh
@@ -111,13 +111,8 @@ export KUBEDB_PRIORITY_CLASS=system-cluster-critical
 export APPSCODE_ENV=${APPSCODE_ENV:-prod}
 export SCRIPT_LOCATION="curl -fsSL https://raw.githubusercontent.com/kubedb/installer/0.12.0/"
 if [ "$APPSCODE_ENV" = "dev" ]; then
-  detect_tag
   export SCRIPT_LOCATION="cat "
   export KUBEDB_IMAGE_PULL_POLICY=Always
-fi
-
-if [ ! -z ${CUSTOM_OPERATOR_TAG:-} ]; then
-  export KUBEDB_OPERATOR_TAG="${CUSTOM_OPERATOR_TAG}"
 fi
 
 KUBE_APISERVER_VERSION=$(kubectl version -o=json | $ONESSL jsonpath '{.serverVersion.gitVersion}')


### PR DESCRIPTION
`detect_tag` function is removed in earlier PR. https://github.com/kubedb/installer/pull/2/files#diff-6c05da76313699c3dab3dae1679675b7L50

`CUSTOM_OPERATOR_TAG` has no need/purpose now. Developers can set `KUBEDB_OPERATOR_TAG`.