### PR TITLE
Allow apiserver port change

### DIFF
--- a/chart/kubedb/templates/deployment.yaml
+++ b/chart/kubedb/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
         - --v={{ .Values.logLevel }}
         - --governing-service=kubedb
         - --rbac={{ .Values.rbac.create }}
-        - --secure-port=8443
+        - --secure-port={{ .Values.apiserver.port }}
         - --audit-log-path=-
         - --tls-cert-file=/var/serving-cert/tls.crt
         - --tls-private-key-file=/var/serving-cert/tls.key
@@ -68,7 +68,8 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         ports:
-        - containerPort: 8443
+        - name: https
+          containerPort: {{ .Values.apiserver.port }}
         volumeMounts:
         - mountPath: /var/serving-cert
           name: serving-cert
@@ -76,13 +77,13 @@ spec:
         readinessProbe:
           httpGet:
             path: /healthz
-            port: 8443
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 5
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 8443
+            port: https
             scheme: HTTPS
           initialDelaySeconds: 15
           timeoutSeconds: 15

--- a/chart/kubedb/templates/service.yaml
+++ b/chart/kubedb/templates/service.yaml
@@ -9,14 +9,14 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/path: "/metrics"
-    prometheus.io/port: "8443"
+    prometheus.io/port: {{ .Values.apiserver.port | quote }}
     prometheus.io/scheme: "https"
   {{- end }}
 spec:
   ports:
   - name: api
     port: 443
-    targetPort: 8443
+    targetPort: https
   selector:
     app: "{{ template "kubedb.name" . }}"
     release: "{{ .Release.Name }}"

--- a/chart/kubedb/values.yaml
+++ b/chart/kubedb/values.yaml
@@ -86,6 +86,8 @@ apiserver:
   # healthcheck configures the readiness and liveliness probes for the operator pod.
   healthcheck:
     enabled: true
+  # port used to run the operator
+  port: 8443
 
 # Send usage events to Google Analytics
 enableAnalytics: true


### PR DESCRIPTION
Should fix https://github.com/kubedb/project/issues/577

In my case, the problem is that the master cannot communicate with the kubelet on port `8443` presumably because of the default GKE firewall rules that come when VPC Native IPs are enabled. 

By changing the api port to `443` kubedb now works for me. 

I think 443 should be the default since 8443 is a nonstandard port, however, I left the default as 8443 in case it breaks something I'm not aware of. 