### PR TITLE
Update kind.yaml

### DIFF
--- a/hack/kubernetes/kind.yaml
+++ b/hack/kubernetes/kind.yaml
@@ -4,10 +4,7 @@ nodes:
   - role: control-plane
     kubeadmConfigPatches:
       - |
-        apiVersion: kubeadm.k8s.io/v1beta2
         kind: ClusterConfiguration
-        metadata:
-          name: config
         apiServer:
           extraArgs:
             enable-admission-plugins: "NodeRestriction,OwnerReferencesPermissionEnforcement"


### PR DESCRIPTION
Signed-off-by: Emruz Hossain <emruz@appscode.com>

Previous one did not work. Newer kind cluster uses apiVersion `kubeadm.k8s.io/v1beta3`. We can omit `apiVersion` and `metadata` section.

Ref: https://kind.sigs.k8s.io/docs/user/configuration/#kubeadm-config-patches