### PR TITLE
Prepare for release v2023.06.13-rc.0

### DIFF
--- a/catalog/raw/mariadb/mariadb-10.10.2.yaml
+++ b/catalog/raw/mariadb/mariadb-10.10.2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.10.2
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.13.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.14.0-rc.0
   db:
     image: mariadb:10.10.2
   exporter:

--- a/catalog/raw/mariadb/mariadb-10.11.2.yaml
+++ b/catalog/raw/mariadb/mariadb-10.11.2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.11.2
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.13.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.14.0-rc.0
   db:
     image: mariadb:10.11.2
   exporter:

--- a/catalog/raw/mariadb/mariadb-10.4.17.yaml
+++ b/catalog/raw/mariadb/mariadb-10.4.17.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.4.17
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.13.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.14.0-rc.0
   db:
     image: mariadb:10.4.17
   exporter:

--- a/catalog/raw/mariadb/mariadb-10.5.8.yaml
+++ b/catalog/raw/mariadb/mariadb-10.5.8.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.5.8
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.13.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.14.0-rc.0
   db:
     image: mariadb:10.5.8
   exporter:

--- a/catalog/raw/mariadb/mariadb-10.6.4.yaml
+++ b/catalog/raw/mariadb/mariadb-10.6.4.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.6.4
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.13.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.14.0-rc.0
   db:
     image: mariadb:10.6.4
   exporter:

--- a/catalog/raw/mongodb/deprecated-mongodb-3.4-official.yaml
+++ b/catalog/raw/mongodb/deprecated-mongodb-3.4-official.yaml
@@ -14,7 +14,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: "3.4"
 
 ---
@@ -34,7 +34,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: "3.4"
 
 ---
@@ -54,7 +54,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: "3.4"
 
 ---
@@ -74,5 +74,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: "3.4"

--- a/catalog/raw/mongodb/deprecated-mongodb-3.6-official.yaml
+++ b/catalog/raw/mongodb/deprecated-mongodb-3.6-official.yaml
@@ -14,7 +14,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: "3.6"
 
 ---
@@ -34,7 +34,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: "3.6"
 
 ---
@@ -54,7 +54,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: "3.6"
 
 ---
@@ -74,5 +74,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: "3.6"

--- a/catalog/raw/mongodb/mongodb-3.4.17-official.yaml
+++ b/catalog/raw/mongodb/mongodb-3.4.17-official.yaml
@@ -13,7 +13,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -42,5 +42,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 3.4.17

--- a/catalog/raw/mongodb/mongodb-3.4.22-official.yaml
+++ b/catalog/raw/mongodb/mongodb-3.4.22-official.yaml
@@ -13,7 +13,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -42,7 +42,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 3.4.22
 
 ---
@@ -62,7 +62,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 3.4.22
 
 ---
@@ -82,5 +82,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 3.4.22

--- a/catalog/raw/mongodb/mongodb-3.6.13-official.yaml
+++ b/catalog/raw/mongodb/mongodb-3.6.13-official.yaml
@@ -13,7 +13,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -42,7 +42,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 3.6.13
 
 ---
@@ -62,7 +62,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 3.6.13
 
 ---
@@ -82,5 +82,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 3.6.13

--- a/catalog/raw/mongodb/mongodb-3.6.18-percona.yaml
+++ b/catalog/raw/mongodb/mongodb-3.6.18-percona.yaml
@@ -13,7 +13,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mongodb/mongodb-3.6.8-official.yaml
+++ b/catalog/raw/mongodb/mongodb-3.6.8-official.yaml
@@ -13,7 +13,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -42,5 +42,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 3.6.8

--- a/catalog/raw/mongodb/mongodb-4.0.10-percona.yaml
+++ b/catalog/raw/mongodb/mongodb-4.0.10-percona.yaml
@@ -13,7 +13,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mongodb/mongodb-4.0.11-official.yaml
+++ b/catalog/raw/mongodb/mongodb-4.0.11-official.yaml
@@ -13,7 +13,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -42,7 +42,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 4.0.11
 
 ---
@@ -62,7 +62,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 4.0.11
 
 ---
@@ -82,5 +82,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 4.0.11

--- a/catalog/raw/mongodb/mongodb-4.0.3-official.yaml
+++ b/catalog/raw/mongodb/mongodb-4.0.3-official.yaml
@@ -13,7 +13,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -42,5 +42,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 4.0.3

--- a/catalog/raw/mongodb/mongodb-4.0.5-official.yaml
+++ b/catalog/raw/mongodb/mongodb-4.0.5-official.yaml
@@ -13,7 +13,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -42,7 +42,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 4.0.5
 
 ---
@@ -62,7 +62,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 4.0.5
 
 ---
@@ -82,7 +82,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 4.0.5
 
 ---
@@ -102,7 +102,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 4.0.5
 
 ---
@@ -122,5 +122,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 4.0.5

--- a/catalog/raw/mongodb/mongodb-4.1.13-official.yaml
+++ b/catalog/raw/mongodb/mongodb-4.1.13-official.yaml
@@ -13,7 +13,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -42,7 +42,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 4.1.13
 
 ---
@@ -62,7 +62,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 4.1.13
 
 ---
@@ -82,5 +82,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 4.1.13

--- a/catalog/raw/mongodb/mongodb-4.1.4-official.yaml
+++ b/catalog/raw/mongodb/mongodb-4.1.4-official.yaml
@@ -13,7 +13,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -42,5 +42,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 4.1.4

--- a/catalog/raw/mongodb/mongodb-4.1.7-official.yaml
+++ b/catalog/raw/mongodb/mongodb-4.1.7-official.yaml
@@ -13,7 +13,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -42,7 +42,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 4.1.7
 
 ---
@@ -62,7 +62,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 4.1.7
 
 ---
@@ -82,5 +82,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 4.1.7

--- a/catalog/raw/mongodb/mongodb-4.2.3-official.yaml
+++ b/catalog/raw/mongodb/mongodb-4.2.3-official.yaml
@@ -13,7 +13,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -42,5 +42,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   version: 4.2.3

--- a/catalog/raw/mongodb/mongodb-4.2.7-percona.yaml
+++ b/catalog/raw/mongodb/mongodb-4.2.7-percona.yaml
@@ -13,7 +13,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mongodb/mongodb-4.4.10-percona.yaml
+++ b/catalog/raw/mongodb/mongodb-4.4.10-percona.yaml
@@ -13,7 +13,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mongodb/mongodb-4.4.6-official.yaml
+++ b/catalog/raw/mongodb/mongodb-4.4.6-official.yaml
@@ -13,7 +13,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mongodb/mongodb-5.0.15-official.yaml
+++ b/catalog/raw/mongodb/mongodb-5.0.15-official.yaml
@@ -13,7 +13,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mongodb/mongodb-5.0.2-official.yaml
+++ b/catalog/raw/mongodb/mongodb-5.0.2-official.yaml
@@ -13,7 +13,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mongodb/mongodb-5.0.3-official.yaml
+++ b/catalog/raw/mongodb/mongodb-5.0.3-official.yaml
@@ -13,7 +13,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mongodb/mongodb-6.0.5-official.yaml
+++ b/catalog/raw/mongodb/mongodb-6.0.5-official.yaml
@@ -13,7 +13,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mysql/deprecated-mysql-5-official.yaml
+++ b/catalog/raw/mysql/deprecated-mysql-5-official.yaml
@@ -14,7 +14,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     denylist:
       groupReplication:
@@ -40,7 +40,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     denylist:
       groupReplication:

--- a/catalog/raw/mysql/deprecated-mysql-5.7-official.yaml
+++ b/catalog/raw/mysql/deprecated-mysql-5.7-official.yaml
@@ -14,7 +14,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     denylist:
       groupReplication:
@@ -40,7 +40,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     denylist:
       groupReplication:

--- a/catalog/raw/mysql/deprecated-mysql-5.7.25-official.yaml
+++ b/catalog/raw/mysql/deprecated-mysql-5.7.25-official.yaml
@@ -14,7 +14,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     denylist:
       groupReplication:
@@ -40,7 +40,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     denylist:
       groupReplication:
@@ -66,7 +66,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     denylist:
       groupReplication:
@@ -92,7 +92,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     denylist:
       groupReplication:
@@ -118,7 +118,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -150,7 +150,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mysql/deprecated-mysql-5.7.29-official.yaml
+++ b/catalog/raw/mysql/deprecated-mysql-5.7.29-official.yaml
@@ -14,7 +14,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     denylist:
       groupReplication:
@@ -40,7 +40,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     denylist:
       groupReplication:
@@ -66,7 +66,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -98,7 +98,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mysql/deprecated-mysql-5.7.31-official.yaml
+++ b/catalog/raw/mysql/deprecated-mysql-5.7.31-official.yaml
@@ -14,7 +14,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     denylist:
       groupReplication:
@@ -40,7 +40,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -72,7 +72,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mysql/deprecated-mysql-5.7.33-official.yaml
+++ b/catalog/raw/mysql/deprecated-mysql-5.7.33-official.yaml
@@ -14,7 +14,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -46,7 +46,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mysql/deprecated-mysql-8-official.yaml
+++ b/catalog/raw/mysql/deprecated-mysql-8-official.yaml
@@ -14,7 +14,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     denylist:
       groupReplication:
@@ -40,7 +40,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     denylist:
       groupReplication:

