### PR TITLE
Add permission to delete PVC for enterprise operator

### DIFF
--- a/charts/kubedb-enterprise/templates/cluster-role.yaml
+++ b/charts/kubedb-enterprise/templates/cluster-role.yaml
@@ -80,4 +80,4 @@ rules:
     - ""
   resources:
     - persistentvolumeclaims
-  verbs: ["get", "list", "patch"]
+  verbs: ["get", "list", "patch", "delete"]


### PR DESCRIPTION
We need to delete the StatefulSet's PVC while horizontally scaling down the DB nodes.