### PR TITLE
Remove kind from metric name prefix

### DIFF
--- a/charts/kubedb-metrics/templates/elasticsearch/catalog-kubedb-com-elasticsearchversion.yaml
+++ b/charts/kubedb-metrics/templates/elasticsearch/catalog-kubedb-com-elasticsearchversion.yaml
@@ -7,7 +7,7 @@ spec:
     apiVersion: catalog.kubedb.com/v1alpha1
     kind: ElasticsearchVersion
   metrics:
-    - name: version_created
+    - name: created
       help: "Unix creation timestamp"
       type: gauge
       field:
@@ -15,7 +15,7 @@ spec:
         type: DateTime
       metricValue:
         valueFromPath: .metadata.creationTimestamp
-    - name: version_info
+    - name: info
       help: "Elastic search versions info"
       type: gauge
       labels:

--- a/charts/kubedb-metrics/templates/mariadb/catalog-kubedb-com-mariadbversion.yaml
+++ b/charts/kubedb-metrics/templates/mariadb/catalog-kubedb-com-mariadbversion.yaml
@@ -7,7 +7,7 @@ spec:
     apiVersion: catalog.kubedb.com/v1alpha1
     kind: MariaDBVersion
   metrics:
-    - name: version_created
+    - name: created
       help: "Unix creation timestamp"
       type: gauge
       field:
@@ -16,7 +16,7 @@ spec:
       metricValue:
         valueFromPath: .metadata.creationTimestamp
 
-    - name: version_info
+    - name: info
       help: "MariaDB versions info"
       type: gauge
       labels:

--- a/charts/kubedb-metrics/templates/mariadb/ops-kubedb-com-mariadbopsrequest.yaml
+++ b/charts/kubedb-metrics/templates/mariadb/ops-kubedb-com-mariadbopsrequest.yaml
@@ -14,12 +14,12 @@ spec:
     - key: type
       valuePath: .spec.type
   metrics:
-    - name: opsrequest_type
+    - name: type
       help: "MariaDB OpsRequest type"
       type: gauge
       metricValue:
         value: 1
-    - name: opsrequest_status_phase
+    - name: status_phase
       help: "MariaDB OpsRequest current phase."
       type: gauge
       field:

--- a/charts/kubedb-metrics/templates/mongodb/catalog-kubedb-com-mongodbversion.yaml
+++ b/charts/kubedb-metrics/templates/mongodb/catalog-kubedb-com-mongodbversion.yaml
@@ -7,7 +7,7 @@ spec:
     apiVersion: catalog.kubedb.com/v1alpha1
     kind: MongoDBVersion
   metrics:
-    - name: version_created
+    - name: created
       help: "Unix creation timestamp"
       type: gauge
       field:
@@ -16,7 +16,7 @@ spec:
       metricValue:
         valueFromPath: .metadata.creationTimestamp
 
-    - name: version_info
+    - name: info
       help: "MongoDB versions info"
       type: gauge
       labels:

--- a/charts/kubedb-metrics/templates/mongodb/ops-kubedb-com-mongodbopsrequest.yaml
+++ b/charts/kubedb-metrics/templates/mongodb/ops-kubedb-com-mongodbopsrequest.yaml
@@ -14,12 +14,12 @@ spec:
     - key: type
       valuePath: .spec.type
   metrics:
-    - name: opsrequest_type
+    - name: type
       help: "MongoDB OpsRequest Type"
       type: gauge
       metricValue:
         value: 1
-    - name: opsrequest_status_phase
+    - name: status_phase
       help: "The current phase of MongoDB OpsRequest."
       type: gauge
       field:

--- a/charts/kubedb-metrics/templates/mysql/catalog-kubedb-com-mysqlversion.yaml
+++ b/charts/kubedb-metrics/templates/mysql/catalog-kubedb-com-mysqlversion.yaml
@@ -7,7 +7,7 @@ spec:
     apiVersion: catalog.kubedb.com/v1alpha1
     kind: MySQLVersion
   metrics:
