### PR TITLE
Allow overriding official registry in catalog

### DIFF
--- a/apis/installer/v1alpha1/kubedb_catalog_types.go
+++ b/apis/installer/v1alpha1/kubedb_catalog_types.go
@@ -50,7 +50,8 @@ type KubedbCatalogSpec struct {
 }
 
 type RegistryRef struct {
-	Registry string `json:"registry"`
+	Registry                 string `json:"registry"`
+	OverrideOfficialRegistry bool   `json:"overrideOfficialRegistry"`
 }
 
 type Catalog struct {

--- a/charts/kubedb-catalog/README.md
+++ b/charts/kubedb-catalog/README.md
@@ -44,23 +44,24 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the `kubedb-catalog` chart and their default values.
 
-|       Parameter       |                   Description                   | Default  |
-|-----------------------|-------------------------------------------------|----------|
-| nameOverride          | Overrides name template                         | `""`     |
-| fullnameOverride      | Overrides fullname template                     | `""`     |
-| image.registry        | Docker registry used to pull database image     | `kubedb` |
-| catalog.elasticsearch | If true, deploys Elasticsearch version catalog  | `true`   |
-| catalog.etcd          | If true, deploys Etcd version catalog           | `true`   |
-| catalog.memcached     | If true, deploys Memcached version catalog      | `true`   |
-| catalog.mongodb       | If true, deploys MongoDB version catalog        | `true`   |
-| catalog.mysql         | If true, deploys MySQL version catalog          | `true`   |
-| catalog.mariadb       | If true, deploys MariaDB version catalog        | `true`   |
-| catalog.perconaxtradb | If true, deploys Percona XtraDB version catalog | `true`   |
-| catalog.pgbouncer     | If true, deploys PgBouncer version catalog      | `true`   |
-| catalog.postgres      | If true, deploys PostgreSQL version catalog     | `true`   |
-| catalog.proxysql      | If true, deploys ProxySQL version catalog       | `true`   |
-| catalog.redis         | If true, deploys Redis version catalog          | `true`   |
-| skipDeprecated        | Set true to avoid deploying deprecated versions | `true`   |
+|           Parameter            |                                                       Description                                                        | Default  |
+|--------------------------------|--------------------------------------------------------------------------------------------------------------------------|----------|
+| nameOverride                   | Overrides name template                                                                                                  | `""`     |
+| fullnameOverride               | Overrides fullname template                                                                                              | `""`     |
+| image.registry                 | Docker registry used to pull database image                                                                              | `kubedb` |
+| image.overrideOfficialRegistry | If true, uses image registry for pulling official docker images. This can be used to pull images from a private registry | `false`  |
+| catalog.elasticsearch          | If true, deploys Elasticsearch version catalog                                                                           | `true`   |
+| catalog.etcd                   | If true, deploys Etcd version catalog                                                                                    | `true`   |
+| catalog.memcached              | If true, deploys Memcached version catalog                                                                               | `true`   |
+| catalog.mongodb                | If true, deploys MongoDB version catalog                                                                                 | `true`   |
+| catalog.mysql                  | If true, deploys MySQL version catalog                                                                                   | `true`   |
+| catalog.mariadb                | If true, deploys MariaDB version catalog                                                                                 | `true`   |
+| catalog.perconaxtradb          | If true, deploys Percona XtraDB version catalog                                                                          | `true`   |
+| catalog.pgbouncer              | If true, deploys PgBouncer version catalog                                                                               | `true`   |
+| catalog.postgres               | If true, deploys PostgreSQL version catalog                                                                              | `true`   |
+| catalog.proxysql               | If true, deploys ProxySQL version catalog                                                                                | `true`   |
+| catalog.redis                  | If true, deploys Redis version catalog                                                                                   | `true`   |
+| skipDeprecated                 | Set true to avoid deploying deprecated versions                                                                          | `true`   |
 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:

--- a/charts/kubedb-catalog/templates/_helpers.tpl
+++ b/charts/kubedb-catalog/templates/_helpers.tpl
@@ -68,3 +68,14 @@ Returns the registry used for catalog docker images
 {{- define "catalog.registry" -}}
 {{- .Values.image.registry }}
 {{- end }}
+
+{{/*
+Returns the registry used for official docker images
+*/}}
+{{- define "official.registry" -}}
+{{- if .image.overrideOfficialRegistry -}}
+{{- list .image.registry (last .officialRegistry) | join "/" }}
+{{- else -}}
+{{- .officialRegistry | join "/" }}
+{{- end }}
+{{- end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-3.6.18-percona.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-3.6.18-percona.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   db:
-    image: percona/percona-server-mongodb:3.6.18
+    image: '{{ include "official.registry" (set (.Values | deepCopy) "officialRegistry" (list "percona" "percona-server-mongodb")) }}:3.6.18'
   distribution: Percona
   exporter:
     image: '{{ include "catalog.registry" . }}/percona-mongodb-exporter:v0.8.0'

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.0.10-percona.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.0.10-percona.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   db:
-    image: percona/percona-server-mongodb:4.0.10
+    image: '{{ include "official.registry" (set (.Values | deepCopy) "officialRegistry" (list "percona" "percona-server-mongodb")) }}:4.0.10'
   distribution: Percona
   exporter:
     image: '{{ include "catalog.registry" . }}/percona-mongodb-exporter:v0.8.0'

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.2.7-percona.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.2.7-percona.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   db:
-    image: percona/percona-server-mongodb:4.2.7-7
+    image: '{{ include "official.registry" (set (.Values | deepCopy) "officialRegistry" (list "percona" "percona-server-mongodb")) }}:4.2.7-7'
   distribution: Percona
   exporter:
     image: '{{ include "catalog.registry" . }}/percona-mongodb-exporter:v0.8.0'

--- a/charts/kubedb-catalog/templates/postgres/postgres-10.16-postgresql.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-10.16-postgresql.yaml
@@ -9,10 +9,10 @@ spec:
   coordinator:
     image: '{{ include "catalog.registry" . }}/pg-coordinator:v0.1.0'
   db:
-    image: postgres:10.16-alpine
+    image: '{{ include "official.registry" (set (.Values | deepCopy) "officialRegistry" (list "postgres")) }}:10.16-alpine'
   distribution: PostgreSQL
   exporter:
-    image: prometheuscommunity/postgres-exporter:v0.9.0
+    image: '{{ include "official.registry" (set (.Values | deepCopy) "officialRegistry" (list "prometheuscommunity" "postgres-exporter")) }}:v0.9.0'
   initContainer:
     image: '{{ include "catalog.registry" . }}/postgres-init:0.1.0'
   podSecurityPolicies:

--- a/charts/kubedb-catalog/templates/postgres/postgres-11.11-postgresql.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-11.11-postgresql.yaml
@@ -9,10 +9,10 @@ spec:
   coordinator:
     image: '{{ include "catalog.registry" . }}/pg-coordinator:v0.1.0'
   db:
-    image: postgres:11.11-alpine
+    image: '{{ include "official.registry" (set (.Values | deepCopy) "officialRegistry" (list "postgres")) }}:11.11-alpine'
   distribution: PostgreSQL
   exporter:
-    image: prometheuscommunity/postgres-exporter:v0.9.0
+    image: '{{ include "official.registry" (set (.Values | deepCopy) "officialRegistry" (list "prometheuscommunity" "postgres-exporter")) }}:v0.9.0'
   initContainer:
     image: '{{ include "catalog.registry" . }}/postgres-init:0.1.0'
   podSecurityPolicies:

--- a/charts/kubedb-catalog/templates/postgres/postgres-11.11-timescaledb.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-11.11-timescaledb.yaml
@@ -9,10 +9,10 @@ spec:
   coordinator:
     image: '{{ include "catalog.registry" . }}/pg-coordinator:v0.1.0'
   db:
-    image: timescale/timescaledb:2.1.0-pg11-oss
+    image: '{{ include "official.registry" (set (.Values | deepCopy) "officialRegistry" (list "timescale" "timescaledb")) }}:2.1.0-pg11-oss'
   distribution: TimescaleDB
   exporter:
-    image: prometheuscommunity/postgres-exporter:v0.9.0
+    image: '{{ include "official.registry" (set (.Values | deepCopy) "officialRegistry" (list "prometheuscommunity" "postgres-exporter")) }}:v0.9.0'
   initContainer:
     image: '{{ include "catalog.registry" . }}/postgres-init:0.1.0'
   podSecurityPolicies:

--- a/charts/kubedb-catalog/templates/postgres/postgres-12.6-postgresql.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-12.6-postgresql.yaml
@@ -9,10 +9,10 @@ spec:
   coordinator:
     image: '{{ include "catalog.registry" . }}/pg-coordinator:v0.1.0'
   db:
-    image: postgres:12.6-alpine
+    image: '{{ include "official.registry" (set (.Values | deepCopy) "officialRegistry" (list "postgres")) }}:12.6-alpine'
   distribution: PostgreSQL
   exporter:
-    image: prometheuscommunity/postgres-exporter:v0.9.0
+    image: '{{ include "official.registry" (set (.Values | deepCopy) "officialRegistry" (list "prometheuscommunity" "postgres-exporter")) }}:v0.9.0'
   initContainer:
     image: '{{ include "catalog.registry" . }}/postgres-init:0.1.0'
   podSecurityPolicies:

--- a/charts/kubedb-catalog/templates/postgres/postgres-12.6-timescaledb.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-12.6-timescaledb.yaml
@@ -9,10 +9,10 @@ spec:
   coordinator:
     image: '{{ include "catalog.registry" . }}/pg-coordinator:v0.1.0'
   db:
-    image: timescale/timescaledb:2.1.0-pg12-oss
+    image: '{{ include "official.registry" (set (.Values | deepCopy) "officialRegistry" (list "timescale" "timescaledb")) }}:2.1.0-pg12-oss'
   distribution: TimescaleDB
   exporter:
-    image: prometheuscommunity/postgres-exporter:v0.9.0
+    image: '{{ include "official.registry" (set (.Values | deepCopy) "officialRegistry" (list "prometheuscommunity" "postgres-exporter")) }}:v0.9.0'
   initContainer:
     image: '{{ include "catalog.registry" . }}/postgres-init:0.1.0'
   podSecurityPolicies:

--- a/charts/kubedb-catalog/templates/postgres/postgres-13.2-postgresql.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-13.2-postgresql.yaml
@@ -9,10 +9,10 @@ spec:
   coordinator:
     image: '{{ include "catalog.registry" . }}/pg-coordinator:v0.1.0'
   db:
-    image: postgres:13.2-alpine
+    image: '{{ include "official.registry" (set (.Values | deepCopy) "officialRegistry" (list "postgres")) }}:13.2-alpine'
   distribution: PostgreSQL
   exporter:
-    image: prometheuscommunity/postgres-exporter:v0.9.0
+    image: '{{ include "official.registry" (set (.Values | deepCopy) "officialRegistry" (list "prometheuscommunity" "postgres-exporter")) }}:v0.9.0'
   initContainer:
     image: '{{ include "catalog.registry" . }}/postgres-init:0.1.0'
   podSecurityPolicies:

--- a/charts/kubedb-catalog/templates/postgres/postgres-13.2-timescaledb.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-13.2-timescaledb.yaml
@@ -9,10 +9,10 @@ spec:
   coordinator:
     image: '{{ include "catalog.registry" . }}/pg-coordinator:v0.1.0'
   db:
-    image: timescale/timescaledb:2.1.0-pg13-oss
+    image: '{{ include "official.registry" (set (.Values | deepCopy) "officialRegistry" (list "timescale" "timescaledb")) }}:2.1.0-pg13-oss'
   distribution: TimescaleDB
   exporter:
-    image: prometheuscommunity/postgres-exporter:v0.9.0
+    image: '{{ include "official.registry" (set (.Values | deepCopy) "officialRegistry" (list "prometheuscommunity" "postgres-exporter")) }}:v0.9.0'
   initContainer:
     image: '{{ include "catalog.registry" . }}/postgres-init:0.1.0'
   podSecurityPolicies:

--- a/charts/kubedb-catalog/templates/postgres/postgres-9.6.21-postgresql.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-9.6.21-postgresql.yaml
@@ -9,10 +9,10 @@ spec:
   coordinator:
     image: '{{ include "catalog.registry" . }}/pg-coordinator:v0.1.0'
   db:
-    image: postgres:9.6.21-alpine
+    image: '{{ include "official.registry" (set (.Values | deepCopy) "officialRegistry" (list "postgres")) }}:9.6.21-alpine'
   distribution: PostgreSQL
   exporter:
-    image: prometheuscommunity/postgres-exporter:v0.9.0
+    image: '{{ include "official.registry" (set (.Values | deepCopy) "officialRegistry" (list "prometheuscommunity" "postgres-exporter")) }}:v0.9.0'
   initContainer:
     image: '{{ include "catalog.registry" . }}/postgres-init:0.1.0'
   podSecurityPolicies:

--- a/charts/kubedb-catalog/values.openapiv3_schema.yaml
+++ b/charts/kubedb-catalog/values.openapiv3_schema.yaml
@@ -28,9 +28,12 @@ properties:
     type: string
   image:
     properties:
+      overrideOfficialRegistry:
+        type: boolean
       registry:
         type: string
     required:
+    - overrideOfficialRegistry
     - registry
     type: object
   nameOverride:

--- a/charts/kubedb-catalog/values.yaml
+++ b/charts/kubedb-catalog/values.yaml
@@ -11,6 +11,10 @@ image:
   # Docker registry used to pull database image
   registry: kubedb
 
+  # If true, uses image registry for pulling official docker images.
+  # This can be used to pull images from a private registry
+  overrideOfficialRegistry: false
+
 catalog:
   # If true, deploys Elasticsearch version catalog
   elasticsearch: true

--- a/charts/kubedb/templates/_helpers.tpl
+++ b/charts/kubedb/templates/_helpers.tpl
@@ -108,3 +108,15 @@ imagePullSecrets:
 {{- toYaml $.Values.imagePullSecrets | nindent 2 }}
 {{- end }}
 {{- end }}
+
+{{/*
+Returns the registry used for official docker images
+*/}}
+{{- define "official.registry" -}}
+{{- if .image.overrideOfficialRegistry -}}
+{{- $reg := default .image.registry .global.registry -}}
+{{- list $reg (last .officialRegistry) | join "/" }}
+{{- else -}}
+{{- .officialRegistry | join "/" }}
+{{- end }}
+{{- end }}

--- a/charts/kubedb/values.openapiv3_schema.yaml
+++ b/charts/kubedb/values.openapiv3_schema.yaml
@@ -1088,9 +1088,12 @@ properties:
         type: string
       image:
         properties:
+          overrideOfficialRegistry:
+            type: boolean
           registry:
             type: string
         required:
+        - overrideOfficialRegistry
         - registry
         type: object
       nameOverride:

--- a/crds/installer.kubedb.com_kubedbcatalogs.yaml
+++ b/crds/installer.kubedb.com_kubedbcatalogs.yaml
@@ -66,9 +66,12 @@ spec:
                 type: string
               image:
                 properties:
+                  overrideOfficialRegistry:
+                    type: boolean
                   registry:
                     type: string
                 required:
+                - overrideOfficialRegistry
                 - registry
                 type: object
               nameOverride:

--- a/crds/installer.kubedb.com_kubedbs.yaml
+++ b/crds/installer.kubedb.com_kubedbs.yaml
@@ -1216,9 +1216,12 @@ spec:
                     type: string
                   image:
                     properties:
+                      overrideOfficialRegistry:
+                        type: boolean
                       registry:
                         type: string
                     required:
+                    - overrideOfficialRegistry
                     - registry
                     type: object
                   nameOverride:

--- a/hack/fmt/main_test.go
+++ b/hack/fmt/main_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright AppsCode Inc. and Contributors
+
+Licensed under the AppsCode Community License 1.0.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "testing"
+
+func TestParseImage(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     string
+		wantReg string
+		wantBin string
+		wantTag string
+	}{
+		{
+			name:    "kubedb/postgres:v1.2.3",
+			arg:     "kubedb/postgres:v1.2.3",
+			wantReg: "kubedb",
+			wantBin: "postgres",
+			wantTag: "v1.2.3",
+		},
+		{
+			name:    "postgres:v1.2.3",
+			arg:     "postgres:v1.2.3",
+			wantReg: "",
+			wantBin: "postgres",
+			wantTag: "v1.2.3",
+		},
+		{
+			name:    "kubedb/postgres",
+			arg:     "kubedb/postgres",
+			wantReg: "kubedb",
+			wantBin: "postgres",
+			wantTag: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotReg, gotBin, gotTag := ParseImage(tt.arg)
+			if gotReg != tt.wantReg {
+				t.Errorf("ParseImage() gotReg = %v, want %v", gotReg, tt.wantReg)
+			}
+			if gotBin != tt.wantBin {
+				t.Errorf("ParseImage() gotBin = %v, want %v", gotBin, tt.wantBin)
+			}
+			if gotTag != tt.wantTag {
+				t.Errorf("ParseImage() gotTag = %v, want %v", gotTag, tt.wantTag)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Example:

```bash
$ helm template charts/kubedb-catalog --set image.registry=tamal --set image.overrideOfficialRegistry=true | grep postgres:

$ helm template charts/kubedb --set global.registry=tamal --set kubedb-catalog.image.overrideOfficialRegistry=true | grep postgres:
```

Signed-off-by: Tamal Saha <tamal@appscode.com>