### PR TITLE
Fix helm install --wait flag

### DIFF
--- a/charts/kubedb/templates/appcatalog-user-roles.yaml
+++ b/charts/kubedb/templates/appcatalog-user-roles.yaml
@@ -6,7 +6,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
 rules:
 - apiGroups:
@@ -22,7 +22,7 @@ metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
 rules:
 - apiGroups:

--- a/charts/kubedb/templates/mutating-webhook.yaml
+++ b/charts/kubedb/templates/mutating-webhook.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     {{- include "kubedb.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
 webhooks:
 {{- if or (eq .Values.kubedb.repository "operator") (eq .Values.kubedb.repository "kubedb-operator") (eq .Values.kubedb.repository "es-operator") }}

--- a/charts/kubedb/templates/user-roles.yaml
+++ b/charts/kubedb/templates/user-roles.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
 rules:
 - apiGroups:
@@ -22,7 +22,7 @@ metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
 rules:
 - apiGroups:
@@ -63,7 +63,7 @@ metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
 rules:
 - apiGroups:

--- a/charts/kubedb/templates/validating-webhook.yaml
+++ b/charts/kubedb/templates/validating-webhook.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     {{- include "kubedb.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
 webhooks:
 {{- if or (eq .Values.kubedb.repository "operator") (eq .Values.kubedb.repository "kubedb-operator") (eq .Values.kubedb.repository "es-operator") }}


### PR DESCRIPTION
Signed-off-by: Arthur Outhenin-Chalandre <arthur@cri.epita.fr>

This PR removes the post-install hook on some cluster roles. I see no reason to have these hooks in the first place (but maybe there is one?). It also fixes this issue https://github.com/kubedb/issues/issues/522.