### PR TITLE
Add permission to set finalizers on services

### DIFF
--- a/charts/kubedb-community/templates/cluster-role.yaml
+++ b/charts/kubedb-community/templates/cluster-role.yaml
@@ -36,6 +36,11 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - services/finalizers
+  verbs: ["update"]
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts
   verbs: ["create", "delete", "get", "patch", "deletecollection"]
 - apiGroups:


### PR DESCRIPTION
ref:
- https://github.com/kmodules/monitoring-agent-api/blob/1953ad20c8084741a62e17ba8bdcbde281d82860/agents/prometheusoperator/lib.go#L82
- https://sdk.operatorframework.io/docs/faqs/#after-deploying-my-operator-why-do-i-see-errors-like-is-forbidden-cannot-set-blockownerdeletion-if-an-ownerreference-refers-to-a-resource-you-cant-set-finalizers-on-


Signed-off-by: Tamal Saha <tamal@appscode.com>