-    - name: version_created
+    - name: created
       help: "Unix creation timestamp"
       type: gauge
       field:
@@ -16,7 +16,7 @@ spec:
       metricValue:
         valueFromPath: .metadata.creationTimestamp
 
-    - name: version_info
+    - name: info
       help: "MySQL versions info"
       type: gauge
       labels:

--- a/charts/kubedb-metrics/templates/mysql/ops-kubedb-com-mysqlopsrequest.yaml
+++ b/charts/kubedb-metrics/templates/mysql/ops-kubedb-com-mysqlopsrequest.yaml
@@ -14,12 +14,12 @@ spec:
     - key: type
       valuePath: .spec.type
   metrics:
-    - name: opsrequest_type
+    - name: type
       help: "MySQL Opsrequest type"
       type: gauge
       metricValue:
         value: 1
-    - name: opsrequest_status_phase
+    - name: status_phase
       help: "The opsrequest current phase."
       type: gauge
       field:

--- a/charts/kubedb-metrics/templates/postgres/catalog-kubedb-com-postgresversion.yaml
+++ b/charts/kubedb-metrics/templates/postgres/catalog-kubedb-com-postgresversion.yaml
@@ -7,7 +7,7 @@ spec:
     apiVersion: catalog.kubedb.com/v1alpha1
     kind: PostgresVersion
   metrics:
-    - name: version_created
+    - name: created
       help: "Unix creation timestamp"
       type: gauge
       field:
@@ -16,7 +16,7 @@ spec:
       metricValue:
         valueFromPath: .metadata.creationTimestamp
 
-    - name: version_info
+    - name: info
       help: "Postgres versions info"
       type: gauge
       labels:

--- a/charts/kubedb-metrics/templates/postgres/ops-kubedb-com-postgresopsrequest.yaml
+++ b/charts/kubedb-metrics/templates/postgres/ops-kubedb-com-postgresopsrequest.yaml
@@ -14,12 +14,12 @@ spec:
     - key: type
       valuePath: .spec.type
   metrics:
-    - name: opsrequest_type
+    - name: type
       help: "Postgres OpsRequest Type"
       type: gauge
       metricValue:
         value: 1
-    - name: opsrequest_status_phase
+    - name: status_phase
       help: "The current phase of Postgres OpsRequest."
       type: gauge
       field:

--- a/charts/kubedb-metrics/templates/redis/catalog-kubedb-com-redisversion.yaml
+++ b/charts/kubedb-metrics/templates/redis/catalog-kubedb-com-redisversion.yaml
@@ -7,7 +7,7 @@ spec:
     apiVersion: catalog.kubedb.com/v1alpha1
     kind: RedisVersion
   metrics:
-    - name: version_created
+    - name: created
       help: "Unix creation timestamp"
       type: gauge
       field:
@@ -16,7 +16,7 @@ spec:
       metricValue:
         valueFromPath: .metadata.creationTimestamp
 
-    - name: version_info
+    - name: info
       help: "Redis versions info"
       type: gauge
       labels:

--- a/charts/kubedb-metrics/templates/redis/ops-kubedb-com-redisopsrequest.yaml
+++ b/charts/kubedb-metrics/templates/redis/ops-kubedb-com-redisopsrequest.yaml
@@ -14,12 +14,12 @@ spec:
     - key: type
       valuePath: .spec.type
   metrics:
-    - name: opsrequest_type
+    - name: type
       help: "Redis OpsRequest Type"
       type: gauge
       metricValue:
         value: 1
-    - name: opsrequest_status_phase
+    - name: status_phase
       help: "The current phase of Redis OpsRequest."
       type: gauge
       field:


### PR DESCRIPTION
This is done to match the new panopticon metrics naming format

Signed-off-by: Tamal Saha <tamal@appscode.com>