### PR TITLE
Use original underlying Elasticsearch version in openDistro version crds 

### DIFF
--- a/charts/kubedb-catalog/templates/elasticsearch/1.0.2-opendistro.yaml
+++ b/charts/kubedb-catalog/templates/elasticsearch/1.0.2-opendistro.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   authPlugin: "OpenDistro"
-  version: "1.0.2"
+  version: "7.0.1"
   db:
     image: "{{ .Values.image.registry }}/elasticsearch:1.0.2-opendistro"
   exporter:

--- a/charts/kubedb-catalog/templates/elasticsearch/1.1.0-opendistro.yaml
+++ b/charts/kubedb-catalog/templates/elasticsearch/1.1.0-opendistro.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   authPlugin: "OpenDistro"
-  version: "1.1.0"
+  version: "7.1.1"
   db:
     image: "{{ .Values.image.registry }}/elasticsearch:1.1.0-opendistro"
   exporter:

--- a/charts/kubedb-catalog/templates/elasticsearch/1.2.1-opendistro.yaml
+++ b/charts/kubedb-catalog/templates/elasticsearch/1.2.1-opendistro.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   authPlugin: "OpenDistro"
-  version: "1.2.1"
+  version: "7.2.1"
   db:
     image: "{{ .Values.image.registry }}/elasticsearch:1.2.1-opendistro"
   exporter:

--- a/charts/kubedb-catalog/templates/elasticsearch/1.3.0-opendistro.yaml
+++ b/charts/kubedb-catalog/templates/elasticsearch/1.3.0-opendistro.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   authPlugin: "OpenDistro"
-  version: "1.3.0"
+  version: "7.3.2"
   db:
     image: "{{ .Values.image.registry }}/elasticsearch:1.3.0-opendistro"
   exporter:

--- a/charts/kubedb-catalog/templates/elasticsearch/1.4.0-opendistro.yaml
+++ b/charts/kubedb-catalog/templates/elasticsearch/1.4.0-opendistro.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   authPlugin: "OpenDistro"
-  version: "1.4.0"
+  version: "7.4.2"
   db:
     image: "{{ .Values.image.registry }}/elasticsearch:1.4.0-opendistro"
   exporter:

--- a/charts/kubedb-catalog/templates/elasticsearch/1.6.0-opendistro.yaml
+++ b/charts/kubedb-catalog/templates/elasticsearch/1.6.0-opendistro.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   authPlugin: "OpenDistro"
-  version: "1.6.0"
+  version: "7.6.1"
   db:
     image: "{{ .Values.image.registry }}/elasticsearch:1.6.0-opendistro"
   exporter:

--- a/charts/kubedb-catalog/templates/elasticsearch/1.7.0-opendistro.yaml
+++ b/charts/kubedb-catalog/templates/elasticsearch/1.7.0-opendistro.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   authPlugin: "OpenDistro"
-  version: "1.7.0"
+  version: "7.6.1"
   db:
     image: "{{ .Values.image.registry }}/elasticsearch:1.7.0-opendistro"
   exporter:

--- a/charts/kubedb-catalog/templates/elasticsearch/1.8.0-opendistro.yaml
+++ b/charts/kubedb-catalog/templates/elasticsearch/1.8.0-opendistro.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   authPlugin: "OpenDistro"
-  version: "1.8.0"
+  version: "7.7.0"
   db:
     image: "{{ .Values.image.registry }}/elasticsearch:1.8.0-opendistro"
   exporter:

--- a/charts/kubedb-catalog/templates/elasticsearch/1.9.0-opendistro.yaml
+++ b/charts/kubedb-catalog/templates/elasticsearch/1.9.0-opendistro.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   authPlugin: "OpenDistro"
-  version: "1.9.0"
+  version: "7.8.0"
   db:
     image: "{{ .Values.image.registry }}/elasticsearch:1.9.0-opendistro"
   exporter:


### PR DESCRIPTION
Ref:
 - https://opendistro.github.io/for-elasticsearch-docs/version-history/