### PR TITLE
Add namespace to cleaner Job

### DIFF
--- a/chart/kubedb/templates/cleaner.yaml
+++ b/chart/kubedb/templates/cleaner.yaml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ .Release.Name }}-cleaner
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubedb.labels" . | nindent 4 }}
   annotations:


### PR DESCRIPTION
When installing kubedb in a namespace other than `default`, the Job will never get executed and fails to create with 

> Error creating: pods "kubedb-operator-cleaner-" is forbidden: error looking up service account default/kubedb-operator: serviceaccount "kubedb-operator" not found