### PR TITLE
Change cluster-role of kubedb for stash/restorebatch

### DIFF
--- a/charts/kubedb/templates/cluster-role.yaml
+++ b/charts/kubedb/templates/cluster-role.yaml
@@ -134,6 +134,7 @@ rules:
   - stash.appscode.com
   resources:
   - restoresessions
+  - restorebatches
   verbs: ["get", "list", "watch"]
 - apiGroups:
   - cert-manager.io


### PR DESCRIPTION
Add `restorbatch` role under `stash` for `kubedb`

Signed-off-by: anis028 <anis028@appscode.com>