### PR TITLE
Prepare for release v0.14.0-beta.1

### DIFF
--- a/charts/kubedb-catalog/Chart.yaml
+++ b/charts/kubedb-catalog/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: 'KubeDB Catalog by AppsCode - Catalog for database versions'
 name: kubedb-catalog
-version: v0.14.0-alpha.2
-appVersion: v0.14.0-alpha.2
+version: v0.14.0-beta.1
+appVersion: v0.14.0-beta.1
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/icon/kubedb.png
 sources:

--- a/charts/kubedb-catalog/README.md
+++ b/charts/kubedb-catalog/README.md
@@ -5,9 +5,9 @@
 ## TL;DR;
 
 ```console
-$ helm repo add appscode https://charts.appscode.com/stable/
+$ helm repo add appscode-testing https://charts.appscode.com/testing/
 $ helm repo update
-$ helm install kubedb-catalog appscode/kubedb-catalog -n kube-system
+$ helm install kubedb-catalog appscode-testing/kubedb-catalog -n kube-system
 ```
 
 ## Introduction
@@ -23,7 +23,7 @@ This chart deploys KubeDB catalog on a [Kubernetes](http://kubernetes.io) cluste
 To install the chart with the release name `kubedb-catalog`:
 
 ```console
-$ helm install kubedb-catalog appscode/kubedb-catalog -n kube-system
+$ helm install kubedb-catalog appscode-testing/kubedb-catalog -n kube-system
 ```
 
 The command deploys KubeDB catalog on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -65,12 +65,12 @@ The following table lists the configurable parameters of the `kubedb-catalog` ch
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 
 ```console
-$ helm install kubedb-catalog appscode/kubedb-catalog -n kube-system --set image.registry=kubedb
+$ helm install kubedb-catalog appscode-testing/kubedb-catalog -n kube-system --set image.registry=kubedb
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```console
-$ helm install kubedb-catalog appscode/kubedb-catalog -n kube-system --values values.yaml
+$ helm install kubedb-catalog appscode-testing/kubedb-catalog -n kube-system --values values.yaml
 ```

--- a/charts/kubedb-catalog/doc.yaml
+++ b/charts/kubedb-catalog/doc.yaml
@@ -5,8 +5,8 @@ project:
   description: Catalog of database versions supported by KubeDB
   app: KubeDB catalog
 repository:
-  url: https://charts.appscode.com/stable/
-  name: appscode
+  url: https://charts.appscode.com/testing/
+  name: appscode-testing
 chart:
   name: kubedb-catalog
   values: "-- generate from values file --"

--- a/charts/kubedb/Chart.yaml
+++ b/charts/kubedb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: 'KubeDB by AppsCode - Production ready databases on Kubernetes'
 name: kubedb
-version: v0.14.0-alpha.2
-appVersion: v0.14.0-alpha.2
+version: v0.14.0-beta.1
+appVersion: v0.14.0-beta.1
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/icon/kubedb.png
 sources:

--- a/charts/kubedb/README.md
+++ b/charts/kubedb/README.md
@@ -5,9 +5,9 @@
 ## TL;DR;
 
 ```console
-$ helm repo add appscode https://charts.appscode.com/stable/
+$ helm repo add appscode-testing https://charts.appscode.com/testing/
 $ helm repo update
-$ helm install kubedb-operator appscode/kubedb -n kube-system
+$ helm install kubedb-operator appscode-testing/kubedb -n kube-system
 ```
 
 ## Introduction
@@ -23,7 +23,7 @@ This chart deploys a KubeDB operator on a [Kubernetes](http://kubernetes.io) clu
 To install the chart with the release name `kubedb-operator`:
 
 ```console
-$ helm install kubedb-operator appscode/kubedb -n kube-system
+$ helm install kubedb-operator appscode-testing/kubedb -n kube-system
 ```
 
 The command deploys a KubeDB operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -51,7 +51,7 @@ The following table lists the configurable parameters of the `kubedb` chart and 
 | replicaCount                          | Number of KubeDB operator replicas to create (only 1 is supported)                                                                                                                                                                                | `1`                                                                   |
 | operator.registry                     | Docker registry used to pull KubeDB operator image                                                                                                                                                                                                | `kubedb`                                                              |
 | operator.repository                   | KubeDB operator container image                                                                                                                                                                                                                   | `operator`                                                            |
-| operator.tag                          | KubeDB operator container image tag                                                                                                                                                                                                               | `v0.14.0-alpha.2`                                                     |
+| operator.tag                          | KubeDB operator container image tag                                                                                                                                                                                                               | `v0.14.0-beta.1`                                                      |
 | operator.resources                    | Compute Resources required by the operator container                                                                                                                                                                                              | `{}`                                                                  |
 | operator.securityContext              | requests: cpu: 100m memory: 128Mi Security options the operator container should run with                                                                                                                                                         | `{}`                                                                  |
 | cleaner.registry                      | Docker registry used to pull Webhook cleaner image                                                                                                                                                                                                | `appscode`                                                            |
@@ -94,12 +94,12 @@ The following table lists the configurable parameters of the `kubedb` chart and 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 
 ```console
-$ helm install kubedb-operator appscode/kubedb -n kube-system --set replicaCount=1
+$ helm install kubedb-operator appscode-testing/kubedb -n kube-system --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```console
-$ helm install kubedb-operator appscode/kubedb -n kube-system --values values.yaml
+$ helm install kubedb-operator appscode-testing/kubedb -n kube-system --values values.yaml
 ```

--- a/charts/kubedb/doc.yaml
+++ b/charts/kubedb/doc.yaml
@@ -5,8 +5,8 @@ project:
   description: Making running production-grade databases easy on Kubernetes
   app: a KubeDB operator
 repository:
-  url: https://charts.appscode.com/stable/
-  name: appscode
+  url: https://charts.appscode.com/testing/
+  name: appscode-testing
 chart:
   name: kubedb
   values: "-- generate from values file --"

--- a/charts/kubedb/values.yaml
+++ b/charts/kubedb/values.yaml
@@ -16,7 +16,7 @@ operator:
   # KubeDB operator container image
   repository: operator
   # KubeDB operator container image tag
-  tag: v0.14.0-alpha.2
+  tag: v0.14.0-beta.1
   # Compute Resources required by the operator container
   resources: {}
   # requests:


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.07.10-beta.1
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/3
Signed-off-by: 1gtm <1gtm@appscode.com>