--- a/catalog/raw/mysql/deprecated-mysql-8.0-official.yaml
+++ b/catalog/raw/mysql/deprecated-mysql-8.0-official.yaml
@@ -14,7 +14,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     denylist:
       groupReplication:

--- a/catalog/raw/mysql/deprecated-mysql-8.0.14-official.yaml
+++ b/catalog/raw/mysql/deprecated-mysql-8.0.14-official.yaml
@@ -14,7 +14,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     denylist:
       groupReplication:
@@ -40,7 +40,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     denylist:
       groupReplication:
@@ -66,7 +66,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     denylist:
       groupReplication:
@@ -92,7 +92,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -124,7 +124,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mysql/deprecated-mysql-8.0.20-official.yaml
+++ b/catalog/raw/mysql/deprecated-mysql-8.0.20-official.yaml
@@ -14,7 +14,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     denylist:
       groupReplication:
@@ -40,7 +40,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     denylist:
       groupReplication:
@@ -66,7 +66,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -98,7 +98,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mysql/deprecated-mysql-8.0.21-official.yaml
+++ b/catalog/raw/mysql/deprecated-mysql-8.0.21-official.yaml
@@ -14,7 +14,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     denylist:
       groupReplication:
@@ -40,7 +40,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -72,7 +72,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mysql/deprecated-mysql-8.0.23-official.yaml
+++ b/catalog/raw/mysql/deprecated-mysql-8.0.23-official.yaml
@@ -14,7 +14,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -46,7 +46,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mysql/deprecated-mysql-8.0.26-official.yaml
+++ b/catalog/raw/mysql/deprecated-mysql-8.0.26-official.yaml
@@ -14,7 +14,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mysql/mysql-5.7.35-official.yaml
+++ b/catalog/raw/mysql/mysql-5.7.35-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 5.7.35-v1
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.11.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.12.0-rc.0
   db:
     image: mysql:5.7.35
   distribution: Official
@@ -15,7 +15,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -47,7 +47,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mysql/mysql-5.7.36-official.yaml
+++ b/catalog/raw/mysql/mysql-5.7.36-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 5.7.36
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.11.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.12.0-rc.0
   db:
     image: mysql:5.7.36
   distribution: Official
@@ -15,7 +15,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mysql/mysql-5.7.41-official.yaml
+++ b/catalog/raw/mysql/mysql-5.7.41-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 5.7.41
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.11.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.12.0-rc.0
   db:
     image: mysql:5.7.41
   distribution: Official
@@ -15,7 +15,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mysql/mysql-8.0.17-official.yaml
+++ b/catalog/raw/mysql/mysql-8.0.17-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.17
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.11.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.12.0-rc.0
   db:
     image: mysql:8.0.17
   distribution: Official
@@ -15,7 +15,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mysql/mysql-8.0.27-mysql.yaml
+++ b/catalog/raw/mysql/mysql-8.0.27-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.27-innodb
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.11.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.12.0-rc.0
   db:
     image: mysql/mysql-server:8.0.27
   distribution: MySQL
@@ -15,11 +15,11 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   router:
     image: mysql/mysql-router:8.0.27
   routerInitContainer:
-    image: ghcr.io/kubedb/mysql-router-init:v0.11.0
+    image: ghcr.io/kubedb/mysql-router-init:v0.12.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mysql/mysql-8.0.27-official.yaml
+++ b/catalog/raw/mysql/mysql-8.0.27-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.27
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.11.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.12.0-rc.0
   db:
     image: mysql:8.0.27
   distribution: Official
@@ -15,7 +15,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mysql/mysql-8.0.29-official.yaml
+++ b/catalog/raw/mysql/mysql-8.0.29-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.29
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.11.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.12.0-rc.0
   db:
     image: mysql:8.0.29
   distribution: Official
@@ -15,7 +15,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mysql/mysql-8.0.3-official.yaml
+++ b/catalog/raw/mysql/mysql-8.0.3-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.3-v4
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.11.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.12.0-rc.0
   db:
     image: mysql:8.0.3
   distribution: Official
@@ -15,7 +15,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -47,7 +47,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     allowlist:
       groupReplication:
@@ -73,7 +73,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     allowlist:
       groupReplication:
@@ -99,7 +99,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   updateConstraints:
     allowlist:
       groupReplication:
@@ -125,7 +125,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:
@@ -157,7 +157,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mysql/mysql-8.0.31-mysql.yaml
+++ b/catalog/raw/mysql/mysql-8.0.31-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.31-innodb
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.11.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.12.0-rc.0
   db:
     image: mysql/mysql-server:8.0.31
   distribution: MySQL
@@ -15,11 +15,11 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   router:
     image: mysql/mysql-router:8.0.31
   routerInitContainer:
-    image: ghcr.io/kubedb/mysql-router-init:v0.11.0
+    image: ghcr.io/kubedb/mysql-router-init:v0.12.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mysql/mysql-8.0.31-official.yaml
+++ b/catalog/raw/mysql/mysql-8.0.31-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.31
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.11.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.12.0-rc.0
   db:
     image: mysql:8.0.31
   distribution: Official
@@ -15,7 +15,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/mysql/mysql-8.0.32-official.yaml
+++ b/catalog/raw/mysql/mysql-8.0.32-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.32
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.11.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.12.0-rc.0
   db:
     image: mysql:8.0.32
   distribution: Official
@@ -15,7 +15,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.20.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.21.0-rc.0
   stash:
     addon:
       backupTask:

--- a/catalog/raw/perconaxtradb/perconaxtradb-8.0.26.yaml
+++ b/catalog/raw/perconaxtradb/perconaxtradb-8.0.26.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.26
 spec:
   coordinator:
-    image: ghcr.io/kubedb/percona-xtradb-coordinator:v0.6.0
+    image: ghcr.io/kubedb/percona-xtradb-coordinator:v0.7.0-rc.0
   db:
     image: percona/percona-xtradb-cluster:8.0.26
   exporter:

--- a/catalog/raw/perconaxtradb/perconaxtradb-8.0.28.yaml
+++ b/catalog/raw/perconaxtradb/perconaxtradb-8.0.28.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.28
 spec:
   coordinator:
-    image: ghcr.io/kubedb/percona-xtradb-coordinator:v0.6.0
+    image: ghcr.io/kubedb/percona-xtradb-coordinator:v0.7.0-rc.0
   db:
     image: percona/percona-xtradb-cluster:8.0.28
   exporter:

--- a/catalog/raw/perconaxtradb/perconaxtradb-8.0.31.yaml
+++ b/catalog/raw/perconaxtradb/perconaxtradb-8.0.31.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.31
 spec:
   coordinator:
-    image: ghcr.io/kubedb/percona-xtradb-coordinator:v0.6.0
+    image: ghcr.io/kubedb/percona-xtradb-coordinator:v0.7.0-rc.0
   db:
     image: percona/percona-xtradb-cluster:8.0.31
   exporter:

--- a/catalog/raw/postgres/postgres-10.16-official.yaml
+++ b/catalog/raw/postgres/postgres-10.16-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.16-debian
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:10.16
@@ -37,7 +37,7 @@ metadata:
   name: "10.16"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:10.16-alpine

--- a/catalog/raw/postgres/postgres-10.19-official.yaml
+++ b/catalog/raw/postgres/postgres-10.19-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.19-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:10.19-bullseye
@@ -36,7 +36,7 @@ metadata:
   name: "10.19"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:10.19-bullseye

--- a/catalog/raw/postgres/postgres-10.20-official.yaml
+++ b/catalog/raw/postgres/postgres-10.20-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.20-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:10.20-bullseye
@@ -36,7 +36,7 @@ metadata:
   name: "10.20"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:10.20-bullseye

--- a/catalog/raw/postgres/postgres-11.11-official.yaml
+++ b/catalog/raw/postgres/postgres-11.11-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 11.11-debian
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:11.11
@@ -36,7 +36,7 @@ metadata:
   name: "11.11"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:11.11-alpine

--- a/catalog/raw/postgres/postgres-11.11-timescaledb.yaml
+++ b/catalog/raw/postgres/postgres-11.11-timescaledb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: timescaledb-2.1.0-pg11
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     image: timescale/timescaledb:2.1.0-pg11-oss
   distribution: TimescaleDB

--- a/catalog/raw/postgres/postgres-11.14-official.yaml
+++ b/catalog/raw/postgres/postgres-11.14-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 11.14-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:11.14-bullseye
@@ -36,7 +36,7 @@ metadata:
   name: "11.14"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:11.14-alpine

--- a/catalog/raw/postgres/postgres-11.14-postgis.yaml
+++ b/catalog/raw/postgres/postgres-11.14-postgis.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 11.14-bullseye-postgis
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     image: postgis/postgis:11-3.1
   distribution: PostGIS

--- a/catalog/raw/postgres/postgres-11.15-official.yaml
+++ b/catalog/raw/postgres/postgres-11.15-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 11.15-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:11.15-bullseye
@@ -36,7 +36,7 @@ metadata:
   name: "11.15"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:11.15-alpine

--- a/catalog/raw/postgres/postgres-11.19-official.yaml
+++ b/catalog/raw/postgres/postgres-11.19-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 11.19-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:11.19-bullseye
@@ -36,7 +36,7 @@ metadata:
   name: "11.19"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:11.19-alpine

