### PR TITLE
Fix missing newline in string slice flags

### DIFF
--- a/charts/kubedb-one/templates/_helpers.tpl
+++ b/charts/kubedb-one/templates/_helpers.tpl
@@ -103,10 +103,10 @@ imagePullSecrets:
 {{- end }}
 
 {{- define "docker.imagePullSecretFlags" -}}
-{{- range .Values.global.imagePullSecrets -}}
+{{- range .Values.global.imagePullSecrets }}
 - --image-pull-secrets={{- .name -}}
 {{- else -}}
-{{- range $.Values.imagePullSecrets -}}
+{{- range $.Values.imagePullSecrets }}
 - --image-pull-secrets={{- .name -}}
 {{- end }}
 {{- end }}
@@ -116,7 +116,7 @@ imagePullSecrets:
 Returns the --insecure-registries flags
 */}}
 {{- define "docker.insecureRegistries" -}}
-{{- range (concat .Values.global.insecureRegistries .Values.insecureRegistries | uniq | sortAlpha) -}}
+{{- range (concat .Values.global.insecureRegistries .Values.insecureRegistries | uniq | sortAlpha) }}
 - --insecure-registries={{.}}
 {{- end }}
 {{- end }}

--- a/charts/kubedb-ops-manager/templates/_helpers.tpl
+++ b/charts/kubedb-ops-manager/templates/_helpers.tpl
@@ -84,7 +84,7 @@ imagePullSecrets:
 {{- end }}
 
 {{- define "docker.imagePullSecretFlags" -}}
-{{- range .Values.imagePullSecrets -}}
+{{- range .Values.imagePullSecrets }}
 - --image-pull-secrets={{- .name -}}
 {{- end }}
 {{- end }}
@@ -93,7 +93,7 @@ imagePullSecrets:
 Returns the --insecure-registries flags
 */}}
 {{- define "docker.insecureRegistries" -}}
-{{- range (.Values.insecureRegistries | uniq | sortAlpha) -}}
+{{- range (.Values.insecureRegistries | uniq | sortAlpha) }}
 - --insecure-registries={{.}}
 {{- end }}
 {{- end }}

--- a/charts/kubedb-provisioner/templates/_helpers.tpl
+++ b/charts/kubedb-provisioner/templates/_helpers.tpl
@@ -87,13 +87,13 @@ imagePullSecrets:
 Returns the --insecure-registries flags
 */}}
 {{- define "docker.insecureRegistries" -}}
-{{- range (.Values.insecureRegistries | uniq | sortAlpha) -}}
+{{- range (.Values.insecureRegistries | uniq | sortAlpha) }}
 - --insecure-registries={{.}}
 {{- end }}
 {{- end }}
 
 {{- define "docker.imagePullSecretFlags" -}}
-{{- range .Values.imagePullSecrets -}}
+{{- range .Values.imagePullSecrets }}
 - --image-pull-secrets={{- .name -}}
 {{- end }}
 {{- end }}

--- a/charts/kubedb/templates/_helpers.tpl
+++ b/charts/kubedb/templates/_helpers.tpl
@@ -103,10 +103,10 @@ imagePullSecrets:
 {{- end }}
 
 {{- define "docker.imagePullSecretFlags" -}}
-{{- range .Values.global.imagePullSecrets -}}
+{{- range .Values.global.imagePullSecrets }}
 - --image-pull-secrets={{- .name -}}
 {{- else -}}
-{{- range $.Values.imagePullSecrets -}}
+{{- range $.Values.imagePullSecrets }}
 - --image-pull-secrets={{- .name -}}
 {{- end }}
 {{- end }}
@@ -116,9 +116,9 @@ imagePullSecrets:
 Returns the --insecure-registries flags
 */}}
 {{- define "docker.insecureRegistries" -}}
-{{- range (concat .Values.global.insecureRegistries .Values.insecureRegistries | uniq | sortAlpha) -}}
+{{- range (concat .Values.global.insecureRegistries .Values.insecureRegistries | uniq | sortAlpha) }}
 - --insecure-registries={{.}}
-{{- end }}
+{{- end -}}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
```
 helm template charts/kubedb \
   --namespace kubedb --create-namespace \
   --set kubedb-provisioner.enabled=true \
   --set kubedb-ops-manager.enabled=true \
   --set kubedb-autoscaler.enabled=true \
   --set kubedb-dashboard.enabled=true \
   --set kubedb-schema-manager.enabled=true \
   --set global.imagePullSecrets[0].name=regcred \
   --set global.imagePullSecrets[1].name=regcred2 \
   --set global.insecureRegistries[0]=registry.tools.example.com \
   --set global.insecureRegistries[1]=harbor.tools..example.com
```