### PR TITLE
Add permission to add finalizers on custom resoures

### DIFF
--- a/charts/kubedb-autoscaler/templates/cluster-role.yaml
+++ b/charts/kubedb-autoscaler/templates/cluster-role.yaml
@@ -25,6 +25,21 @@ rules:
   - "*"
   verbs: ["*"]
 - apiGroups:
+  - autoscaling.kubedb.com
+  resources:
+  - elasticsearchautoscalers/finalizers
+  - etcdautoscalers/finalizers
+  - mariadbautoscalers/finalizers
+  - memcachedautoscalers/finalizers
+  - mongodbautoscalers/finalizers
+  - mysqlautoscalers/finalizers
+  - perconaxtradbautoscalers/finalizers
+  - pgbouncerautoscalers/finalizers
+  - postgresautoscalers/finalizers
+  - proxysqlautoscalers/finalizers
+  - redisautoscalers/finalizers
+  verbs: ["update"]
+- apiGroups:
   - ""
   resources:
   - pods

--- a/charts/kubedb-enterprise/templates/cluster-role.yaml
+++ b/charts/kubedb-enterprise/templates/cluster-role.yaml
@@ -49,15 +49,25 @@ rules:
   - "*"
   verbs: ["*"]
 - apiGroups:
+  - ops.kubedb.com
+  resources:
+  - elasticsearchopsrequests/finalizers
+  - etcdopsrequests/finalizers
+  - mariadbopsrequests/finalizers
+  - memcachedopsrequests/finalizers
+  - mongodbopsrequests/finalizers
+  - mysqlopsrequests/finalizers
+  - perconaxtradbopsrequests/finalizers
+  - pgbounceropsrequests/finalizers
+  - postgresopsrequests/finalizers
+  - proxysqlopsrequests/finalizers
+  - redisopsrequests/finalizers
+  verbs: ["update"]
+- apiGroups:
   - cert-manager.io
   resources:
-  - certificates
-  - certificates/status
-  - issuers
-  - clusterissuers
-  - challenges
-  - orders
-  verbs: ["get", "list", "create", "delete", "patch", "update", "watch"]
+  - "*"
+  verbs: ["*"]
 - apiGroups:
   - ""
   resources:

--- a/charts/kubedb/templates/cluster-role.yaml
+++ b/charts/kubedb/templates/cluster-role.yaml
@@ -87,10 +87,24 @@ rules:
 - apiGroups:
   - kubedb.com
   - catalog.kubedb.com
-  - authorization.kubedb.com
   resources:
   - "*"
   verbs: ["*"]
+- apiGroups:
+  - kubedb.com
+  resources:
+  - elasticsearches/finalizers
+  - etcds/finalizers
+  - mariadbs/finalizers
+  - memcacheds/finalizers
+  - mongodbs/finalizers
+  - mysqls/finalizers
+  - perconaxtradbs/finalizers
+  - pgbouncers/finalizers
+  - postgreses/finalizers
+  - proxysqls/finalizers
+  - redises/finalizers
+  verbs: ["update"]
 - apiGroups:
   - appcatalog.appscode.com
   resources:


### PR DESCRIPTION
xref: https://sdk.operatorframework.io/docs/faqs/#i-keep-hitting-errors-like-is-forbidden-cannot-set-blockownerdeletion-if-an-ownerreference-refers-to-a-resource-you-cant-set-finalizers-on-how-do-i-fix-this

Signed-off-by: Tamal Saha <tamal@appscode.com>