### PR TITLE
Support more Mongodb versions

### DIFF
--- a/chart/kubedb-catalog/templates/mongodb.yaml
+++ b/chart/kubedb-catalog/templates/mongodb.yaml
@@ -89,6 +89,7 @@ spec:
 
 ---
 # After 0.9.0
+
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MongoDBVersion
 metadata:
@@ -197,7 +198,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
     snapshotterPolicyName: mongodb-snapshot
-
 
 ---
 # After 0.11.0
@@ -312,17 +312,101 @@ spec:
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MongoDBVersion
 metadata:
+  name: "3.4.17"
+  labels:
+        {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "3.4.17"
+  db:
+    image: "{{ .Values.dockerRegistry }}/mongo:3.4.17"
+  exporter:
+    image: "{{ .Values.dockerRegistry }}/mongodb_exporter:v1.0.0"
+  tools:
+    image: "{{ .Values.dockerRegistry }}/mongo-tools:3.4.17"
+  initContainer:
+    image: "{{ .Values.dockerRegistry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+    snapshotterPolicyName: mongodb-snapshot
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
+  name: "3.4.22"
+  labels:
+        {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "3.4.22"
+  db:
+    image: "{{ .Values.dockerRegistry }}/mongo:3.4.22"
+  exporter:
+    image: "{{ .Values.dockerRegistry }}/mongodb_exporter:v1.0.0"
+  tools:
+    image: "{{ .Values.dockerRegistry }}/mongo-tools:3.4.22"
+  initContainer:
+    image: "{{ .Values.dockerRegistry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+    snapshotterPolicyName: mongodb-snapshot
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
   name: "3.4-v4"
   labels:
         {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
-  version: "3.4"
+  version: "3.4.22"
   db:
     image: "{{ .Values.dockerRegistry }}/mongo:3.4-v4"
   exporter:
     image: "{{ .Values.dockerRegistry }}/mongodb_exporter:v1.0.0"
   tools:
-    image: "{{ .Values.dockerRegistry }}/mongo-tools:3.4-v3"
+    image: "{{ .Values.dockerRegistry }}/mongo-tools:3.4-v4"
+  initContainer:
+    image: "{{ .Values.dockerRegistry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+    snapshotterPolicyName: mongodb-snapshot
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
+  name: "3.6.8"
+  labels:
+        {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "3.6.8"
+  db:
+    image: "{{ .Values.dockerRegistry }}/mongo:3.6.8"
+  exporter:
+    image: "{{ .Values.dockerRegistry }}/mongodb_exporter:v1.0.0"
+  tools:
+    image: "{{ .Values.dockerRegistry }}/mongo-tools:3.6.8"
+  initContainer:
+    image: "{{ .Values.dockerRegistry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+    snapshotterPolicyName: mongodb-snapshot
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
+  name: "3.6.13"
+  labels:
+        {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "3.6.13"
+  db:
+    image: "{{ .Values.dockerRegistry }}/mongo:3.6.13"
+  exporter:
+    image: "{{ .Values.dockerRegistry }}/mongodb_exporter:v1.0.0"
+  tools:
+    image: "{{ .Values.dockerRegistry }}/mongo-tools:3.6.13"
   initContainer:
     image: "{{ .Values.dockerRegistry }}/busybox"
   podSecurityPolicies:
@@ -337,13 +421,34 @@ metadata:
   labels:
         {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
-  version: "3.6"
+  version: "3.6.13"
   db:
     image: "{{ .Values.dockerRegistry }}/mongo:3.6-v4"
   exporter:
     image: "{{ .Values.dockerRegistry }}/mongodb_exporter:v1.0.0"
   tools:
-    image: "{{ .Values.dockerRegistry }}/mongo-tools:3.6-v3"
+    image: "{{ .Values.dockerRegistry }}/mongo-tools:3.6-v4"
+  initContainer:
+    image: "{{ .Values.dockerRegistry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+    snapshotterPolicyName: mongodb-snapshot
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
+  name: "4.0.3"
+  labels:
+        {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "4.0.3"
+  db:
+    image: "{{ .Values.dockerRegistry }}/mongo:4.0.3"
+  exporter:
+    image: "{{ .Values.dockerRegistry }}/mongodb_exporter:v1.0.0"
+  tools:
+    image: "{{ .Values.dockerRegistry }}/mongo-tools:4.0.3"
   initContainer:
     image: "{{ .Values.dockerRegistry }}/busybox"
   podSecurityPolicies:
@@ -364,7 +469,28 @@ spec:
   exporter:
     image: "{{ .Values.dockerRegistry }}/mongodb_exporter:v1.0.0"
   tools:
-    image: "{{ .Values.dockerRegistry }}/mongo-tools:4.0.5-v1"
+    image: "{{ .Values.dockerRegistry }}/mongo-tools:4.0.5-v2"
+  initContainer:
+    image: "{{ .Values.dockerRegistry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+    snapshotterPolicyName: mongodb-snapshot
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
+  name: "4.0.11"
+  labels:
+        {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "4.0.11"
+  db:
+    image: "{{ .Values.dockerRegistry }}/mongo:4.0.11"
+  exporter:
+    image: "{{ .Values.dockerRegistry }}/mongodb_exporter:v1.0.0"
+  tools:
+    image: "{{ .Values.dockerRegistry }}/mongo-tools:4.0.11"
   initContainer:
     image: "{{ .Values.dockerRegistry }}/busybox"
   podSecurityPolicies:
@@ -379,13 +505,34 @@ metadata:
   labels:
         {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
-  version: "4.0.5"
+  version: "4.0.11"
   db:
     image: "{{ .Values.dockerRegistry }}/mongo:4.0-v2"
   exporter:
     image: "{{ .Values.dockerRegistry }}/mongodb_exporter:v1.0.0"
   tools:
-    image: "{{ .Values.dockerRegistry }}/mongo-tools:4.0-v1"
+    image: "{{ .Values.dockerRegistry }}/mongo-tools:4.0-v2"
+  initContainer:
+    image: "{{ .Values.dockerRegistry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+    snapshotterPolicyName: mongodb-snapshot
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
+  name: "4.1.4"
+  labels:
+        {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "4.1.4"
+  db:
+    image: "{{ .Values.dockerRegistry }}/mongo:4.1.4"
+  exporter:
+    image: "{{ .Values.dockerRegistry }}/mongodb_exporter:v1.0.0"
+  tools:
+    image: "{{ .Values.dockerRegistry }}/mongo-tools:4.1.4"
   initContainer:
     image: "{{ .Values.dockerRegistry }}/busybox"
   podSecurityPolicies:
@@ -406,11 +553,54 @@ spec:
   exporter:
     image: "{{ .Values.dockerRegistry }}/mongodb_exporter:v1.0.0"
   tools:
-    image: "{{ .Values.dockerRegistry }}/mongo-tools:4.1.7-v1"
+    image: "{{ .Values.dockerRegistry }}/mongo-tools:4.1.7-v2"
   initContainer:
     image: "{{ .Values.dockerRegistry }}/busybox"
   podSecurityPolicies:
     databasePolicyName: mongodb-db
     snapshotterPolicyName: mongodb-snapshot
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
+  name: "4.1.13"
+  labels:
+        {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "4.1.13"
+  db:
+    image: "{{ .Values.dockerRegistry }}/mongo:4.1.13"
+  exporter:
+    image: "{{ .Values.dockerRegistry }}/mongodb_exporter:v1.0.0"
+  tools:
+    image: "{{ .Values.dockerRegistry }}/mongo-tools:4.1.13"
+  initContainer:
+    image: "{{ .Values.dockerRegistry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+    snapshotterPolicyName: mongodb-snapshot
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
+  name: "4.1"
+  labels:
+        {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "4.1.13"
+  db:
+    image: "{{ .Values.dockerRegistry }}/mongo:4.1"
+  exporter:
+    image: "{{ .Values.dockerRegistry }}/mongodb_exporter:v1.0.0"
+  tools:
+    image: "{{ .Values.dockerRegistry }}/mongo-tools:4.1"
+  initContainer:
+    image: "{{ .Values.dockerRegistry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+    snapshotterPolicyName: mongodb-snapshot
+
 
 {{ end }}

--- a/deploy/kubedb-catalog/mongodb.yaml
+++ b/deploy/kubedb-catalog/mongodb.yaml
@@ -311,17 +311,101 @@ spec:
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MongoDBVersion
 metadata:
+  name: "3.4.17"
+  labels:
+    app: kubedb
+spec:
+  version: "3.4.17"
+  db:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo:3.4.17"
+  exporter:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongodb_exporter:v1.0.0"
+  tools:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo-tools:3.4.17"
+  initContainer:
+    image: "${KUBEDB_DOCKER_REGISTRY}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+    snapshotterPolicyName: mongodb-snapshot
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
+  name: "3.4.22"
+  labels:
+    app: kubedb
+spec:
+  version: "3.4.22"
+  db:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo:3.4.22"
+  exporter:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongodb_exporter:v1.0.0"
+  tools:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo-tools:3.4.22"
+  initContainer:
+    image: "${KUBEDB_DOCKER_REGISTRY}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+    snapshotterPolicyName: mongodb-snapshot
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
   name: "3.4-v4"
   labels:
     app: kubedb
 spec:
-  version: "3.4"
+  version: "3.4.22"
   db:
     image: "${KUBEDB_DOCKER_REGISTRY}/mongo:3.4-v4"
   exporter:
     image: "${KUBEDB_DOCKER_REGISTRY}/mongodb_exporter:v1.0.0"
   tools:
-    image: "${KUBEDB_DOCKER_REGISTRY}/mongo-tools:3.4-v3"
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo-tools:3.4-v4"
+  initContainer:
+    image: "${KUBEDB_DOCKER_REGISTRY}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+    snapshotterPolicyName: mongodb-snapshot
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
+  name: "3.6.8"
+  labels:
+    app: kubedb
+spec:
+  version: "3.6.8"
+  db:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo:3.6.8"
+  exporter:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongodb_exporter:v1.0.0"
+  tools:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo-tools:3.6.8"
+  initContainer:
+    image: "${KUBEDB_DOCKER_REGISTRY}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+    snapshotterPolicyName: mongodb-snapshot
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
+  name: "3.6.13"
+  labels:
+    app: kubedb
+spec:
+  version: "3.6.13"
+  db:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo:3.6.13"
+  exporter:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongodb_exporter:v1.0.0"
+  tools:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo-tools:3.6.13"
   initContainer:
     image: "${KUBEDB_DOCKER_REGISTRY}/busybox"
   podSecurityPolicies:
@@ -336,13 +420,34 @@ metadata:
   labels:
     app: kubedb
 spec:
-  version: "3.6"
+  version: "3.6.13"
   db:
     image: "${KUBEDB_DOCKER_REGISTRY}/mongo:3.6-v4"
   exporter:
     image: "${KUBEDB_DOCKER_REGISTRY}/mongodb_exporter:v1.0.0"
   tools:
-    image: "${KUBEDB_DOCKER_REGISTRY}/mongo-tools:3.6-v3"
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo-tools:3.6-v4"
+  initContainer:
+    image: "${KUBEDB_DOCKER_REGISTRY}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+    snapshotterPolicyName: mongodb-snapshot
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
+  name: "4.0.3"
+  labels:
+    app: kubedb
+spec:
+  version: "4.0.3"
+  db:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo:4.0.3"
+  exporter:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongodb_exporter:v1.0.0"
+  tools:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo-tools:4.0.3"
   initContainer:
     image: "${KUBEDB_DOCKER_REGISTRY}/busybox"
   podSecurityPolicies:
@@ -363,7 +468,28 @@ spec:
   exporter:
     image: "${KUBEDB_DOCKER_REGISTRY}/mongodb_exporter:v1.0.0"
   tools:
-    image: "${KUBEDB_DOCKER_REGISTRY}/mongo-tools:4.0.5-v1"
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo-tools:4.0.5-v2"
+  initContainer:
+    image: "${KUBEDB_DOCKER_REGISTRY}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+    snapshotterPolicyName: mongodb-snapshot
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
+  name: "4.0.11"
+  labels:
+    app: kubedb
+spec:
+  version: "4.0.11"
+  db:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo:4.0.11"
+  exporter:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongodb_exporter:v1.0.0"
+  tools:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo-tools:4.0.11"
   initContainer:
     image: "${KUBEDB_DOCKER_REGISTRY}/busybox"
   podSecurityPolicies:
@@ -378,13 +504,34 @@ metadata:
   labels:
     app: kubedb
 spec:
-  version: "4.0.5"
+  version: "4.0.11"
   db:
     image: "${KUBEDB_DOCKER_REGISTRY}/mongo:4.0-v2"
   exporter:
     image: "${KUBEDB_DOCKER_REGISTRY}/mongodb_exporter:v1.0.0"
   tools:
-    image: "${KUBEDB_DOCKER_REGISTRY}/mongo-tools:4.0-v1"
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo-tools:4.0-v2"
+  initContainer:
+    image: "${KUBEDB_DOCKER_REGISTRY}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+    snapshotterPolicyName: mongodb-snapshot
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
+  name: "4.1.4"
+  labels:
+    app: kubedb
+spec:
+  version: "4.1.4"
+  db:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo:4.1.4"
+  exporter:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongodb_exporter:v1.0.0"
+  tools:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo-tools:4.1.4"
   initContainer:
     image: "${KUBEDB_DOCKER_REGISTRY}/busybox"
   podSecurityPolicies:
@@ -405,7 +552,49 @@ spec:
   exporter:
     image: "${KUBEDB_DOCKER_REGISTRY}/mongodb_exporter:v1.0.0"
   tools:
-    image: "${KUBEDB_DOCKER_REGISTRY}/mongo-tools:4.1.7-v1"
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo-tools:4.1.7-v2"
+  initContainer:
+    image: "${KUBEDB_DOCKER_REGISTRY}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+    snapshotterPolicyName: mongodb-snapshot
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
+  name: "4.1.13"
+  labels:
+    app: kubedb
+spec:
+  version: "4.1.13"
+  db:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo:4.1.13"
+  exporter:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongodb_exporter:v1.0.0"
+  tools:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo-tools:4.1.13"
+  initContainer:
+    image: "${KUBEDB_DOCKER_REGISTRY}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+    snapshotterPolicyName: mongodb-snapshot
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
+  name: "4.1"
+  labels:
+    app: kubedb
+spec:
+  version: "4.1.13"
+  db:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo:4.1"
+  exporter:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongodb_exporter:v1.0.0"
+  tools:
+    image: "${KUBEDB_DOCKER_REGISTRY}/mongo-tools:4.1"
   initContainer:
     image: "${KUBEDB_DOCKER_REGISTRY}/busybox"
   podSecurityPolicies:


### PR DESCRIPTION
`mongo` and `mongo-tools` shared tags:

- 3.4.17
- 3.4.22 => 3.4-v4
- 3.6.8
- 3.6.13 => 3.6-v4
- 4.0.3
- 4.0.5-v2
- 4.0.11 => 4.0-v2
- 4.1.4
- 4.1.7-v2
- 4.1.13 => 4.1

Here, Pre-SSPL (before October 16, 2018) versions:

- 3.4.17
- 3.6.8
- 4.0.3
- 4.1.4

Fixes https://github.com/kubedb/project/issues/614