### PR TITLE
Add operation "DELETE" for MutatingWebhookConfigurations

### DIFF
--- a/charts/kubedb-autoscaler/templates/mutating-webhook.yaml
+++ b/charts/kubedb-autoscaler/templates/mutating-webhook.yaml
@@ -35,7 +35,7 @@ webhooks:
     - apiGroups: ["autoscaling.kubedb.com"]
       apiVersions: ["*"]
       resources: ["elasticsearchautoscalers"]
-      operations: ["CREATE", "UPDATE"]
+      operations: ["CREATE", "UPDATE", "DELETE"]
   admissionReviewVersions: ["v1beta1"]
   failurePolicy: Fail
   sideEffects: None

--- a/charts/kubedb-community/templates/mutating-webhook.yaml
+++ b/charts/kubedb-community/templates/mutating-webhook.yaml
@@ -21,7 +21,7 @@ webhooks:
   - apiGroups: ["kubedb.com"]
     apiVersions: ["*"]
     resources: ["elasticsearches"]
-    operations: ["CREATE", "UPDATE"]
+    operations: ["CREATE", "UPDATE", "DELETE"]
   admissionReviewVersions: ["v1beta1"]
   failurePolicy: Fail
   sideEffects: None
@@ -38,7 +38,7 @@ webhooks:
   - apiGroups: ["kubedb.com"]
     apiVersions: ["*"]
     resources: ["postgreses"]
-    operations: ["CREATE", "UPDATE"]
+    operations: ["CREATE", "UPDATE", "DELETE"]
   admissionReviewVersions: ["v1beta1"]
   failurePolicy: Fail
   sideEffects: None
@@ -55,7 +55,7 @@ webhooks:
   - apiGroups: ["kubedb.com"]
     apiVersions: ["*"]
     resources: ["mysqls"]
-    operations: ["CREATE", "UPDATE"]
+    operations: ["CREATE", "UPDATE", "DELETE"]
   admissionReviewVersions: ["v1beta1"]
   failurePolicy: Fail
   sideEffects: None
@@ -72,7 +72,7 @@ webhooks:
   - apiGroups: ["kubedb.com"]
     apiVersions: ["*"]
     resources: ["perconaxtradbs"]
-    operations: ["CREATE", "UPDATE"]
+    operations: ["CREATE", "UPDATE", "DELETE"]
   admissionReviewVersions: ["v1beta1"]
   failurePolicy: Fail
   sideEffects: None
@@ -89,7 +89,7 @@ webhooks:
   - apiGroups: ["kubedb.com"]
     apiVersions: ["*"]
     resources: ["mongodbs"]
-    operations: ["CREATE", "UPDATE"]
+    operations: ["CREATE", "UPDATE", "DELETE"]
   admissionReviewVersions: ["v1beta1"]
   failurePolicy: Fail
   sideEffects: None
@@ -106,7 +106,7 @@ webhooks:
   - apiGroups: ["kubedb.com"]
     apiVersions: ["*"]
     resources: ["redises"]
-    operations: ["CREATE", "UPDATE"]
+    operations: ["CREATE", "UPDATE", "DELETE"]
   admissionReviewVersions: ["v1beta1"]
   failurePolicy: Fail
   sideEffects: None
@@ -123,7 +123,7 @@ webhooks:
   - apiGroups: ["kubedb.com"]
     apiVersions: ["*"]
     resources: ["memcacheds"]
-    operations: ["CREATE", "UPDATE"]
+    operations: ["CREATE", "UPDATE", "DELETE"]
   admissionReviewVersions: ["v1beta1"]
   failurePolicy: Fail
   sideEffects: None
@@ -140,7 +140,7 @@ webhooks:
   - apiGroups: ["kubedb.com"]
     apiVersions: ["*"]
     resources: ["etcds"]
-    operations: ["CREATE", "UPDATE"]
+    operations: ["CREATE", "UPDATE", "DELETE"]
   admissionReviewVersions: ["v1beta1"]
   failurePolicy: Fail
   sideEffects: None
@@ -157,7 +157,7 @@ webhooks:
   - apiGroups: ["kubedb.com"]
     apiVersions: ["*"]
     resources: ["pgbouncers"]
-    operations: ["CREATE", "UPDATE"]
+    operations: ["CREATE", "UPDATE", "DELETE"]
   admissionReviewVersions: ["v1beta1"]
   failurePolicy: Fail
   sideEffects: None
@@ -174,7 +174,7 @@ webhooks:
   - apiGroups: ["kubedb.com"]
     apiVersions: ["*"]
     resources: ["proxysqls"]
-    operations: ["CREATE", "UPDATE"]
+    operations: ["CREATE", "UPDATE", "DELETE"]
   admissionReviewVersions: ["v1beta1"]
   failurePolicy: Fail
   sideEffects: None
@@ -191,7 +191,7 @@ webhooks:
     - apiGroups: ["kubedb.com"]
       apiVersions: ["*"]
       resources: ["mariadbs"]
-      operations: ["CREATE", "UPDATE"]
+      operations: ["CREATE", "UPDATE", "DELETE"]
   admissionReviewVersions: ["v1beta1"]
   failurePolicy: Fail
   sideEffects: None

--- a/charts/kubedb-enterprise/templates/mutating-webhook.yaml
+++ b/charts/kubedb-enterprise/templates/mutating-webhook.yaml
@@ -20,7 +20,7 @@ webhooks:
   - apiGroups: ["ops.kubedb.com"]
     apiVersions: ["*"]
     resources: ["mysqlopsrequests"]
-    operations: ["CREATE", "UPDATE"]
+    operations: ["CREATE", "UPDATE", "DELETE"]
   admissionReviewVersions: ["v1beta1"]
   failurePolicy: Fail
   sideEffects: None


### PR DESCRIPTION
To avoid mutation on DELETE operation, we use check like:

```go
	// N.B.: No Mutating for delete
	if (req.Operation != admission.Create && req.Operation != admission.Update) ||
		len(req.SubResource) != 0 ||
		req.Kind.Group != api.SchemeGroupVersion.Group ||
		req.Kind.Kind != api.ResourceKindElasticsearch {
		status.Allowed = true
		return status
	}
```
https://github.com/kubedb/elasticsearch/blob/master/pkg/admission/mutator.go#L79

If we don't use "DELETE" while configuring the webhook, this check doesn't work (ie. req.Operation == "UPDATE"). Ended up mutating. 