### PR TITLE
Add MySQL new Version

### DIFF
--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.25.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.25.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
+  deprecated: true
   version: "5.7.25"
   db:
     image: "{{ .Values.image.registry }}/mysql:5.7.25"
@@ -21,5 +22,40 @@ spec:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
     databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: ["5.7.25"]
+      groupReplication: ["5.7.25"]
+    blacklist:
+      standAlone: []
+      groupReplication: []
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MySQLVersion
+metadata:
+  name: "5.7.25-v1"
+  labels:
+  {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "5.7.25"
+  db:
+    image: "{{ .Values.image.registry }}/mysql:5.7.25-v1"
+  exporter:
+    image: "{{ .Values.image.registry }}/mysqld-exporter:v0.11.0"
+  tools:
+    image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
+  replicationModeDetector:
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.0.1"
+  initContainer:
+    image: "{{ .Values.image.registry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: []
+      groupReplication: []
+    blacklist:
+      standAlone: ["< 5.7.25"]
+      groupReplication: ["< 5.7.25", "<= 8.0.20, >= 8.0.19"]
 
 {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.25.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.25.yaml
@@ -25,11 +25,8 @@ spec:
     databasePolicyName: mysql-db
   upgradeConstraints:
     whitelist:
-      standAlone: ["5.7.25"]
+      standalone: ["5.7.25"]
       groupReplication: ["5.7.25"]
-    blacklist:
-      standAlone: []
-      groupReplication: []
 {{- end }}
 ---
 apiVersion: catalog.kubedb.com/v1alpha1
@@ -53,11 +50,8 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   upgradeConstraints:
-    whitelist:
-      standAlone: []
-      groupReplication: []
     blacklist:
-      standAlone: ["< 5.7.25"]
-      groupReplication: ["< 5.7.25", "<= 8.0.20, >= 8.0.19"]
+      standalone: ["< 5.7.25"]
+      groupReplication: ["< 5.7.25", "8.0.20", "8.0.19"]
 
 {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.25.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.25.yaml
@@ -1,12 +1,13 @@
 {{ if .Values.catalog.mysql }}
 
+{{- if not .Values.skipDeprecated }}
 ---
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MySQLVersion
 metadata:
   name: "5.7.25"
   labels:
-    {{- include "kubedb-catalog.labels" . | nindent 4 }}
+  {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   deprecated: true
   version: "5.7.25"
@@ -29,6 +30,7 @@ spec:
     blacklist:
       standAlone: []
       groupReplication: []
+{{- end }}
 ---
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MySQLVersion

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.29.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.29.yaml
@@ -1,0 +1,32 @@
+{{ if .Values.catalog.mysql }}
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MySQLVersion
+metadata:
+  name: "5.7.29"
+  labels:
+  {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "5.7.29"
+  db:
+    image: "{{ .Values.image.registry }}/mysql:5.7.29"
+  exporter:
+    image: "{{ .Values.image.registry }}/mysqld-exporter:v0.11.0"
+  tools:
+    image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
+  replicationModeDetector:
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.0.1"
+  initContainer:
+    image: "{{ .Values.image.registry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: []
+      groupReplication: []
+    blacklist:
+      standAlone: ["< 5.7.29"]
+      groupReplication: ["< 5.7.29"]
+
+  {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.29.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.29.yaml
@@ -21,11 +21,8 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   upgradeConstraints:
-    whitelist:
-      standAlone: []
-      groupReplication: []
     blacklist:
-      standAlone: ["< 5.7.29"]
+      standalone: ["< 5.7.29"]
       groupReplication: ["< 5.7.29"]
 
   {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.29.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.29.yaml
@@ -1,5 +1,4 @@
 {{ if .Values.catalog.mysql }}
-
 ---
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MySQLVersion

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.yaml
@@ -97,6 +97,7 @@ spec:
       groupReplication: []
 {{- end }}
 
+{{- if not .Values.skipDeprecated }}
 ---
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MySQLVersion
@@ -126,6 +127,7 @@ spec:
     blacklist:
       standAlone: []
       groupReplication: []
+{{- end }}
 ---
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MySQLVersion

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.yaml
@@ -25,11 +25,8 @@ spec:
     databasePolicyName: mysql-db
   upgradeConstraints:
     whitelist:
-      standAlone: ["5.7"]
+      standalone: ["5.7"]
       groupReplication: ["5.7"]
-    blacklist:
-      standAlone: []
-      groupReplication: []
 {{- end }}
 
 {{- if not .Values.skipDeprecated }}
@@ -57,11 +54,8 @@ spec:
     databasePolicyName: mysql-db
   upgradeConstraints:
     whitelist:
-      standAlone: ["5.7"]
+      standalone: ["5.7"]
       groupReplication: ["5.7"]
-    blacklist:
-      standAlone: []
-      groupReplication: []
 {{- end }}
 
 {{- if not .Values.skipDeprecated }}
@@ -90,11 +84,8 @@ spec:
     databasePolicyName: mysql-db
   upgradeConstraints:
     whitelist:
-      standAlone: ["5.7.25"]
+      standalone: ["5.7.25"]
       groupReplication: ["5.7.25"]
-    blacklist:
-      standAlone: []
-      groupReplication: []
 {{- end }}
 
 {{- if not .Values.skipDeprecated }}
@@ -122,11 +113,8 @@ spec:
     databasePolicyName: mysql-db
   upgradeConstraints:
     whitelist:
-      standAlone: ["5.7.25"]
+      standalone: ["5.7.25"]
       groupReplication: ["5.7.25"]
-    blacklist:
-      standAlone: []
-      groupReplication: []
 {{- end }}
 ---
 apiVersion: catalog.kubedb.com/v1alpha1
@@ -150,11 +138,8 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   upgradeConstraints:
-    whitelist:
-      standAlone: []
-      groupReplication: []
     blacklist:
-      standAlone: ["< 5.7.29"]
+      standalone: ["< 5.7.29"]
       groupReplication: ["< 5.7.29"]
 
 {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.yaml
@@ -23,6 +23,13 @@ spec:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
     databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: ["5.7"]
+      groupReplication: ["5.7"]
+    blacklist:
+      standAlone: []
+      groupReplication: []
 {{- end }}
 
 {{- if not .Values.skipDeprecated }}
@@ -48,6 +55,13 @@ spec:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
     databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: ["5.7"]
+      groupReplication: ["5.7"]
+    blacklist:
+      standAlone: []
+      groupReplication: []
 {{- end }}
 
 {{- if not .Values.skipDeprecated }}
@@ -74,6 +88,13 @@ spec:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
     databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: ["5.7.25"]
+      groupReplication: ["5.7.25"]
+    blacklist:
+      standAlone: []
+      groupReplication: []
 {{- end }}
 
 ---
@@ -84,6 +105,7 @@ metadata:
   labels:
   {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
+  deprecated: true
   version: "5.7.25"
   db:
     image: "{{ .Values.image.registry }}/mysql:5.7.25"
@@ -97,5 +119,40 @@ spec:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
     databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: ["5.7.25"]
+      groupReplication: ["5.7.25"]
+    blacklist:
+      standAlone: []
+      groupReplication: []
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MySQLVersion
+metadata:
+  name: "5.7-v4"
+  labels:
+  {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "5.7.29"
+  db:
+    image: "{{ .Values.image.registry }}/mysql:5.7.29"
+  exporter:
+    image: "{{ .Values.image.registry }}/mysqld-exporter:v0.11.0"
+  tools:
+    image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
+  replicationModeDetector:
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.0.1"
+  initContainer:
+    image: "{{ .Values.image.registry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: []
+      groupReplication: []
+    blacklist:
+      standAlone: ["< 5.7.29"]
+      groupReplication: ["< 5.7.29"]
 
 {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.yaml
@@ -23,6 +23,13 @@ spec:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
     databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: ["5"]
+      groupReplication: ["5"]
+    blacklist:
+      standAlone: []
+      groupReplication: []
 {{- end }}
 
 {{- if not .Values.skipDeprecated }}
@@ -48,6 +55,13 @@ spec:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
     databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: ["5"]
+      groupReplication: ["5"]
+    blacklist:
+      standAlone: []
+      groupReplication: []
 {{- end }}
 
 {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.yaml
@@ -25,11 +25,8 @@ spec:
     databasePolicyName: mysql-db
   upgradeConstraints:
     whitelist:
-      standAlone: ["5"]
+      standalone: ["5"]
       groupReplication: ["5"]
-    blacklist:
-      standAlone: []
-      groupReplication: []
 {{- end }}
 
 {{- if not .Values.skipDeprecated }}
@@ -57,11 +54,8 @@ spec:
     databasePolicyName: mysql-db
   upgradeConstraints:
     whitelist:
-      standAlone: ["5"]
+      standalone: ["5"]
       groupReplication: ["5"]
-    blacklist:
-      standAlone: []
-      groupReplication: []
 {{- end }}
 
 {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.14.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.14.yaml
@@ -25,11 +25,8 @@ spec:
     databasePolicyName: mysql-db
   upgradeConstraints:
     whitelist:
-      standAlone: ["8.0.14"]
+      standalone: ["8.0.14"]
       groupReplication: ["8.0.14"]
-    blacklist:
-      standAlone: []
-      groupReplication: []
 {{- end }}
 ---
 apiVersion: catalog.kubedb.com/v1alpha1
@@ -53,11 +50,8 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   upgradeConstraints:
-    whitelist:
-      standAlone: []
-      groupReplication: []
     blacklist:
-      standAlone: ["< 8.0.14"]
+      standalone: ["< 8.0.14"]
       groupReplication: ["< 8.0.14"]
 
 {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.14.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.14.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
+  deprecated: true
   version: "8.0.14"
   db:
     image: "{{ .Values.image.registry }}/mysql:8.0.14"
@@ -21,5 +22,40 @@ spec:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
     databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: ["8.0.14"]
+      groupReplication: ["8.0.14"]
+    blacklist:
+      standAlone: []
+      groupReplication: []
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MySQLVersion
+metadata:
+  name: "8.0.14-v1"
+  labels:
+  {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "8.0.14"
+  db:
+    image: "{{ .Values.image.registry }}/mysql:8.0.14-v1"
+  exporter:
+    image: "{{ .Values.image.registry }}/mysqld-exporter:v0.11.0"
+  tools:
+    image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
+  replicationModeDetector:
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.0.1"
+  initContainer:
+    image: "{{ .Values.image.registry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: []
+      groupReplication: []
+    blacklist:
+      standAlone: ["< 8.0.14"]
+      groupReplication: ["< 8.0.14"]
 
 {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.14.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.14.yaml
@@ -1,5 +1,6 @@
 {{ if .Values.catalog.mysql }}
 
+{{- if not .Values.skipDeprecated }}
 ---
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MySQLVersion
@@ -29,6 +30,7 @@ spec:
     blacklist:
       standAlone: []
       groupReplication: []
+{{- end }}
 ---
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MySQLVersion

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.18.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.18.yaml
@@ -22,11 +22,8 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   upgradeConstraints:
-    whitelist:
-      standAlone: []
-      groupReplication: []
     blacklist:
-      standAlone: ["< 8.0.18"]
+      standalone: ["< 8.0.18"]
       groupReplication: ["< 8.0.18"]
 
   {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.18.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.18.yaml
@@ -1,0 +1,32 @@
+{{ if .Values.catalog.mysql }}
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MySQLVersion
+metadata:
+  name: "8.0.18"
+  labels:
+  {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "8.0.18"
+  db:
+    image: "{{ .Values.image.registry }}/mysql:8.0.18"
+  exporter:
+    image: "{{ .Values.image.registry }}/mysqld-exporter:v0.11.0"
+  tools:
+    image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
+  replicationModeDetector:
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.0.1"
+  initContainer:
+    image: "{{ .Values.image.registry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: []
+      groupReplication: []
+    blacklist:
+      standAlone: ["< 8.0.18"]
+      groupReplication: ["< 8.0.18"]
+
+  {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.19.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.19.yaml
@@ -1,0 +1,32 @@
+{{ if .Values.catalog.mysql }}
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MySQLVersion
+metadata:
+  name: "8.0.19"
+  labels:
+  {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "8.0.19"
+  db:
+    image: "{{ .Values.image.registry }}/mysql:8.0.19"
+  exporter:
+    image: "{{ .Values.image.registry }}/mysqld-exporter:v0.11.0"
+  tools:
+    image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
+  replicationModeDetector:
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.0.1"
+  initContainer:
+    image: "{{ .Values.image.registry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: []
+      groupReplication: []
+    blacklist:
+      standAlone: ["< 8.0.19"]
+      groupReplication: ["< 8.0.19"]
+
+  {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.19.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.19.yaml
@@ -22,11 +22,8 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   upgradeConstraints:
-    whitelist:
-      standAlone: []
-      groupReplication: []
     blacklist:
-      standAlone: ["< 8.0.19"]
+      standalone: ["< 8.0.19"]
       groupReplication: ["< 8.0.19"]
 
   {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.20.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.20.yaml
@@ -1,0 +1,32 @@
+{{ if .Values.catalog.mysql }}
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MySQLVersion
+metadata:
+  name: "8.0.20"
+  labels:
+  {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "8.0.20"
+  db:
+    image: "{{ .Values.image.registry }}/mysql:8.0.20"
+  exporter:
+    image: "{{ .Values.image.registry }}/mysqld-exporter:v0.11.0"
+  tools:
+    image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
+  replicationModeDetector:
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.0.1"
+  initContainer:
+    image: "{{ .Values.image.registry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: []
+      groupReplication: []
+    blacklist:
+      standAlone: ["< 8.0.20"]
+      groupReplication: ["< 8.0.20"]
+
+  {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.20.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.20.yaml
@@ -22,11 +22,8 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   upgradeConstraints:
-    whitelist:
-      standAlone: []
-      groupReplication: []
     blacklist:
-      standAlone: ["< 8.0.20"]
+      standalone: ["< 8.0.20"]
       groupReplication: ["< 8.0.20"]
 
   {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.3.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.3.yaml
@@ -1,5 +1,6 @@
 {{ if .Values.catalog.mysql }}
 
+{{- if not .Values.skipDeprecated }}
 ---
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MySQLVersion
@@ -29,6 +30,7 @@ spec:
     blacklist:
       standAlone: []
       groupReplication: []
+{{- end }}
 ---
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MySQLVersion

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.3.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.3.yaml
@@ -25,11 +25,8 @@ spec:
     databasePolicyName: mysql-db
   upgradeConstraints:
     whitelist:
-      standAlone: ["8.0.3"]
+      standalone: ["8.0.3"]
       groupReplication: ["8.0.3"]
-    blacklist:
-      standAlone: []
-      groupReplication: []
 {{- end }}
 ---
 apiVersion: catalog.kubedb.com/v1alpha1
@@ -54,10 +51,7 @@ spec:
     databasePolicyName: mysql-db
   upgradeConstraints:
     whitelist:
-      standAlone: ["8.0.3"]
+      standalone: ["8.0.3"]
       groupReplication: ["8.0.3"]
-    blacklist:
-      standAlone: []
-      groupReplication: []
 
 {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.3.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.3.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
+  deprecated: true
   version: "8.0.3"
   db:
     image: "{{ .Values.image.registry }}/mysql:8.0.3"
@@ -21,5 +22,40 @@ spec:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
     databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: ["8.0.3"]
+      groupReplication: ["8.0.3"]
+    blacklist:
+      standAlone: []
+      groupReplication: []
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MySQLVersion
+metadata:
+  name: "8.0.3-v1"
+  labels:
+  {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "8.0.3"
+  db:
+    image: "{{ .Values.image.registry }}/mysql:8.0.3-v1"
+  exporter:
+    image: "{{ .Values.image.registry }}/mysqld-exporter:v0.11.0"
+  tools:
+    image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
+  replicationModeDetector:
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.0.1"
+  initContainer:
+    image: "{{ .Values.image.registry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: ["8.0.3"]
+      groupReplication: ["8.0.3"]
+    blacklist:
+      standAlone: []
+      groupReplication: []
 
 {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.yaml
@@ -64,6 +64,7 @@ spec:
       groupReplication: []
 {{- end }}
 
+{{- if not .Values.skipDeprecated }}
 ---
 # After 0.9.0
 apiVersion: catalog.kubedb.com/v1alpha1
@@ -94,6 +95,7 @@ spec:
     blacklist:
       standAlone: []
       groupReplication: []
+{{- end }}
 ---
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: MySQLVersion

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.yaml
@@ -23,6 +23,13 @@ spec:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
     databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: ["8.0"]
+      groupReplication: ["8.0"]
+    blacklist:
+      standAlone: []
+      groupReplication: []
 {{- end }}
 
 {{- if not .Values.skipDeprecated }}
@@ -48,6 +55,13 @@ spec:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
     databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: ["8.0.3"]
+      groupReplication: ["8.0.3"]
+    blacklist:
+      standAlone: []
+      groupReplication: []
 {{- end }}
 
 ---
@@ -59,6 +73,7 @@ metadata:
   labels:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
+  deprecated: true
   version: "8.0.14"
   db:
     image: "{{ .Values.image.registry }}/mysql:8.0-v2"
@@ -72,5 +87,40 @@ spec:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
     databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: ["8.0.14"]
+      groupReplication: ["8.0.14"]
+    blacklist:
+      standAlone: []
+      groupReplication: []
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MySQLVersion
+metadata:
+  name: "8.0-v3"
+  labels:
+  {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "8.0.20"
+  db:
+    image: "{{ .Values.image.registry }}/mysql:8.0.20"
+  exporter:
+    image: "{{ .Values.image.registry }}/mysqld-exporter:v0.11.0"
+  tools:
+    image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
+  replicationModeDetector:
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.0.1"
+  initContainer:
+    image: "{{ .Values.image.registry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: []
+      groupReplication: []
+    blacklist:
+      standAlone: ["< 8.0.20"]
+      groupReplication: ["< 8.0.20"]
 
 {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.yaml
@@ -25,11 +25,8 @@ spec:
     databasePolicyName: mysql-db
   upgradeConstraints:
     whitelist:
-      standAlone: ["8.0"]
+      standalone: ["8.0"]
       groupReplication: ["8.0"]
-    blacklist:
-      standAlone: []
-      groupReplication: []
 {{- end }}
 
 {{- if not .Values.skipDeprecated }}
@@ -57,11 +54,8 @@ spec:
     databasePolicyName: mysql-db
   upgradeConstraints:
     whitelist:
-      standAlone: ["8.0.3"]
+      standalone: ["8.0.3"]
       groupReplication: ["8.0.3"]
-    blacklist:
-      standAlone: []
-      groupReplication: []
 {{- end }}
 
 {{- if not .Values.skipDeprecated }}
@@ -90,11 +84,8 @@ spec:
     databasePolicyName: mysql-db
   upgradeConstraints:
     whitelist:
-      standAlone: ["8.0.14"]
+      standalone: ["8.0.14"]
       groupReplication: ["8.0.14"]
-    blacklist:
-      standAlone: []
-      groupReplication: []
 {{- end }}
 ---
 apiVersion: catalog.kubedb.com/v1alpha1
@@ -118,11 +109,8 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   upgradeConstraints:
-    whitelist:
-      standAlone: []
-      groupReplication: []
     blacklist:
-      standAlone: ["< 8.0.20"]
+      standalone: ["< 8.0.20"]
       groupReplication: ["< 8.0.20"]
 
 {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.yaml
@@ -25,11 +25,8 @@ spec:
     databasePolicyName: mysql-db
   upgradeConstraints:
     whitelist:
-      standAlone: ["8"]
+      standalone: ["8"]
       groupReplication: ["8"]
-    blacklist:
-      standAlone: []
-      groupReplication: []
 {{- end }}
 
 {{- if not .Values.skipDeprecated }}
@@ -57,11 +54,8 @@ spec:
     databasePolicyName: mysql-db
   upgradeConstraints:
     whitelist:
-      standAlone: ["8"]
+      standalone: ["8"]
       groupReplication: ["8"]
-    blacklist:
-      standAlone: []
-      groupReplication: []
 {{- end }}
 
 {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.yaml
@@ -23,6 +23,13 @@ spec:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
     databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: ["8"]
+      groupReplication: ["8"]
+    blacklist:
+      standAlone: []
+      groupReplication: []
 {{- end }}
 
 {{- if not .Values.skipDeprecated }}
@@ -48,6 +55,13 @@ spec:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
     databasePolicyName: mysql-db
+  upgradeConstraints:
+    whitelist:
+      standAlone: ["8"]
+      groupReplication: ["8"]
+    blacklist:
+      standAlone: []
+      groupReplication: []
 {{- end }}
 
 {{ end }}


### PR DESCRIPTION
Downgrade from MySQL 8.0 to MySQL 5.7, or from a MySQL 8.0 release to a previous MySQL 8.0 release, is not supported.

ref: https://dev.mysql.com/doc/refman/8.0/en/downgrading.html

Signed-off-by: suaas21 <sagor@appscode.com>