### PR TITLE
memcached: add 1.5.22

### DIFF
--- a/charts/kubedb-catalog/templates/memcached.yaml
+++ b/charts/kubedb-catalog/templates/memcached.yaml
@@ -65,4 +65,20 @@ spec:
   podSecurityPolicies:
     databasePolicyName: memcached-db
 
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MemcachedVersion
+metadata:
+  name: "1.5.22"
+  labels:
+    {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "1.5.22"
+  db:
+    image: "{{ .Values.dockerRegistry }}/memcached:1.5.22"
+  exporter:
+    image: "{{ .Values.dockerRegistry }}/memcached-exporter:v0.4.1"
+  podSecurityPolicies:
+    databasePolicyName: memcached-db
+
 {{ end }}


### PR DESCRIPTION
The newer release is needed for PMEM and probably also various bug
fixes.

Related-to: https://github.com/kubedb/issues/issues/690

Signed-off-by: Patrick Ohly <patrick.ohly@intel.com>