### PR TITLE
Prepare for release v0.14.0-beta.6

### DIFF
--- a/charts/kubedb-catalog/Chart.yaml
+++ b/charts/kubedb-catalog/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: 'KubeDB Catalog by AppsCode - Catalog for database versions'
 name: kubedb-catalog
-version: v0.14.0-beta.5
-appVersion: v0.14.0-beta.5
+version: v0.14.0-beta.6
+appVersion: v0.14.0-beta.6
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/icon/kubedb.png
 sources:

--- a/charts/kubedb-catalog/README.md
+++ b/charts/kubedb-catalog/README.md
@@ -5,9 +5,9 @@
 ## TL;DR;
 
 ```console
-$ helm repo add appscode-testing https://charts.appscode.com/testing/
+$ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm install kubedb-catalog appscode-testing/kubedb-catalog -n kube-system
+$ helm install kubedb-catalog appscode/kubedb-catalog -n kube-system
 ```
 
 ## Introduction
@@ -23,7 +23,7 @@ This chart deploys KubeDB catalog on a [Kubernetes](http://kubernetes.io) cluste
 To install the chart with the release name `kubedb-catalog`:
 
 ```console
-$ helm install kubedb-catalog appscode-testing/kubedb-catalog -n kube-system
+$ helm install kubedb-catalog appscode/kubedb-catalog -n kube-system
 ```
 
 The command deploys KubeDB catalog on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -65,12 +65,12 @@ The following table lists the configurable parameters of the `kubedb-catalog` ch
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 
 ```console
-$ helm install kubedb-catalog appscode-testing/kubedb-catalog -n kube-system --set image.registry=kubedb
+$ helm install kubedb-catalog appscode/kubedb-catalog -n kube-system --set image.registry=kubedb
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```console
-$ helm install kubedb-catalog appscode-testing/kubedb-catalog -n kube-system --values values.yaml
+$ helm install kubedb-catalog appscode/kubedb-catalog -n kube-system --values values.yaml
 ```

--- a/charts/kubedb-catalog/doc.yaml
+++ b/charts/kubedb-catalog/doc.yaml
@@ -5,8 +5,8 @@ project:
   description: Catalog of database versions supported by KubeDB
   app: KubeDB catalog
 repository:
-  url: https://charts.appscode.com/testing/
-  name: appscode-testing
+  url: https://charts.appscode.com/stable/
+  name: appscode
 chart:
   name: kubedb-catalog
   values: "-- generate from values file --"

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.yaml
@@ -18,7 +18,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:5.7"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
@@ -45,7 +45,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:5.7-v2"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
@@ -73,7 +73,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:5.7-v2"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
@@ -100,7 +100,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
@@ -127,7 +127,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.yaml
@@ -18,7 +18,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:5"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
@@ -45,7 +45,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:5-v2"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.yaml
@@ -18,7 +18,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:8.0"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
@@ -45,7 +45,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:8.0-v2"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
@@ -73,7 +73,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:8.0-v3"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
@@ -100,7 +100,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.yaml
@@ -18,7 +18,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:8"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
@@ -45,7 +45,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:8-v2"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.25.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.25.yaml
@@ -18,7 +18,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
@@ -44,7 +44,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.29.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.29.yaml
@@ -15,7 +15,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.31.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.31.yaml
@@ -16,7 +16,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.14.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.14.yaml
@@ -18,7 +18,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:8.0.14"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
@@ -44,7 +44,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.20.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.20.yaml
@@ -16,7 +16,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.21.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.21.yaml
@@ -16,7 +16,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.3.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.3.yaml
@@ -18,7 +18,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:8.0.3"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:
@@ -44,7 +44,7 @@ spec:
   tools:
     image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
   replicationModeDetector:
-    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.5"
+    image: "{{ .Values.image.registry }}/mysql-replication-mode-detector:v0.1.0-beta.6"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
   podSecurityPolicies:

--- a/charts/kubedb/Chart.yaml
+++ b/charts/kubedb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: 'KubeDB by AppsCode - Production ready databases on Kubernetes'
 name: kubedb
-version: v0.14.0-beta.5
-appVersion: v0.14.0-beta.5
+version: v0.14.0-beta.6
+appVersion: v0.14.0-beta.6
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-community-icon.png
 sources:

--- a/charts/kubedb/README.md
+++ b/charts/kubedb/README.md
@@ -5,9 +5,9 @@
 ## TL;DR;
 
 ```console
-$ helm repo add appscode-testing https://charts.appscode.com/testing/
+$ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm install kubedb-community appscode-testing/kubedb -n kube-system
+$ helm install kubedb-community appscode/kubedb -n kube-system
 ```
 
 ## Introduction
@@ -23,7 +23,7 @@ This chart deploys a KubeDB operator on a [Kubernetes](http://kubernetes.io) clu
 To install the chart with the release name `kubedb-community`:
 
 ```console
-$ helm install kubedb-community appscode-testing/kubedb -n kube-system
+$ helm install kubedb-community appscode/kubedb -n kube-system
 ```
 
 The command deploys a KubeDB operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -52,7 +52,7 @@ The following table lists the configurable parameters of the `kubedb` chart and 
 | license                               | License for the product. Get a license by following the steps from [here](https://kubedb.run/docs/latest/setup/install/enterprise#get-a-trial-license). <br> Example: <br> `helm install appscode/kubedb-enterprise \` <br> `--set-file license=/path/to/license/file` <br> `or` <br> `helm install appscode/kubedb-enterprise \` <br> `--set license=<license file content>` | `""`                                                                  |
 | operator.registry                     | Docker registry used to pull KubeDB operator image                                                                                                                                                                                                                                                                                                                            | `kubedb`                                                              |
 | operator.repository                   | KubeDB operator container image                                                                                                                                                                                                                                                                                                                                               | `operator`                                                            |
-| operator.tag                          | KubeDB operator container image tag                                                                                                                                                                                                                                                                                                                                           | `v0.14.0-beta.5`                                                      |
+| operator.tag                          | KubeDB operator container image tag                                                                                                                                                                                                                                                                                                                                           | `v0.14.0-beta.6`                                                      |
 | operator.resources                    | Compute Resources required by the operator container                                                                                                                                                                                                                                                                                                                          | `{}`                                                                  |
 | operator.securityContext              | requests: cpu: 100m memory: 128Mi Security options the operator container should run with                                                                                                                                                                                                                                                                                     | `{}`                                                                  |
 | cleaner.registry                      | Docker registry used to pull Webhook cleaner image                                                                                                                                                                                                                                                                                                                            | `appscode`                                                            |
@@ -94,12 +94,12 @@ The following table lists the configurable parameters of the `kubedb` chart and 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 
 ```console
-$ helm install kubedb-community appscode-testing/kubedb -n kube-system --set replicaCount=1
+$ helm install kubedb-community appscode/kubedb -n kube-system --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```console
-$ helm install kubedb-community appscode-testing/kubedb -n kube-system --values values.yaml
+$ helm install kubedb-community appscode/kubedb -n kube-system --values values.yaml
 ```

--- a/charts/kubedb/doc.yaml
+++ b/charts/kubedb/doc.yaml
@@ -5,8 +5,8 @@ project:
   description: Making running production-grade databases easy on Kubernetes
   app: a KubeDB operator
 repository:
-  url: https://charts.appscode.com/testing/
-  name: appscode-testing
+  url: https://charts.appscode.com/stable/
+  name: appscode
 chart:
   name: kubedb
   values: "-- generate from values file --"

--- a/charts/kubedb/values.yaml
+++ b/charts/kubedb/values.yaml
@@ -25,7 +25,7 @@ operator:
   # KubeDB operator container image
   repository: operator
   # KubeDB operator container image tag
-  tag: v0.14.0-beta.5
+  tag: v0.14.0-beta.6
   # Compute Resources required by the operator container
   resources: {}
   # requests:


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2020.10.27-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/17
Signed-off-by: 1gtm <1gtm@appscode.com>