--- a/catalog/raw/postgres/postgres-11.20-official.yaml
+++ b/catalog/raw/postgres/postgres-11.20-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 11.20-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:11.20-bullseye
@@ -36,7 +36,7 @@ metadata:
   name: "11.20"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:11.20-alpine

--- a/catalog/raw/postgres/postgres-12.10-official.yaml
+++ b/catalog/raw/postgres/postgres-12.10-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 12.10-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:12.10-bullseye
@@ -37,7 +37,7 @@ metadata:
   name: "12.10"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:12.10-alpine

--- a/catalog/raw/postgres/postgres-12.13-official.yaml
+++ b/catalog/raw/postgres/postgres-12.13-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 12.13-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:12.13-bullseye
@@ -37,7 +37,7 @@ metadata:
   name: "12.13"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:12.13-alpine

--- a/catalog/raw/postgres/postgres-12.14-official.yaml
+++ b/catalog/raw/postgres/postgres-12.14-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 12.14-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:12.14-bullseye
@@ -37,7 +37,7 @@ metadata:
   name: "12.14"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:12.14-alpine

--- a/catalog/raw/postgres/postgres-12.15-official.yaml
+++ b/catalog/raw/postgres/postgres-12.15-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 12.15-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:12.15-bullseye
@@ -37,7 +37,7 @@ metadata:
   name: "12.15"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:12.15-alpine

--- a/catalog/raw/postgres/postgres-12.6-official.yaml
+++ b/catalog/raw/postgres/postgres-12.6-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 12.6-debian
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:12.6
@@ -37,7 +37,7 @@ metadata:
   name: "12.6"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:12.6-alpine

--- a/catalog/raw/postgres/postgres-12.6-timescaledb.yaml
+++ b/catalog/raw/postgres/postgres-12.6-timescaledb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: timescaledb-2.1.0-pg12
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     image: timescale/timescaledb:2.1.0-pg12-oss
   distribution: TimescaleDB

--- a/catalog/raw/postgres/postgres-12.9-official.yaml
+++ b/catalog/raw/postgres/postgres-12.9-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 12.9-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:12.9-bullseye
@@ -37,7 +37,7 @@ metadata:
   name: "12.9"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:12.9-alpine

--- a/catalog/raw/postgres/postgres-12.9-postgis.yaml
+++ b/catalog/raw/postgres/postgres-12.9-postgis.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 12.9-bullseye-postgis
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     image: postgis/postgis:12-3.1
   distribution: PostGIS

--- a/catalog/raw/postgres/postgres-13.10-official.yaml
+++ b/catalog/raw/postgres/postgres-13.10-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 13.10-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:13.10-bullseye
@@ -36,7 +36,7 @@ metadata:
   name: "13.10"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:13.10-alpine

--- a/catalog/raw/postgres/postgres-13.11-official.yaml
+++ b/catalog/raw/postgres/postgres-13.11-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 13.11-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:13.11-bullseye
@@ -36,7 +36,7 @@ metadata:
   name: "13.11"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:13.11-alpine

--- a/catalog/raw/postgres/postgres-13.2-official.yaml
+++ b/catalog/raw/postgres/postgres-13.2-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 13.2-debian
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:13.2
@@ -36,7 +36,7 @@ metadata:
   name: "13.2"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:13.2-alpine

--- a/catalog/raw/postgres/postgres-13.2-timescaledb.yaml
+++ b/catalog/raw/postgres/postgres-13.2-timescaledb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: timescaledb-2.1.0-pg13
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     image: timescale/timescaledb:2.1.0-pg13-oss
   distribution: TimescaleDB

--- a/catalog/raw/postgres/postgres-13.5-official.yaml
+++ b/catalog/raw/postgres/postgres-13.5-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 13.5-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:13.5-bullseye
@@ -36,7 +36,7 @@ metadata:
   name: "13.5"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:13.5-alpine

--- a/catalog/raw/postgres/postgres-13.5-postgis.yaml
+++ b/catalog/raw/postgres/postgres-13.5-postgis.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 13.5-bullseye-postgis
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     image: postgis/postgis:13-3.1
   distribution: PostGIS

--- a/catalog/raw/postgres/postgres-13.6-official.yaml
+++ b/catalog/raw/postgres/postgres-13.6-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 13.6-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:13.6-bullseye
@@ -36,7 +36,7 @@ metadata:
   name: "13.6"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:13.6-alpine

--- a/catalog/raw/postgres/postgres-13.9-official.yaml
+++ b/catalog/raw/postgres/postgres-13.9-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 13.9-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:13.9-bullseye
@@ -36,7 +36,7 @@ metadata:
   name: "13.9"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:13.9-alpine

--- a/catalog/raw/postgres/postgres-14.1-official.yaml
+++ b/catalog/raw/postgres/postgres-14.1-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 14.1-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:14.1-bullseye
@@ -36,7 +36,7 @@ metadata:
   name: "14.1"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:14.1-alpine

--- a/catalog/raw/postgres/postgres-14.1-postgis.yaml
+++ b/catalog/raw/postgres/postgres-14.1-postgis.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 14.1-bullseye-postgis
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     image: postgis/postgis:14-3.1
   distribution: PostGIS

--- a/catalog/raw/postgres/postgres-14.1-timescaledb.yaml
+++ b/catalog/raw/postgres/postgres-14.1-timescaledb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: timescaledb-2.5.0-pg14.1
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     image: timescale/timescaledb:2.5.0-pg14-oss
   distribution: TimescaleDB

--- a/catalog/raw/postgres/postgres-14.2-official.yaml
+++ b/catalog/raw/postgres/postgres-14.2-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 14.2-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:14.2-bullseye
@@ -33,7 +33,7 @@ metadata:
   name: "14.2"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:14.2-alpine

--- a/catalog/raw/postgres/postgres-14.6-official.yaml
+++ b/catalog/raw/postgres/postgres-14.6-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 14.6-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:14.6-bullseye
@@ -33,7 +33,7 @@ metadata:
   name: "14.6"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:14.6-alpine

--- a/catalog/raw/postgres/postgres-14.7-official.yaml
+++ b/catalog/raw/postgres/postgres-14.7-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 14.7-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:14.7-bullseye
@@ -33,7 +33,7 @@ metadata:
   name: "14.7"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:14.7-alpine

--- a/catalog/raw/postgres/postgres-14.8-official.yaml
+++ b/catalog/raw/postgres/postgres-14.8-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 14.8-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:14.8-bullseye
@@ -33,7 +33,7 @@ metadata:
   name: "14.8"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:14.8-alpine

--- a/catalog/raw/postgres/postgres-15.1-official.yaml
+++ b/catalog/raw/postgres/postgres-15.1-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 15.1-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:15.1-bullseye
@@ -36,7 +36,7 @@ metadata:
   name: "15.1"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:15.1-alpine

--- a/catalog/raw/postgres/postgres-15.2-official.yaml
+++ b/catalog/raw/postgres/postgres-15.2-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 15.2-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:15.2-bullseye
@@ -36,7 +36,7 @@ metadata:
   name: "15.2"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:15.2-alpine

--- a/catalog/raw/postgres/postgres-15.3-official.yaml
+++ b/catalog/raw/postgres/postgres-15.3-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 15.3-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:15.3-bullseye
@@ -36,7 +36,7 @@ metadata:
   name: "15.3"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:15.3-alpine

--- a/catalog/raw/postgres/postgres-9.6.21-official.yaml
+++ b/catalog/raw/postgres/postgres-9.6.21-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 9.6.21-debian
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: debian
     image: postgres:9.6.21
@@ -37,7 +37,7 @@ metadata:
   name: 9.6.21
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:9.6.21-alpine

--- a/catalog/raw/postgres/postgres-9.6.24-official.yaml
+++ b/catalog/raw/postgres/postgres-9.6.24-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 9.6.24-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: bullseye
     image: postgres:9.6.24-bullseye
@@ -36,7 +36,7 @@ metadata:
   name: 9.6.24
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.17.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.18.0-rc.0
   db:
     baseOS: alpine
     image: postgres:9.6.24-alpine

--- a/catalog/raw/redis/deprecated-redis-4.0.yaml
+++ b/catalog/raw/redis/deprecated-redis-4.0.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "4.0"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: ghcr.io/kubedb/redis:4.0
   deprecated: true
@@ -23,7 +23,7 @@ metadata:
   name: 4.0-v1
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: ghcr.io/kubedb/redis:4.0-v1
   deprecated: true
@@ -42,7 +42,7 @@ metadata:
   name: 4.0-v2
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: ghcr.io/kubedb/redis:4.0-v2
   deprecated: true

--- a/catalog/raw/redis/deprecated-redis-4.yaml
+++ b/catalog/raw/redis/deprecated-redis-4.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "4"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: ghcr.io/kubedb/redis:4
   deprecated: true
@@ -23,7 +23,7 @@ metadata:
   name: 4-v1
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: ghcr.io/kubedb/redis:4-v1
   deprecated: true

--- a/catalog/raw/redis/deprecated-redis-5.0.yaml
+++ b/catalog/raw/redis/deprecated-redis-5.0.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "5.0"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: ghcr.io/kubedb/redis:5.0
   deprecated: true
@@ -29,7 +29,7 @@ metadata:
   name: 5.0-v1
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: ghcr.io/kubedb/redis:5.0-v1
   deprecated: true

--- a/catalog/raw/redis/redis-4.0.11.yaml
+++ b/catalog/raw/redis/redis-4.0.11.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 4.0.11
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: ghcr.io/kubedb/redis:4.0.11
   exporter:

