### PR TITLE
Fix tolerations indentation for deployment

### DIFF
--- a/charts/kubedb/templates/deployment.yaml
+++ b/charts/kubedb/templates/deployment.yaml
@@ -140,8 +140,8 @@ spec:
 {{ toYaml .Values.tolerations | indent 8 }}
 {{- end -}}
 {{- if and .Values.criticalAddon (eq .Release.Namespace "kube-system") }}
-      - key: CriticalAddonsOnly
-        operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists
 {{- end -}}
 {{- end -}}
 {{- if .Values.affinity }}


### PR DESCRIPTION
Hi,

If we both use `criticalAddon: true` and
`tolerations: {...}`, generated yaml is not correct.

This PR adds correct indentation for critical addons toleration