### PR TITLE
Fix RBAC permissions for Stash restoresessions

### DIFF
--- a/charts/kubedb/templates/cluster-role.yaml
+++ b/charts/kubedb/templates/cluster-role.yaml
@@ -133,7 +133,7 @@ rules:
   - poddisruptionbudgets
   verbs: ["get", "list", "create", "delete", "patch"]
 - apiGroups:
-  - kubedb.com
+  - stash.appscode.com
   resources:
   - restoresessions
   verbs: ["get", "list", "watch"]

--- a/deploy/rbac-list.yaml
+++ b/deploy/rbac-list.yaml
@@ -131,7 +131,7 @@ rules:
   - poddisruptionbudgets
   verbs: ["get", "list", "create", "delete", "patch"]
 - apiGroups:
-  - kubedb.com
+  - stash.appscode.com
   resources:
   - restoresessions
   verbs: ["get", "list", "watch"]


### PR DESCRIPTION
Changed by mistake in https://github.com/kubedb/installer/commit/b24b05e18c7fc59cab4a9da126f7631acb3c9452#diff-148edb39f7cfdfba7fdda1069bd3e762L136

Signed-off-by: Tamal Saha <tamal@appscode.com>