--- a/catalog/raw/redis/redis-4.0.6.yaml
+++ b/catalog/raw/redis/redis-4.0.6.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 4.0.6-v2
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: ghcr.io/kubedb/redis:4.0.6-v2
   exporter:
@@ -22,7 +22,7 @@ metadata:
   name: 4.0.6
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: ghcr.io/kubedb/redis:4.0.6
   deprecated: true
@@ -41,7 +41,7 @@ metadata:
   name: 4.0.6-v1
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: ghcr.io/kubedb/redis:4.0.6-v1
   deprecated: true

--- a/catalog/raw/redis/redis-5.0.14.yaml
+++ b/catalog/raw/redis/redis-5.0.14.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 5.0.14
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: redis:5.0.14
   exporter:

--- a/catalog/raw/redis/redis-5.0.3.yaml
+++ b/catalog/raw/redis/redis-5.0.3.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 5.0.3-v1
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: ghcr.io/kubedb/redis:5.0.3-v1
   exporter:
@@ -28,7 +28,7 @@ metadata:
   name: 5.0.3
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: ghcr.io/kubedb/redis:5.0.3
   deprecated: true

--- a/catalog/raw/redis/redis-6.0.18.yaml
+++ b/catalog/raw/redis/redis-6.0.18.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 6.0.18
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: redis:6.0.18
   exporter:

--- a/catalog/raw/redis/redis-6.0.6.yaml
+++ b/catalog/raw/redis/redis-6.0.6.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 6.0.6
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: ghcr.io/kubedb/redis:6.0.6
   exporter:

--- a/catalog/raw/redis/redis-6.2.11.yaml
+++ b/catalog/raw/redis/redis-6.2.11.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 6.2.11
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: redis:6.2.11
   exporter:

--- a/catalog/raw/redis/redis-6.2.5.yaml
+++ b/catalog/raw/redis/redis-6.2.5.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 6.2.5
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: redis:6.2.5
   exporter:

--- a/catalog/raw/redis/redis-6.2.7.yaml
+++ b/catalog/raw/redis/redis-6.2.7.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 6.2.7
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: redis:6.2.7
   exporter:

--- a/catalog/raw/redis/redis-6.2.8.yaml
+++ b/catalog/raw/redis/redis-6.2.8.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 6.2.8
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: redis:6.2.8
   exporter:

--- a/catalog/raw/redis/redis-7.0.10.yaml
+++ b/catalog/raw/redis/redis-7.0.10.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.0.10
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: redis:7.0.10
   exporter:

--- a/catalog/raw/redis/redis-7.0.4.yaml
+++ b/catalog/raw/redis/redis-7.0.4.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.0.4
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: redis:7.0.4
   exporter:

--- a/catalog/raw/redis/redis-7.0.5.yaml
+++ b/catalog/raw/redis/redis-7.0.5.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.0.5
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: redis:7.0.5
   exporter:

--- a/catalog/raw/redis/redis-7.0.6.yaml
+++ b/catalog/raw/redis/redis-7.0.6.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.0.6
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: redis:7.0.6
   exporter:

--- a/catalog/raw/redis/redis-7.0.9.yaml
+++ b/catalog/raw/redis/redis-7.0.9.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.0.9
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.12.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.13.0-rc.0
   db:
     image: redis:7.0.9
   exporter:

--- a/charts/kubedb-autoscaler/Chart.yaml
+++ b/charts/kubedb-autoscaler/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeDB Autoscaler by AppsCode - Autoscale KubeDB operated Databases
 name: kubedb-autoscaler
-version: v0.18.0
-appVersion: v0.18.1
+version: v0.19.0-rc.0
+appVersion: v0.19.0-rc.0
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-autoscaler-icon.png
 sources:

--- a/charts/kubedb-autoscaler/README.md
+++ b/charts/kubedb-autoscaler/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-autoscaler --version=v0.18.0
-$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.18.0
+$ helm search repo appscode/kubedb-autoscaler --version=v0.19.0-rc.0
+$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.19.0-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Autoscaler operator on a [Kubernetes](http://kuberne
 To install/upgrade the chart with the release name `kubedb-autoscaler`:
 
 ```bash
-$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.18.0
+$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.19.0-rc.0
 ```
 
 The command deploys a KubeDB Autoscaler operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -85,12 +85,12 @@ The following table lists the configurable parameters of the `kubedb-autoscaler`
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.18.0 --set replicaCount=1
+$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.19.0-rc.0 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.18.0 --values values.yaml
+$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.19.0-rc.0 --values values.yaml
 ```

--- a/charts/kubedb-catalog/Chart.yaml
+++ b/charts/kubedb-catalog/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeDB Catalog by AppsCode - Catalog for database versions
 name: kubedb-catalog
-version: v2023.04.10
-appVersion: v2023.04.10
+version: v2023.06.13-rc.0
+appVersion: v2023.06.13-rc.0
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/icon/kubedb.png
 sources:

--- a/charts/kubedb-catalog/README.md
+++ b/charts/kubedb-catalog/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-catalog --version=v2023.04.10
-$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2023.04.10
+$ helm search repo appscode/kubedb-catalog --version=v2023.06.13-rc.0
+$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2023.06.13-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys KubeDB catalog on a [Kubernetes](http://kubernetes.io) cluste
 To install/upgrade the chart with the release name `kubedb-catalog`:
 
 ```bash
-$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2023.04.10
+$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2023.06.13-rc.0
 ```
 
 The command deploys KubeDB catalog on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -90,12 +90,12 @@ The following table lists the configurable parameters of the `kubedb-catalog` ch
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2023.04.10 --set -- generate from values file --
+$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2023.06.13-rc.0 --set -- generate from values file --
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2023.04.10 --values values.yaml
+$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2023.06.13-rc.0 --values values.yaml
 ```

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-10.10.2.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-10.10.2.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mariadb-coordinator:v0.13.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mariadb-coordinator:v0.14.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "mariadb") .Values) }}:10.10.2'
   exporter:

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-10.11.2.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-10.11.2.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mariadb-coordinator:v0.13.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mariadb-coordinator:v0.14.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "mariadb") .Values) }}:10.11.2'
   exporter:

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-10.4.17.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-10.4.17.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mariadb-coordinator:v0.13.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mariadb-coordinator:v0.14.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "mariadb") .Values) }}:10.4.17'
   exporter:

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-10.5.8.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-10.5.8.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mariadb-coordinator:v0.13.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mariadb-coordinator:v0.14.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "mariadb") .Values) }}:10.5.8'
   exporter:

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-10.6.4.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-10.6.4.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mariadb-coordinator:v0.13.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mariadb-coordinator:v0.14.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "mariadb") .Values) }}:10.6.4'
   exporter:

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.4-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.4-official.yaml
@@ -17,7 +17,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: "3.4"
 {{ end }}
 
@@ -41,7 +41,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: "3.4"
 {{ end }}
 
@@ -65,7 +65,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: "3.4"
 {{ end }}
 
@@ -89,6 +89,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: "3.4"
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.6-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.6-official.yaml
@@ -17,7 +17,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: "3.6"
 {{ end }}
 
@@ -41,7 +41,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: "3.6"
 {{ end }}
 
@@ -65,7 +65,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: "3.6"
 {{ end }}
 
@@ -89,6 +89,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: "3.6"
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-3.4.17-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-3.4.17-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -49,6 +49,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 3.4.17
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-3.4.22-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-3.4.22-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -49,7 +49,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 3.4.22
 {{ end }}
 
@@ -73,7 +73,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 3.4.22
 {{ end }}
 
@@ -97,6 +97,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 3.4.22
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-3.6.13-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-3.6.13-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -49,7 +49,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 3.6.13
 {{ end }}
 
@@ -73,7 +73,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 3.6.13
 {{ end }}
 
@@ -97,6 +97,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 3.6.13
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-3.6.18-percona.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-3.6.18-percona.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-3.6.8-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-3.6.8-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -49,6 +49,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 3.6.8
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.0.10-percona.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.0.10-percona.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.0.11-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.0.11-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -49,7 +49,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 4.0.11
 {{ end }}
 
@@ -73,7 +73,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 4.0.11
 {{ end }}
 
@@ -97,6 +97,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 4.0.11
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.0.3-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.0.3-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -49,6 +49,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 4.0.3
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.0.5-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.0.5-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -49,7 +49,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 4.0.5
 {{ end }}
 
@@ -73,7 +73,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 4.0.5
 {{ end }}
 
@@ -97,7 +97,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 4.0.5
 {{ end }}
 
@@ -121,7 +121,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 4.0.5
 {{ end }}
 
@@ -145,6 +145,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 4.0.5
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.1.13-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.1.13-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -49,7 +49,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 4.1.13
 {{ end }}
 
@@ -73,7 +73,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 4.1.13
 {{ end }}
 
@@ -97,6 +97,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 4.1.13
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.1.4-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.1.4-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -49,6 +49,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 4.1.4
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.1.7-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.1.7-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -49,7 +49,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 4.1.7
 {{ end }}
 
@@ -73,7 +73,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 4.1.7
 {{ end }}
 
