### PR TITLE
Don't fail deleting namespace when license expires

### DIFF
--- a/charts/kubedb-community/templates/validating-webhook.yaml
+++ b/charts/kubedb-community/templates/validating-webhook.yaml
@@ -205,7 +205,7 @@ webhooks:
     apiVersions: ["*"]
     resources: ["namespaces"]
     operations: ["DELETE"]
-  failurePolicy: Fail
+  failurePolicy: Ignore
 {{- if and (ge $major 1) (ge $minor 12) }}
   sideEffects: None
 {{- end }}


### PR DESCRIPTION
When the license expires, the operator pod goes into a crashloop. This change ensures that users can delete namespaces even though the namespace validator is not running.

Signed-off-by: Tamal Saha <tamal@appscode.com>