### PR TITLE
Update MySQL catalogs

### DIFF
--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.25.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.25.yaml
@@ -36,6 +36,7 @@ metadata:
   labels:
   {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
+  deprecated: true
   version: "5.7.25"
   db:
     image: "{{ .Values.image.registry }}/mysql:5.7.25-v1"
@@ -47,6 +48,31 @@ spec:
     image: "{{ .Values.image.registry }}/replication-mode-detector:v0.3.2"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mysql-db
+  upgradeConstraints:
+    denylist:
+      standalone: ["< 5.7.25"]
+      groupReplication: ["< 5.7.25", "8.0.20", "8.0.19"]
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MySQLVersion
+metadata:
+  name: "5.7.25-v2"
+  labels:
+  {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "5.7.25"
+  db:
+    image: "{{ .Values.image.registry }}/mysql:5.7.25-v2"
+  exporter:
+    image: "{{ .Values.image.registry }}/mysqld-exporter:v0.11.0"
+  tools:
+    image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
+  replicationModeDetector:
+    image: "{{ .Values.image.registry }}/replication-mode-detector:v0.3.2"
+  initContainer:
+    image: "{{ .Values.image.registry }}/toybox:0.8.4"
   podSecurityPolicies:
     databasePolicyName: mysql-db
   upgradeConstraints:

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.29.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.29.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
   {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
+  deprecated: true
   version: "5.7.29"
   db:
     image: "{{ .Values.image.registry }}/mysql:5.7.29"
@@ -18,6 +19,31 @@ spec:
     image: "{{ .Values.image.registry }}/replication-mode-detector:v0.3.2"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mysql-db
+  upgradeConstraints:
+    denylist:
+      standalone: ["< 5.7.29"]
+      groupReplication: ["< 5.7.29"]
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MySQLVersion
+metadata:
+  name: "5.7.29-v1"
+  labels:
+  {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "5.7.29"
+  db:
+    image: "{{ .Values.image.registry }}/mysql:5.7.29-v1"
+  exporter:
+    image: "{{ .Values.image.registry }}/mysqld-exporter:v0.11.0"
+  tools:
+    image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
+  replicationModeDetector:
+    image: "{{ .Values.image.registry }}/replication-mode-detector:v0.3.2"
+  initContainer:
+    image: "{{ .Values.image.registry }}/toybox:0.8.4"
   podSecurityPolicies:
     databasePolicyName: mysql-db
   upgradeConstraints:

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.31.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.31.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
   {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
+  deprecated: true
   version: "5.7.31"
   db:
     image: "{{ .Values.image.registry }}/mysql:5.7.31"
@@ -19,6 +20,31 @@ spec:
     image: "{{ .Values.image.registry }}/replication-mode-detector:v0.3.2"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mysql-db
+  upgradeConstraints:
+    denylist:
+      standalone: ["< 5.7.31"]
+      groupReplication: ["< 5.7.31"]
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MySQLVersion
+metadata:
+  name: "5.7.31-v1"
+  labels:
+  {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "5.7.31"
+  db:
+    image: "{{ .Values.image.registry }}/mysql:5.7.31-v1"
+  exporter:
+    image: "{{ .Values.image.registry }}/mysqld-exporter:v0.11.0"
+  tools:
+    image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
+  replicationModeDetector:
+    image: "{{ .Values.image.registry }}/replication-mode-detector:v0.3.2"
+  initContainer:
+    image: "{{ .Values.image.registry }}/toybox:0.8.4"
   podSecurityPolicies:
     databasePolicyName: mysql-db
   upgradeConstraints:

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.33.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.33.yaml
@@ -1,0 +1,29 @@
+{{ if .Values.catalog.mysql }}
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MySQLVersion
+metadata:
+  name: "5.7.33"
+  labels:
+  {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "5.7.33"
+  db:
+    image: "{{ .Values.image.registry }}/mysql:5.7.33"
+  exporter:
+    image: "{{ .Values.image.registry }}/mysqld-exporter:v0.11.0"
+  tools:
+    image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
+  replicationModeDetector:
+    image: "{{ .Values.image.registry }}/replication-mode-detector:v0.3.2"
+  initContainer:
+    image: "{{ .Values.image.registry }}/toybox:0.8.4"
+  podSecurityPolicies:
+    databasePolicyName: mysql-db
+  upgradeConstraints:
+    denylist:
+      standalone: ["< 5.7.33"]
+      groupReplication: ["< 5.7.33"]
+
+  {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.14.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.14.yaml
@@ -36,6 +36,7 @@ metadata:
   labels:
   {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
+  deprecated: true
   version: "8.0.14"
   db:
     image: "{{ .Values.image.registry }}/mysql:8.0.14-v1"
@@ -47,6 +48,31 @@ spec:
     image: "{{ .Values.image.registry }}/replication-mode-detector:v0.3.2"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mysql-db
+  upgradeConstraints:
+    denylist:
+      standalone: ["< 8.0.14"]
+      groupReplication: ["< 8.0.14"]
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MySQLVersion
+metadata:
+  name: "8.0.14-v2"
+  labels:
+  {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "8.0.14"
+  db:
+    image: "{{ .Values.image.registry }}/mysql:8.0.14-v2"
+  exporter:
+    image: "{{ .Values.image.registry }}/mysqld-exporter:v0.11.0"
+  tools:
+    image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
+  replicationModeDetector:
+    image: "{{ .Values.image.registry }}/replication-mode-detector:v0.3.2"
+  initContainer:
+    image: "{{ .Values.image.registry }}/toybox:0.8.4"
   podSecurityPolicies:
     databasePolicyName: mysql-db
   upgradeConstraints:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.20.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.20.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
   {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
+  deprecated: true
   version: "8.0.20"
   db:
     image: "{{ .Values.image.registry }}/mysql:8.0.20"
@@ -19,6 +20,31 @@ spec:
     image: "{{ .Values.image.registry }}/replication-mode-detector:v0.3.2"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mysql-db
+  upgradeConstraints:
+    denylist:
+      standalone: ["< 8.0.20"]
+      groupReplication: ["< 8.0.20"]
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MySQLVersion
+metadata:
+  name: "8.0.20-v1"
+  labels:
+  {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "8.0.20"
+  db:
+    image: "{{ .Values.image.registry }}/mysql:8.0.20-v1"
+  exporter:
+    image: "{{ .Values.image.registry }}/mysqld-exporter:v0.11.0"
+  tools:
+    image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
+  replicationModeDetector:
+    image: "{{ .Values.image.registry }}/replication-mode-detector:v0.3.2"
+  initContainer:
+    image: "{{ .Values.image.registry }}/toybox:0.8.4"
   podSecurityPolicies:
     databasePolicyName: mysql-db
   upgradeConstraints:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.21.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.21.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
   {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
+  deprecated: true
   version: "8.0.21"
   db:
     image: "{{ .Values.image.registry }}/mysql:8.0.21"
@@ -19,6 +20,31 @@ spec:
     image: "{{ .Values.image.registry }}/replication-mode-detector:v0.3.2"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mysql-db
+  upgradeConstraints:
+    denylist:
+      standalone: ["< 8.0.21"]
+      groupReplication: ["< 8.0.21"]
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MySQLVersion
+metadata:
+  name: "8.0.21-v1"
+  labels:
+  {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "8.0.21"
+  db:
+    image: "{{ .Values.image.registry }}/mysql:8.0.21-v1"
+  exporter:
+    image: "{{ .Values.image.registry }}/mysqld-exporter:v0.11.0"
+  tools:
+    image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
+  replicationModeDetector:
+    image: "{{ .Values.image.registry }}/replication-mode-detector:v0.3.2"
+  initContainer:
+    image: "{{ .Values.image.registry }}/toybox:0.8.4"
   podSecurityPolicies:
     databasePolicyName: mysql-db
   upgradeConstraints:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.23.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.23.yaml
@@ -1,0 +1,29 @@
+{{ if .Values.catalog.mysql }}
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MySQLVersion
+metadata:
+  name: "8.0.23"
+  labels:
+  {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "8.0.23"
+  db:
+    image: "{{ .Values.image.registry }}/mysql:8.0.23"
+  exporter:
+    image: "{{ .Values.image.registry }}/mysqld-exporter:v0.11.0"
+  tools:
+    image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
+  replicationModeDetector:
+    image: "{{ .Values.image.registry }}/replication-mode-detector:v0.3.2"
+  initContainer:
+    image: "{{ .Values.image.registry }}/toybox:0.8.4"
+  podSecurityPolicies:
+    databasePolicyName: mysql-db
+  upgradeConstraints:
+    denylist:
+      standalone: ["< 8.0.23"]
+      groupReplication: ["< 8.0.23"]
+
+  {{ end }}

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.3.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.3.yaml
@@ -36,6 +36,7 @@ metadata:
   labels:
   {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
+  deprecated: true
   version: "8.0.3"
   db:
     image: "{{ .Values.image.registry }}/mysql:8.0.3-v1"
@@ -47,6 +48,31 @@ spec:
     image: "{{ .Values.image.registry }}/replication-mode-detector:v0.3.2"
   initContainer:
     image: "{{ .Values.image.registry }}/busybox"
+  podSecurityPolicies:
+    databasePolicyName: mysql-db
+  upgradeConstraints:
+    allowlist:
+      standalone: ["8.0.3"]
+      groupReplication: ["8.0.3"]
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MySQLVersion
+metadata:
+  name: "8.0.3-v2"
+  labels:
+  {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  version: "8.0.3"
+  db:
+    image: "{{ .Values.image.registry }}/mysql:8.0.3-v2"
+  exporter:
+    image: "{{ .Values.image.registry }}/mysqld-exporter:v0.11.0"
+  tools:
+    image: "{{ .Values.image.registry }}/mysql-tools:5.7.25"
+  replicationModeDetector:
+    image: "{{ .Values.image.registry }}/replication-mode-detector:v0.3.2"
+  initContainer:
+    image: "{{ .Values.image.registry }}/toybox:0.8.4"
   podSecurityPolicies:
     databasePolicyName: mysql-db
   upgradeConstraints:


### PR DESCRIPTION
1. Added/Updated MySQL catalogs:
- [x] Added versions:
    - 8.0.23 
    - 5.7.33
- [x] Updated versions:
    - 8.0.21, 8.0.20, 8.0.14, 8.0.3
    - 5.7.31, 5.7.29, 5.7.25
  
2. Used `kubedb/toybox:0.8.4` instead of `kubedb/busybox`



Signed-off-by: suaas21 <sagor@appscode.com>