@@ -97,6 +97,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 4.1.7
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.2.3-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.2.3-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -49,6 +49,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   version: 4.2.3
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.2.7-percona.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.2.7-percona.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.4.10-percona.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.4.10-percona.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.4.6-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.4.6-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-5.0.15-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-5.0.15-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-5.0.2-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-5.0.2-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-5.0.3-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-5.0.3-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-6.0.5-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-6.0.5-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5-official.yaml
@@ -17,7 +17,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     denylist:
       groupReplication:
@@ -47,7 +47,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     denylist:
       groupReplication:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7-official.yaml
@@ -17,7 +17,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     denylist:
       groupReplication:
@@ -47,7 +47,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     denylist:
       groupReplication:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.25-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.25-official.yaml
@@ -17,7 +17,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     denylist:
       groupReplication:
@@ -47,7 +47,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     denylist:
       groupReplication:
@@ -77,7 +77,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     denylist:
       groupReplication:
@@ -107,7 +107,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     denylist:
       groupReplication:
@@ -137,7 +137,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -173,7 +173,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.29-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.29-official.yaml
@@ -17,7 +17,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     denylist:
       groupReplication:
@@ -47,7 +47,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     denylist:
       groupReplication:
@@ -77,7 +77,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -113,7 +113,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.31-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.31-official.yaml
@@ -17,7 +17,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     denylist:
       groupReplication:
@@ -47,7 +47,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -83,7 +83,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.33-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.33-official.yaml
@@ -17,7 +17,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -53,7 +53,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8-official.yaml
@@ -17,7 +17,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     denylist:
       groupReplication:
@@ -47,7 +47,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     denylist:
       groupReplication:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0-official.yaml
@@ -17,7 +17,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     denylist:
       groupReplication:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.14-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.14-official.yaml
@@ -17,7 +17,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     denylist:
       groupReplication:
@@ -47,7 +47,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     denylist:
       groupReplication:
@@ -77,7 +77,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     denylist:
       groupReplication:
@@ -107,7 +107,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -143,7 +143,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.20-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.20-official.yaml
@@ -17,7 +17,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     denylist:
       groupReplication:
@@ -47,7 +47,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     denylist:
       groupReplication:
@@ -77,7 +77,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -113,7 +113,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.21-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.21-official.yaml
@@ -17,7 +17,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     denylist:
       groupReplication:
@@ -47,7 +47,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -83,7 +83,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.23-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.23-official.yaml
@@ -17,7 +17,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -53,7 +53,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.26-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.26-official.yaml
@@ -17,7 +17,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.35-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.35-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.11.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.12.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "mysql") .Values) }}:5.7.35'
   distribution: Official
@@ -18,7 +18,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -54,7 +54,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.36-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.36-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.11.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.12.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "mysql") .Values) }}:5.7.36'
   distribution: Official
@@ -18,7 +18,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.41-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.41-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.11.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.12.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "mysql") .Values) }}:5.7.41'
   distribution: Official
@@ -18,7 +18,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.17-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.17-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.11.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.12.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "mysql") .Values) }}:8.0.17'
   distribution: Official
@@ -18,7 +18,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.27-mysql.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.27-mysql.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.11.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.12.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "mysql") .Values) }}/mysql-server:8.0.27'
   distribution: MySQL
@@ -18,11 +18,11 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   router:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "mysql") .Values) }}/mysql-router:8.0.27'
   routerInitContainer:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-router-init:v0.11.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-router-init:v0.12.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.27-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.27-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.11.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.12.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "mysql") .Values) }}:8.0.27'
   distribution: Official
@@ -18,7 +18,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.29-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.29-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.11.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.12.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "mysql") .Values) }}:8.0.29'
   distribution: Official
@@ -18,7 +18,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.3-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.3-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.11.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.12.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "mysql") .Values) }}:8.0.3'
   distribution: Official
@@ -18,7 +18,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -54,7 +54,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     allowlist:
       groupReplication:
@@ -84,7 +84,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     allowlist:
       groupReplication:
@@ -114,7 +114,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   updateConstraints:
     allowlist:
       groupReplication:
@@ -144,7 +144,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:
@@ -180,7 +180,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.31-mysql.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.31-mysql.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.11.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.12.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "mysql") .Values) }}/mysql-server:8.0.31'
   distribution: MySQL
@@ -18,11 +18,11 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   router:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "mysql") .Values) }}/mysql-router:8.0.31'
   routerInitContainer:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-router-init:v0.11.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-router-init:v0.12.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.31-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.31-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.11.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.12.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "mysql") .Values) }}:8.0.31'
   distribution: Official
@@ -18,7 +18,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.32-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.32-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.11.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/mysql-coordinator:v0.12.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "mysql") .Values) }}:8.0.32'
   distribution: Official
@@ -18,7 +18,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.20.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/replication-mode-detector:v0.21.0-rc.0'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/perconaxtradb/perconaxtradb-8.0.26.yaml
+++ b/charts/kubedb-catalog/templates/perconaxtradb/perconaxtradb-8.0.26.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/percona-xtradb-coordinator:v0.6.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/percona-xtradb-coordinator:v0.7.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "percona") .Values) }}/percona-xtradb-cluster:8.0.26'
   exporter:

--- a/charts/kubedb-catalog/templates/perconaxtradb/perconaxtradb-8.0.28.yaml
+++ b/charts/kubedb-catalog/templates/perconaxtradb/perconaxtradb-8.0.28.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/percona-xtradb-coordinator:v0.6.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/percona-xtradb-coordinator:v0.7.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "percona") .Values) }}/percona-xtradb-cluster:8.0.28'
   exporter:

--- a/charts/kubedb-catalog/templates/perconaxtradb/perconaxtradb-8.0.31.yaml
+++ b/charts/kubedb-catalog/templates/perconaxtradb/perconaxtradb-8.0.31.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/percona-xtradb-coordinator:v0.6.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/percona-xtradb-coordinator:v0.7.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "percona") .Values) }}/percona-xtradb-cluster:8.0.31'
   exporter:

--- a/charts/kubedb-catalog/templates/postgres/postgres-10.16-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-10.16-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:10.16'
@@ -44,7 +44,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:10.16-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-10.19-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-10.19-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:10.19-bullseye'
@@ -43,7 +43,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:10.19-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/postgres-10.20-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-10.20-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:10.20-bullseye'
@@ -43,7 +43,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:10.20-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/postgres-11.11-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-11.11-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:11.11'
@@ -43,7 +43,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:11.11-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-11.11-timescaledb.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-11.11-timescaledb.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "timescale") .Values) }}/timescaledb:2.1.0-pg11-oss'
   distribution: TimescaleDB

--- a/charts/kubedb-catalog/templates/postgres/postgres-11.14-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-11.14-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:11.14-bullseye'
@@ -43,7 +43,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:11.14-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-11.14-postgis.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-11.14-postgis.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "postgis") .Values) }}/postgis:11-3.1'
   distribution: PostGIS

--- a/charts/kubedb-catalog/templates/postgres/postgres-11.15-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-11.15-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:11.15-bullseye'
@@ -43,7 +43,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:11.15-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-11.19-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-11.19-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:11.19-bullseye'
@@ -43,7 +43,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:11.19-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-11.20-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-11.20-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:11.20-bullseye'
@@ -43,7 +43,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:11.20-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-12.10-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-12.10-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:12.10-bullseye'
@@ -44,7 +44,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:12.10-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-12.13-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-12.13-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:12.13-bullseye'
@@ -44,7 +44,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:12.13-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-12.14-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-12.14-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:12.14-bullseye'
@@ -44,7 +44,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:12.14-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-12.15-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-12.15-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:12.15-bullseye'
@@ -44,7 +44,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:12.15-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-12.6-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-12.6-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:12.6'
@@ -44,7 +44,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:12.6-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-12.6-timescaledb.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-12.6-timescaledb.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "timescale") .Values) }}/timescaledb:2.1.0-pg12-oss'
   distribution: TimescaleDB

--- a/charts/kubedb-catalog/templates/postgres/postgres-12.9-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-12.9-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:12.9-bullseye'
@@ -44,7 +44,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:12.9-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-12.9-postgis.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-12.9-postgis.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "postgis") .Values) }}/postgis:12-3.1'
   distribution: PostGIS

--- a/charts/kubedb-catalog/templates/postgres/postgres-13.10-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-13.10-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:13.10-bullseye'
@@ -43,7 +43,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:13.10-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-13.11-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-13.11-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:13.11-bullseye'
@@ -43,7 +43,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:13.11-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-13.2-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-13.2-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:13.2'
@@ -43,7 +43,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:13.2-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-13.2-timescaledb.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-13.2-timescaledb.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "timescale") .Values) }}/timescaledb:2.1.0-pg13-oss'
   distribution: TimescaleDB

--- a/charts/kubedb-catalog/templates/postgres/postgres-13.5-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-13.5-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:13.5-bullseye'
@@ -43,7 +43,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:13.5-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-13.5-postgis.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-13.5-postgis.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "postgis") .Values) }}/postgis:13-3.1'
   distribution: PostGIS

--- a/charts/kubedb-catalog/templates/postgres/postgres-13.6-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-13.6-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:13.6-bullseye'
@@ -43,7 +43,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:13.6-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-13.9-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-13.9-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:13.9-bullseye'
@@ -43,7 +43,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:13.9-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-14.1-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-14.1-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:14.1-bullseye'
@@ -43,7 +43,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:14.1-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-14.1-postgis.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-14.1-postgis.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "postgis") .Values) }}/postgis:14-3.1'
   distribution: PostGIS

--- a/charts/kubedb-catalog/templates/postgres/postgres-14.1-timescaledb.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-14.1-timescaledb.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "" "_repo" "timescale") .Values) }}/timescaledb:2.5.0-pg14-oss'
   distribution: TimescaleDB

--- a/charts/kubedb-catalog/templates/postgres/postgres-14.2-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-14.2-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:14.2-bullseye'
@@ -40,7 +40,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:14.2-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-14.6-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-14.6-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:14.6-bullseye'
@@ -40,7 +40,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:14.6-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-14.7-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-14.7-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:14.7-bullseye'
@@ -40,7 +40,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:14.7-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-14.8-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-14.8-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:14.8-bullseye'
@@ -40,7 +40,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:14.8-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-15.1-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-15.1-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:15.1-bullseye'
@@ -43,7 +43,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:15.1-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-15.2-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-15.2-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:15.2-bullseye'
@@ -43,7 +43,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:15.2-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-15.3-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-15.3-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:15.3-bullseye'
@@ -43,7 +43,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:15.3-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-9.6.21-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-9.6.21-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: debian
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:9.6.21'
@@ -44,7 +44,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:9.6.21-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-9.6.24-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-9.6.24-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: bullseye
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:9.6.24-bullseye'
@@ -43,7 +43,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.17.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/pg-coordinator:v0.18.0-rc.0'
   db:
     baseOS: alpine
     image: '{{ include "official.registry" (merge (dict "_bin" "postgres") .Values) }}:9.6.24-alpine'

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-4.0.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-4.0.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis:4.0'
   deprecated: true
@@ -30,7 +30,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis:4.0-v1'
   deprecated: true
@@ -53,7 +53,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis:4.0-v2'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-4.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-4.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis:4'
   deprecated: true
@@ -30,7 +30,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis:4-v1'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-5.0.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-5.0.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis:5.0'
   deprecated: true
@@ -36,7 +36,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis:5.0-v1'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/redis-4.0.11.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-4.0.11.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis:4.0.11'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-4.0.6.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-4.0.6.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis:4.0.6-v2'
   exporter:
@@ -29,7 +29,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis:4.0.6'
   deprecated: true
@@ -52,7 +52,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis:4.0.6-v1'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/redis-5.0.14.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-5.0.14.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "redis") .Values) }}:5.0.14'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-5.0.3.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-5.0.3.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis:5.0.3-v1'
   exporter:
@@ -35,7 +35,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis:5.0.3'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/redis-6.0.18.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-6.0.18.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "redis") .Values) }}:6.0.18'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-6.0.6.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-6.0.6.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis:6.0.6'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-6.2.11.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-6.2.11.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "redis") .Values) }}:6.2.11'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-6.2.5.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-6.2.5.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "redis") .Values) }}:6.2.5'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-6.2.7.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-6.2.7.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "redis") .Values) }}:6.2.7'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-6.2.8.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-6.2.8.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "redis") .Values) }}:6.2.8'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-7.0.10.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-7.0.10.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "redis") .Values) }}:7.0.10'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-7.0.4.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-7.0.4.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "redis") .Values) }}:7.0.4'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-7.0.5.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-7.0.5.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "redis") .Values) }}:7.0.5'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-7.0.6.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-7.0.6.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "redis") .Values) }}:7.0.6'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-7.0.9.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-7.0.9.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.12.0'
+    image: '{{ include "catalog.registry" (merge (dict "_reg" "ghcr.io" "_repo" "kubedb") .Values) }}/redis-coordinator:v0.13.0-rc.0'
   db:
     image: '{{ include "official.registry" (merge (dict "_bin" "redis") .Values) }}:7.0.9'
   exporter:

--- a/charts/kubedb-crds/Chart.yaml
+++ b/charts/kubedb-crds/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-crds
 description: KubeDB Custom Resource Definitions
 type: application
-version: v2023.04.10
-appVersion: v2023.04.10
+version: v2023.06.13-rc.0
+appVersion: v2023.06.13-rc.0
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-community-icon.png
 sources:

--- a/charts/kubedb-crds/README.md
+++ b/charts/kubedb-crds/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-crds --version=v2023.04.10
-$ helm upgrade -i kubedb-crds appscode/kubedb-crds -n kubedb --create-namespace --version=v2023.04.10
+$ helm search repo appscode/kubedb-crds --version=v2023.06.13-rc.0
+$ helm upgrade -i kubedb-crds appscode/kubedb-crds -n kubedb --create-namespace --version=v2023.06.13-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys KubeDB crds on a [Kubernetes](http://kubernetes.io) cluster u
 To install/upgrade the chart with the release name `kubedb-crds`:
 
 ```bash
-$ helm upgrade -i kubedb-crds appscode/kubedb-crds -n kubedb --create-namespace --version=v2023.04.10
+$ helm upgrade -i kubedb-crds appscode/kubedb-crds -n kubedb --create-namespace --version=v2023.06.13-rc.0
 ```
 
 The command deploys KubeDB crds on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.

--- a/charts/kubedb-dashboard/Chart.yaml
+++ b/charts/kubedb-dashboard/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 description: KubeDB Dashboard by AppsCode
 name: kubedb-dashboard
 type: application
-version: v0.9.0
-appVersion: v0.9.1
+version: v0.10.0-rc.0
+appVersion: v0.10.0-rc.0
 home: https://github.com/kubedb
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-icon.png
 sources:

--- a/charts/kubedb-dashboard/README.md
+++ b/charts/kubedb-dashboard/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-dashboard --version=v0.9.0
-$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.9.0
+$ helm search repo appscode/kubedb-dashboard --version=v0.10.0-rc.0
+$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.10.0-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Dashboard operator on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `kubedb-dashboard`:
 
 ```bash
-$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.9.0
+$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.10.0-rc.0
 ```
 
 The command deploys a KubeDB Dashboard operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -82,12 +82,12 @@ The following table lists the configurable parameters of the `kubedb-dashboard` 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.9.0 --set replicaCount=1
+$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.10.0-rc.0 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.9.0 --values values.yaml
+$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.10.0-rc.0 --values values.yaml
 ```

--- a/charts/kubedb-grafana-dashboards/Chart.yaml
+++ b/charts/kubedb-grafana-dashboards/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-grafana-dashboards
 description: A Helm chart for kubedb-grafana-dashboards by AppsCode
 type: application
-version: v2023.04.10
-appVersion: v2023.04.10
+version: v2023.06.13-rc.0
+appVersion: v2023.06.13-rc.0
 home: https://github.com/kubedb
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-icon.png
 sources:

--- a/charts/kubedb-grafana-dashboards/README.md
+++ b/charts/kubedb-grafana-dashboards/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-grafana-dashboards --version=v2023.04.10
-$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2023.04.10
+$ helm search repo appscode/kubedb-grafana-dashboards --version=v2023.06.13-rc.0
+$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2023.06.13-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Grafana Dashboards on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `kubedb-grafana-dashboards`:
 
 ```bash
-$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2023.04.10
+$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2023.06.13-rc.0
 ```
 
 The command deploys a KubeDB Grafana Dashboards on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -61,12 +61,12 @@ The following table lists the configurable parameters of the `kubedb-grafana-das
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2023.04.10 --set resources=["elasticsearch","mariadb","mongodb","mysql","postgres","redis","proxysql"]
+$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2023.06.13-rc.0 --set resources=["elasticsearch","mariadb","mongodb","mysql","postgres","redis","proxysql"]
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2023.04.10 --values values.yaml
+$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2023.06.13-rc.0 --values values.yaml
 ```

--- a/charts/kubedb-metrics/Chart.yaml
+++ b/charts/kubedb-metrics/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-metrics
 description: KubeDB State Metrics
 type: application
-version: v2023.04.10
-appVersion: v2023.04.10
+version: v2023.06.13-rc.0
+appVersion: v2023.06.13-rc.0
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-community-icon.png
 sources:

--- a/charts/kubedb-metrics/README.md
+++ b/charts/kubedb-metrics/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-metrics --version=v2023.04.10
-$ helm upgrade -i kubedb-metrics appscode/kubedb-metrics -n kubedb --create-namespace --version=v2023.04.10
+$ helm search repo appscode/kubedb-metrics --version=v2023.06.13-rc.0
+$ helm upgrade -i kubedb-metrics appscode/kubedb-metrics -n kubedb --create-namespace --version=v2023.06.13-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys KubeDB metrics configurations on a [Kubernetes](http://kubern
 To install/upgrade the chart with the release name `kubedb-metrics`:
 
 ```bash
-$ helm upgrade -i kubedb-metrics appscode/kubedb-metrics -n kubedb --create-namespace --version=v2023.04.10
+$ helm upgrade -i kubedb-metrics appscode/kubedb-metrics -n kubedb --create-namespace --version=v2023.06.13-rc.0
 ```
 
 The command deploys KubeDB metrics configurations on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.

--- a/charts/kubedb-one/Chart.lock
+++ b/charts/kubedb-one/Chart.lock
@@ -1,36 +1,36 @@
 dependencies:
 - name: kubedb-catalog
   repository: file://../kubedb-catalog
-  version: v2023.04.10
+  version: v2023.06.13-rc.0
 - name: kubedb-provisioner
   repository: file://../kubedb-provisioner
-  version: v0.33.0
+  version: v0.34.0-rc.0
 - name: kubedb-ops-manager
   repository: file://../kubedb-ops-manager
-  version: v0.20.0
+  version: v0.21.0-rc.0
 - name: kubedb-autoscaler
   repository: file://../kubedb-autoscaler
-  version: v0.18.0
+  version: v0.19.0-rc.0
 - name: kubedb-dashboard
   repository: file://../kubedb-dashboard
-  version: v0.9.0
+  version: v0.10.0-rc.0
 - name: kubedb-schema-manager
   repository: file://../kubedb-schema-manager
-  version: v0.9.0
+  version: v0.10.0-rc.0
 - name: kubedb-webhook-server
   repository: file://../kubedb-webhook-server
-  version: v0.9.0
+  version: v0.10.0-rc.0
 - name: kubedb-metrics
   repository: file://../kubedb-metrics
-  version: v2023.04.10
+  version: v2023.06.13-rc.0
 - name: stash-enterprise
   repository: https://charts.appscode.com/stable/
-  version: v0.29.0
+  version: v0.30.0
 - name: stash-catalog
   repository: https://charts.appscode.com/stable/
-  version: v2023.04.30
+  version: v2023.05.31
 - name: stash-metrics
   repository: https://charts.appscode.com/stable/
-  version: v2023.04.30
-digest: sha256:c3d7879c26b114d7f215a45dac86bf9dae5547bfbd3409d9d06302ba455d5985
-generated: "2023-05-01T04:41:29.971779-04:00"
+  version: v2023.05.31
+digest: sha256:953a7058444c4c5936ca0536447115018a01b6da23f14775f42320e9da936b4a
+generated: "2023-06-13T05:40:11.049639-07:00"

--- a/charts/kubedb-one/Chart.yaml
+++ b/charts/kubedb-one/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-one
 description: KubeDB and Stash by AppsCode - Production ready databases on Kubernetes
 type: application
-version: v2023.04.10
-appVersion: v2023.04.10
+version: v2023.06.13-rc.0
+appVersion: v2023.06.13-rc.0
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-icon.png
 sources:
@@ -15,43 +15,43 @@ dependencies:
 - name: kubedb-catalog
   repository: file://../kubedb-catalog
   condition: kubedb-catalog.enabled
-  version: v2023.04.10
+  version: v2023.06.13-rc.0
 - name: kubedb-provisioner
   repository: file://../kubedb-provisioner
   condition: kubedb-provisioner.enabled
-  version: v0.33.0
+  version: v0.34.0-rc.0
 - name: kubedb-ops-manager
   repository: file://../kubedb-ops-manager
   condition: kubedb-ops-manager.enabled
-  version: v0.20.0
+  version: v0.21.0-rc.0
 - name: kubedb-autoscaler
   repository: file://../kubedb-autoscaler
   condition: kubedb-autoscaler.enabled
-  version: v0.18.0
+  version: v0.19.0-rc.0
 - name: kubedb-dashboard
   repository: file://../kubedb-dashboard
   condition: kubedb-dashboard.enabled
-  version: v0.9.0
+  version: v0.10.0-rc.0
 - name: kubedb-schema-manager
   repository: file://../kubedb-schema-manager
   condition: kubedb-schema-manager.enabled
-  version: v0.9.0
+  version: v0.10.0-rc.0
 - name: kubedb-webhook-server
   repository: file://../kubedb-webhook-server
-  version: v0.9.0
+  version: v0.10.0-rc.0
 - name: kubedb-metrics
   repository: file://../kubedb-metrics
   condition: kubedb-metrics.enabled
-  version: v2023.04.10
+  version: v2023.06.13-rc.0
 - name: stash-enterprise
   repository: https://charts.appscode.com/stable/
-  version: v0.29.0
+  version: v0.30.0
   condition: stash-enterprise.enabled
 - name: stash-catalog
   repository: https://charts.appscode.com/stable/
-  version: v2023.04.30
+  version: v2023.05.31
   condition: stash-catalog.enabled
 - name: stash-metrics
   repository: https://charts.appscode.com/stable/
-  version: v2023.04.30
+  version: v2023.05.31
   condition: stash-metrics.enabled

--- a/charts/kubedb-one/README.md
+++ b/charts/kubedb-one/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-one --version=v2023.04.10
-$ helm upgrade -i kubedb appscode/kubedb-one -n kubedb --create-namespace --version=v2023.04.10
+$ helm search repo appscode/kubedb-one --version=v2023.06.13-rc.0
+$ helm upgrade -i kubedb appscode/kubedb-one -n kubedb --create-namespace --version=v2023.06.13-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB operator on a [Kubernetes](http://kubernetes.io) clu
 To install/upgrade the chart with the release name `kubedb`:
 
 ```bash
-$ helm upgrade -i kubedb appscode/kubedb-one -n kubedb --create-namespace --version=v2023.04.10
+$ helm upgrade -i kubedb appscode/kubedb-one -n kubedb --create-namespace --version=v2023.06.13-rc.0
 ```
 
 The command deploys a KubeDB operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -70,12 +70,12 @@ The following table lists the configurable parameters of the `kubedb-one` chart 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb appscode/kubedb-one -n kubedb --create-namespace --version=v2023.04.10 --set global.registry=kubedb
+$ helm upgrade -i kubedb appscode/kubedb-one -n kubedb --create-namespace --version=v2023.06.13-rc.0 --set global.registry=kubedb
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb appscode/kubedb-one -n kubedb --create-namespace --version=v2023.04.10 --values values.yaml
+$ helm upgrade -i kubedb appscode/kubedb-one -n kubedb --create-namespace --version=v2023.06.13-rc.0 --values values.yaml
 ```

--- a/charts/kubedb-ops-manager/Chart.yaml
+++ b/charts/kubedb-ops-manager/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeDB Ops Manager by AppsCode - Enterprise features for KubeDB
 name: kubedb-ops-manager
-version: v0.20.0
-appVersion: v0.20.2
+version: v0.21.0-rc.0
+appVersion: v0.21.0-rc.0
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-ops-manager-icon.png
 sources:

--- a/charts/kubedb-ops-manager/README.md
+++ b/charts/kubedb-ops-manager/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-ops-manager --version=v0.20.0
-$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.20.0
+$ helm search repo appscode/kubedb-ops-manager --version=v0.21.0-rc.0
+$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.21.0-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Ops Manager operator on a [Kubernetes](http://kubern
 To install/upgrade the chart with the release name `kubedb-ops-manager`:
 
 ```bash
-$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.20.0
+$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.21.0-rc.0
 ```
 
 The command deploys a KubeDB Ops Manager operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -86,12 +86,12 @@ The following table lists the configurable parameters of the `kubedb-ops-manager
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.20.0 --set replicaCount=1
+$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.21.0-rc.0 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.20.0 --values values.yaml
+$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.21.0-rc.0 --values values.yaml
 ```

--- a/charts/kubedb-opscenter/Chart.lock
+++ b/charts/kubedb-opscenter/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kubedb-metrics
   repository: file://../kubedb-metrics
-  version: v2023.04.10
+  version: v2023.06.13-rc.0
 - name: kubedb-ui-server
   repository: file://../kubedb-ui-server
-  version: v0.9.0
+  version: v0.10.0-rc.0
 - name: kubedb-grafana-dashboards
   repository: file://../kubedb-grafana-dashboards
-  version: v2023.04.10
-digest: sha256:1b2d7b0df800ec036c7d40c318ea16e6ccdf6f42123363d6c91e2cf670fbd97a
-generated: "2023-04-07T10:04:48.232757536Z"
+  version: v2023.06.13-rc.0
+digest: sha256:da1810be9706d567274d1ea5a8b257a8d09d95db62e78802374a62843e0e8d68
+generated: "2023-06-13T12:19:24.628592638Z"

--- a/charts/kubedb-opscenter/Chart.yaml
+++ b/charts/kubedb-opscenter/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-opscenter
 description: KubeDB Opscenter by AppsCode
 type: application
-version: v2023.04.10
-appVersion: v2023.04.10
+version: v2023.06.13-rc.0
+appVersion: v2023.06.13-rc.0
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-icon.png
 sources:
@@ -15,12 +15,12 @@ dependencies:
 - name: kubedb-metrics
   repository: file://../kubedb-metrics
   condition: kubedb-metrics.enabled
-  version: v2023.04.10
+  version: v2023.06.13-rc.0
 - name: kubedb-ui-server
   repository: file://../kubedb-ui-server
   condition: kubedb-ui-server.enabled
-  version: v0.9.0
+  version: v0.10.0-rc.0
 - name: kubedb-grafana-dashboards
   repository: file://../kubedb-grafana-dashboards
   condition: kubedb-grafana-dashboards.enabled
-  version: v2023.04.10
+  version: v2023.06.13-rc.0

--- a/charts/kubedb-opscenter/README.md
+++ b/charts/kubedb-opscenter/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-opscenter --version=v2023.04.10
-$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2023.04.10
+$ helm search repo appscode/kubedb-opscenter --version=v2023.06.13-rc.0
+$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2023.06.13-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Opscenter on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `kubedb-opscenter`:
 
 ```bash
-$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2023.04.10
+$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2023.06.13-rc.0
 ```
 
 The command deploys a KubeDB Opscenter on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -61,12 +61,12 @@ The following table lists the configurable parameters of the `kubedb-opscenter` 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2023.04.10 --set global.registryFQDN=ghcr.io
+$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2023.06.13-rc.0 --set global.registryFQDN=ghcr.io
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2023.04.10 --values values.yaml
+$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2023.06.13-rc.0 --values values.yaml
 ```

--- a/charts/kubedb-provisioner/Chart.yaml
+++ b/charts/kubedb-provisioner/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeDB Provisioner by AppsCode - Community features for KubeDB
 name: kubedb-provisioner
-version: v0.33.0
-appVersion: v0.33.1
+version: v0.34.0-rc.0
+appVersion: v0.34.0-rc.0
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-community-icon.png
 sources:

--- a/charts/kubedb-provisioner/README.md
+++ b/charts/kubedb-provisioner/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-provisioner --version=v0.33.0
-$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.33.0
+$ helm search repo appscode/kubedb-provisioner --version=v0.34.0-rc.0
+$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.34.0-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Provisioner operator on a [Kubernetes](http://kubern
 To install/upgrade the chart with the release name `kubedb-provisioner`:
 
 ```bash
-$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.33.0
+$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.34.0-rc.0
 ```
 
 The command deploys a KubeDB Provisioner operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -84,12 +84,12 @@ The following table lists the configurable parameters of the `kubedb-provisioner
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.33.0 --set replicaCount=1
+$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.34.0-rc.0 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.33.0 --values values.yaml
+$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.34.0-rc.0 --values values.yaml
 ```

--- a/charts/kubedb-schema-manager/Chart.yaml
+++ b/charts/kubedb-schema-manager/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 description: KubeDB Schema Manager by AppsCode
 name: kubedb-schema-manager
 type: application
-version: v0.9.0
-appVersion: v0.9.1
+version: v0.10.0-rc.0
+appVersion: v0.10.0-rc.0
 home: https://github.com/kubedb
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-icon.png
 sources:

--- a/charts/kubedb-schema-manager/README.md
+++ b/charts/kubedb-schema-manager/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-schema-manager --version=v0.9.0
-$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.9.0
+$ helm search repo appscode/kubedb-schema-manager --version=v0.10.0-rc.0
+$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.10.0-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB schema manager operator on a [Kubernetes](http://kub
 To install/upgrade the chart with the release name `kubedb-schema-manager`:
 
 ```bash
-$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.9.0
+$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.10.0-rc.0
 ```
 
 The command deploys a KubeDB schema manager operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -82,12 +82,12 @@ The following table lists the configurable parameters of the `kubedb-schema-mana
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.9.0 --set replicaCount=1
+$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.10.0-rc.0 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.9.0 --values values.yaml
+$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.10.0-rc.0 --values values.yaml
 ```

--- a/charts/kubedb-ui-server/Chart.yaml
+++ b/charts/kubedb-ui-server/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-ui-server
 description: A Helm chart for kubedb-ui-server by AppsCode
 type: application
-version: v0.9.0
-appVersion: v0.9.0
+version: v0.10.0-rc.0
+appVersion: v0.10.0-rc.0
 home: https://github.com/kubedb/kubedb-ui-server
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-icon.png
 sources:

--- a/charts/kubedb-ui-server/README.md
+++ b/charts/kubedb-ui-server/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-ui-server --version=v0.9.0
-$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.9.0
+$ helm search repo appscode/kubedb-ui-server --version=v0.10.0-rc.0
+$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.10.0-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB UI Server on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `kubedb-ui-server`:
 
 ```bash
-$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.9.0
+$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.10.0-rc.0
 ```
 
 The command deploys a KubeDB UI Server on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -84,12 +84,12 @@ The following table lists the configurable parameters of the `kubedb-ui-server` 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.9.0 --set replicaCount=1
+$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.10.0-rc.0 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.9.0 --values values.yaml
+$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.10.0-rc.0 --values values.yaml
 ```

--- a/charts/kubedb-webhook-server/Chart.yaml
+++ b/charts/kubedb-webhook-server/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeDB Webhook Server by AppsCode
 name: kubedb-webhook-server
-version: v0.9.0
-appVersion: v0.9.1
+version: v0.10.0-rc.0
+appVersion: v0.10.0-rc.0
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-community-icon.png
 sources:

--- a/charts/kubedb-webhook-server/README.md
+++ b/charts/kubedb-webhook-server/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-webhook-server --version=v0.9.0
-$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.9.0
+$ helm search repo appscode/kubedb-webhook-server --version=v0.10.0-rc.0
+$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.10.0-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Provisioner operator on a [Kubernetes](http://kubern
 To install/upgrade the chart with the release name `kubedb-webhook-server`:
 
 ```bash
-$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.9.0
+$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.10.0-rc.0
 ```
 
 The command deploys a KubeDB Provisioner operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -89,12 +89,12 @@ The following table lists the configurable parameters of the `kubedb-webhook-ser
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.9.0 --set replicaCount=1
+$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.10.0-rc.0 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.9.0 --values values.yaml
+$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.10.0-rc.0 --values values.yaml
 ```

--- a/charts/kubedb/Chart.lock
+++ b/charts/kubedb/Chart.lock
@@ -1,27 +1,27 @@
 dependencies:
 - name: kubedb-catalog
   repository: file://../kubedb-catalog
-  version: v2023.04.10
+  version: v2023.06.13-rc.0
 - name: kubedb-provisioner
   repository: file://../kubedb-provisioner
-  version: v0.33.0
+  version: v0.34.0-rc.0
 - name: kubedb-ops-manager
   repository: file://../kubedb-ops-manager
-  version: v0.20.0
+  version: v0.21.0-rc.0
 - name: kubedb-autoscaler
   repository: file://../kubedb-autoscaler
-  version: v0.18.0
+  version: v0.19.0-rc.0
 - name: kubedb-dashboard
   repository: file://../kubedb-dashboard
-  version: v0.9.0
+  version: v0.10.0-rc.0
 - name: kubedb-schema-manager
   repository: file://../kubedb-schema-manager
-  version: v0.9.0
+  version: v0.10.0-rc.0
 - name: kubedb-webhook-server
   repository: file://../kubedb-webhook-server
-  version: v0.9.0
+  version: v0.10.0-rc.0
 - name: kubedb-metrics
   repository: file://../kubedb-metrics
-  version: v2023.04.10
-digest: sha256:3790407c222a00e6d7bcf2bc206b1a3431310aa05c4e17946f5ae3f50c959e0e
-generated: "2023-04-25T14:42:33.890617+02:00"
+  version: v2023.06.13-rc.0
+digest: sha256:1cf19ca0b79860a9401b70a2cdc362d7951ab29d048e45c0180c632e64fe3f1e
+generated: "2023-06-13T12:19:22.786219483Z"

--- a/charts/kubedb/Chart.yaml
+++ b/charts/kubedb/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb
 description: KubeDB by AppsCode - Production ready databases on Kubernetes
 type: application
-version: v2023.04.10
-appVersion: v2023.04.10
+version: v2023.06.13-rc.0
+appVersion: v2023.06.13-rc.0
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-icon.png
 sources:
@@ -15,31 +15,31 @@ dependencies:
 - name: kubedb-catalog
   repository: file://../kubedb-catalog
   condition: kubedb-catalog.enabled
-  version: v2023.04.10
+  version: v2023.06.13-rc.0
 - name: kubedb-provisioner
   repository: file://../kubedb-provisioner
   condition: kubedb-provisioner.enabled
-  version: v0.33.0
+  version: v0.34.0-rc.0
 - name: kubedb-ops-manager
   repository: file://../kubedb-ops-manager
   condition: kubedb-ops-manager.enabled
-  version: v0.20.0
+  version: v0.21.0-rc.0
 - name: kubedb-autoscaler
   repository: file://../kubedb-autoscaler
   condition: kubedb-autoscaler.enabled
-  version: v0.18.0
+  version: v0.19.0-rc.0
 - name: kubedb-dashboard
   repository: file://../kubedb-dashboard
   condition: kubedb-dashboard.enabled
-  version: v0.9.0
+  version: v0.10.0-rc.0
 - name: kubedb-schema-manager
   repository: file://../kubedb-schema-manager
   condition: kubedb-schema-manager.enabled
-  version: v0.9.0
+  version: v0.10.0-rc.0
 - name: kubedb-webhook-server
   repository: file://../kubedb-webhook-server
-  version: v0.9.0
+  version: v0.10.0-rc.0
 - name: kubedb-metrics
   repository: file://../kubedb-metrics
   condition: kubedb-metrics.enabled
-  version: v2023.04.10
+  version: v2023.06.13-rc.0

--- a/charts/kubedb/README.md
+++ b/charts/kubedb/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb --version=v2023.04.10
-$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2023.04.10
+$ helm search repo appscode/kubedb --version=v2023.06.13-rc.0
+$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2023.06.13-rc.0
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB operator on a [Kubernetes](http://kubernetes.io) clu
 To install/upgrade the chart with the release name `kubedb`:
 
 ```bash
-$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2023.04.10
+$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2023.06.13-rc.0
 ```
 
 The command deploys a KubeDB operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -67,12 +67,12 @@ The following table lists the configurable parameters of the `kubedb` chart and 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2023.04.10 --set global.registry=kubedb
+$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2023.06.13-rc.0 --set global.registry=kubedb
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2023.04.10 --values values.yaml
+$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2023.06.13-rc.0 --values values.yaml
 ```


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2023.06.13-rc.0
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/70
Signed-off-by: 1gtm <1gtm@appscode.com>