### PR TITLE
Prepare for release v2023.12.1-rc.1

### DIFF
--- a/catalog/kubedb/raw/mariadb/deprecated-mariadb-10.4.17.yaml
+++ b/catalog/kubedb/raw/mariadb/deprecated-mariadb-10.4.17.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.4.17
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.1
   db:
     image: mariadb:10.4.17
   deprecated: true

--- a/catalog/kubedb/raw/mariadb/deprecated-mariadb-10.5.8.yaml
+++ b/catalog/kubedb/raw/mariadb/deprecated-mariadb-10.5.8.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.5.8
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.1
   db:
     image: mariadb:10.5.8
   deprecated: true

--- a/catalog/kubedb/raw/mariadb/mariadb-10.10.2.yaml
+++ b/catalog/kubedb/raw/mariadb/mariadb-10.10.2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.10.2
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:10.10.2-jammy
   exporter:

--- a/catalog/kubedb/raw/mariadb/mariadb-10.10.7.yaml
+++ b/catalog/kubedb/raw/mariadb/mariadb-10.10.7.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.10.7
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:10.10.7-jammy
   exporter:

--- a/catalog/kubedb/raw/mariadb/mariadb-10.11.2.yaml
+++ b/catalog/kubedb/raw/mariadb/mariadb-10.11.2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.11.2
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:10.11.2-jammy
   exporter:

--- a/catalog/kubedb/raw/mariadb/mariadb-10.11.6.yaml
+++ b/catalog/kubedb/raw/mariadb/mariadb-10.11.6.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.11.6
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:10.11.6-jammy
   exporter:

--- a/catalog/kubedb/raw/mariadb/mariadb-10.4.31.yaml
+++ b/catalog/kubedb/raw/mariadb/mariadb-10.4.31.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.4.31
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:10.4.31-focal
   exporter:

--- a/catalog/kubedb/raw/mariadb/mariadb-10.4.32.yaml
+++ b/catalog/kubedb/raw/mariadb/mariadb-10.4.32.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.4.32
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:10.4.32-focal
   exporter:

--- a/catalog/kubedb/raw/mariadb/mariadb-10.5.23.yaml
+++ b/catalog/kubedb/raw/mariadb/mariadb-10.5.23.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.5.23
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:10.5.23-focal
   exporter:

--- a/catalog/kubedb/raw/mariadb/mariadb-10.6.16.yaml
+++ b/catalog/kubedb/raw/mariadb/mariadb-10.6.16.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.6.16
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:10.6.16-focal
   exporter:

--- a/catalog/kubedb/raw/mariadb/mariadb-10.6.4.yaml
+++ b/catalog/kubedb/raw/mariadb/mariadb-10.6.4.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.6.4
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:10.6.4-focal
   exporter:

--- a/catalog/kubedb/raw/mariadb/mariadb-11.0.4.yaml
+++ b/catalog/kubedb/raw/mariadb/mariadb-11.0.4.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 11.0.4
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:11.0.4-jammy
   exporter:

--- a/catalog/kubedb/raw/mariadb/mariadb-11.1.3.yaml
+++ b/catalog/kubedb/raw/mariadb/mariadb-11.1.3.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 11.1.3
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.18.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:11.1.3-jammy
   exporter:

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-3.4-official.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-3.4-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: "3.4"
 
 ---
@@ -38,7 +38,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: "3.4"
 
 ---
@@ -60,7 +60,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: "3.4"
 
 ---
@@ -82,5 +82,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: "3.4"

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-3.6-official.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-3.6-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: "3.6"
 
 ---
@@ -38,7 +38,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: "3.6"
 
 ---
@@ -60,7 +60,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: "3.6"
 
 ---
@@ -82,5 +82,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: "3.6"

--- a/catalog/kubedb/raw/mongodb/mongodb-3.4.17-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-3.4.17-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:
@@ -60,5 +60,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 3.4.17

--- a/catalog/kubedb/raw/mongodb/mongodb-3.4.22-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-3.4.22-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:
@@ -60,7 +60,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 3.4.22
 
 ---
@@ -82,7 +82,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 3.4.22
 
 ---
@@ -104,5 +104,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 3.4.22

--- a/catalog/kubedb/raw/mongodb/mongodb-3.6.13-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-3.6.13-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:
@@ -60,7 +60,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 3.6.13
 
 ---
@@ -82,7 +82,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 3.6.13
 
 ---
@@ -104,5 +104,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 3.6.13

--- a/catalog/kubedb/raw/mongodb/mongodb-3.6.18-percona.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-3.6.18-percona.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mongodb/mongodb-3.6.8-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-3.6.8-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:
@@ -60,5 +60,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 3.6.8

--- a/catalog/kubedb/raw/mongodb/mongodb-4.0.10-percona.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-4.0.10-percona.yaml
@@ -15,7 +15,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mongodb/mongodb-4.0.11-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-4.0.11-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:
@@ -60,7 +60,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 4.0.11
 
 ---
@@ -82,7 +82,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 4.0.11
 
 ---
@@ -104,5 +104,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 4.0.11

--- a/catalog/kubedb/raw/mongodb/mongodb-4.0.3-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-4.0.3-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:
@@ -60,5 +60,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 4.0.3

--- a/catalog/kubedb/raw/mongodb/mongodb-4.0.5-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-4.0.5-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:
@@ -60,7 +60,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 4.0.5
 
 ---
@@ -82,7 +82,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 4.0.5
 
 ---
@@ -104,7 +104,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 4.0.5
 
 ---
@@ -126,7 +126,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 4.0.5
 
 ---
@@ -148,5 +148,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 4.0.5

--- a/catalog/kubedb/raw/mongodb/mongodb-4.1.13-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-4.1.13-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:
@@ -60,7 +60,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 4.1.13
 
 ---
@@ -82,7 +82,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 4.1.13
 
 ---
@@ -104,5 +104,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 4.1.13

--- a/catalog/kubedb/raw/mongodb/mongodb-4.1.4-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-4.1.4-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:
@@ -60,5 +60,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 4.1.4

--- a/catalog/kubedb/raw/mongodb/mongodb-4.1.7-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-4.1.7-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:
@@ -60,7 +60,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 4.1.7
 
 ---
@@ -82,7 +82,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 4.1.7
 
 ---
@@ -104,5 +104,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 4.1.7

--- a/catalog/kubedb/raw/mongodb/mongodb-4.2.24-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-4.2.24-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mongodb/mongodb-4.2.3-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-4.2.3-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:
@@ -60,5 +60,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   version: 4.2.3

--- a/catalog/kubedb/raw/mongodb/mongodb-4.2.7-percona.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-4.2.7-percona.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mongodb/mongodb-4.4.10-percona.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-4.4.10-percona.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mongodb/mongodb-4.4.6-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-4.4.6-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mongodb/mongodb-5.0.15-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-5.0.15-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mongodb/mongodb-5.0.2-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-5.0.2-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mongodb/mongodb-5.0.3-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-5.0.3-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mongodb/mongodb-6.0.5-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-6.0.5-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-5-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-5-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -44,7 +44,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-5.7-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-5.7-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -44,7 +44,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.25-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.25-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -42,7 +42,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -68,7 +68,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -94,7 +94,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -120,7 +120,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:
@@ -152,7 +152,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.29-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.29-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -44,7 +44,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -72,7 +72,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:
@@ -106,7 +106,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.31-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.31-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -44,7 +44,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:
@@ -78,7 +78,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.33-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.33-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:
@@ -50,7 +50,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.35-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.35-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:
@@ -38,7 +38,7 @@ metadata:
   name: 5.7.35-v1
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.1
   db:
     image: mysql:5.7.35
   deprecated: true
@@ -52,7 +52,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.36-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.36-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 5.7.36
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.1
   db:
     image: mysql:5.7.36
   deprecated: true
@@ -18,7 +18,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -44,7 +44,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.14-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.14-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -44,7 +44,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -72,7 +72,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -100,7 +100,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:
@@ -134,7 +134,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.17-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.17-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.17
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.1
   db:
     image: mysql:8.0.17
   deprecated: true
@@ -18,7 +18,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.20-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.20-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -44,7 +44,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -72,7 +72,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:
@@ -106,7 +106,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.21-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.21-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -44,7 +44,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:
@@ -78,7 +78,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.23-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.23-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:
@@ -50,7 +50,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.26-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.26-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.27-mysql.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.27-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.27-innodb
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.1
   db:
     image: mysql/mysql-server:8.0.27
   deprecated: true
@@ -18,11 +18,11 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   router:
     image: mysql/mysql-router:8.0.27
   routerInitContainer:
-    image: ghcr.io/kubedb/mysql-router-init:v0.16.0-rc.0
+    image: ghcr.io/kubedb/mysql-router-init:v0.16.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.27-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.27-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.27
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.1
   db:
     image: mysql:8.0.27
   deprecated: true
@@ -18,7 +18,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.29-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.29-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.29
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.1
   db:
     image: mysql:8.0.29
   deprecated: true
@@ -18,7 +18,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.3-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.3-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     allowlist:
       groupReplication:
@@ -44,7 +44,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     allowlist:
       groupReplication:
@@ -72,7 +72,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   updateConstraints:
     allowlist:
       groupReplication:
@@ -100,7 +100,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:
@@ -134,7 +134,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:
@@ -156,7 +156,7 @@ metadata:
   name: 8.0.3-v4
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.1
   db:
     image: mysql:8.0.3
   deprecated: true
@@ -170,7 +170,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/mysql-5.7.41-official.yaml
+++ b/catalog/kubedb/raw/mysql/mysql-5.7.41-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 5.7.41
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.1
   db:
     image: ghcr.io/appscode-images/mysql:5.7.41-oracle
   distribution: Official
@@ -17,7 +17,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mysql/mysql-8.0.31-mysql.yaml
+++ b/catalog/kubedb/raw/mysql/mysql-8.0.31-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.31-innodb
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.1
   db:
     image: ghcr.io/appscode-images/mysql:8.0.31-oracle
   distribution: MySQL
@@ -17,11 +17,11 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   router:
     image: mysql/mysql-router:8.0.31
   routerInitContainer:
-    image: ghcr.io/kubedb/mysql-router-init:v0.16.0-rc.0
+    image: ghcr.io/kubedb/mysql-router-init:v0.16.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mysql/mysql-8.0.31-official.yaml
+++ b/catalog/kubedb/raw/mysql/mysql-8.0.31-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.31
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.1
   db:
     image: ghcr.io/appscode-images/mysql:8.0.31-oracle
   distribution: Official
@@ -17,7 +17,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mysql/mysql-8.0.32-official.yaml
+++ b/catalog/kubedb/raw/mysql/mysql-8.0.32-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.32
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.1
   db:
     image: ghcr.io/appscode-images/mysql:8.0.32-oracle
   distribution: Official
@@ -17,7 +17,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mysql/mysql-8.1.0-official.yaml
+++ b/catalog/kubedb/raw/mysql/mysql-8.1.0-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.1.0
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.16.0-rc.1
   db:
     image: ghcr.io/appscode-images/mysql:8.1.0-oracle
   distribution: Official
@@ -17,7 +17,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.25.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/perconaxtradb/perconaxtradb-8.0.26.yaml
+++ b/catalog/kubedb/raw/perconaxtradb/perconaxtradb-8.0.26.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.26
 spec:
   coordinator:
-    image: ghcr.io/kubedb/percona-xtradb-coordinator:v0.11.0-rc.0
+    image: ghcr.io/kubedb/percona-xtradb-coordinator:v0.11.0-rc.1
   db:
     image: percona/percona-xtradb-cluster:8.0.26
   exporter:

--- a/catalog/kubedb/raw/perconaxtradb/perconaxtradb-8.0.28.yaml
+++ b/catalog/kubedb/raw/perconaxtradb/perconaxtradb-8.0.28.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.28
 spec:
   coordinator:
-    image: ghcr.io/kubedb/percona-xtradb-coordinator:v0.11.0-rc.0
+    image: ghcr.io/kubedb/percona-xtradb-coordinator:v0.11.0-rc.1
   db:
     image: percona/percona-xtradb-cluster:8.0.28
   exporter:

--- a/catalog/kubedb/raw/perconaxtradb/perconaxtradb-8.0.31.yaml
+++ b/catalog/kubedb/raw/perconaxtradb/perconaxtradb-8.0.31.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.31
 spec:
   coordinator:
-    image: ghcr.io/kubedb/percona-xtradb-coordinator:v0.11.0-rc.0
+    image: ghcr.io/kubedb/percona-xtradb-coordinator:v0.11.0-rc.1
   db:
     image: percona/percona-xtradb-cluster:8.0.31
   exporter:

--- a/catalog/kubedb/raw/postgres/postgres-10.16-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-10.16-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.16-debian
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:10.16
@@ -37,7 +37,7 @@ metadata:
   name: "10.16"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:10.16-alpine

--- a/catalog/kubedb/raw/postgres/postgres-10.19-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-10.19-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.19-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:10.19-bullseye
@@ -36,7 +36,7 @@ metadata:
   name: "10.19"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:10.19-bullseye

--- a/catalog/kubedb/raw/postgres/postgres-10.20-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-10.20-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.20-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:10.20-bullseye
@@ -36,7 +36,7 @@ metadata:
   name: "10.20"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:10.20-bullseye

--- a/catalog/kubedb/raw/postgres/postgres-11.11-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-11.11-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_11.22-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:11.11
@@ -60,7 +60,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_11.22-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:11.11-alpine

--- a/catalog/kubedb/raw/postgres/postgres-11.11-timescaledb.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-11.11-timescaledb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: timescaledb-2.1.0-pg11
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     image: timescale/timescaledb:2.1.0-pg11-oss
   distribution: TimescaleDB

--- a/catalog/kubedb/raw/postgres/postgres-11.14-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-11.14-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_11.22-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:11.14-bullseye
@@ -60,7 +60,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_11.22-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:11.14-alpine

--- a/catalog/kubedb/raw/postgres/postgres-11.14-postgis.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-11.14-postgis.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_11.22-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     image: postgis/postgis:11-3.1
   distribution: PostGIS

--- a/catalog/kubedb/raw/postgres/postgres-11.15-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-11.15-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_11.22-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:11.15-bullseye
@@ -60,7 +60,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_11.22-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:11.15-alpine

--- a/catalog/kubedb/raw/postgres/postgres-11.19-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-11.19-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_11.22-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:11.19-bullseye
@@ -60,7 +60,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_11.22-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:11.19-alpine

--- a/catalog/kubedb/raw/postgres/postgres-11.20-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-11.20-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_11.22-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:11.20-bullseye
@@ -60,7 +60,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_11.22-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:11.20-alpine

--- a/catalog/kubedb/raw/postgres/postgres-12.10-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-12.10-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_12.17-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:12.10-bullseye
@@ -61,7 +61,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_12.17-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:12.10-alpine

--- a/catalog/kubedb/raw/postgres/postgres-12.13-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-12.13-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_12.17-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:12.13-bullseye
@@ -61,7 +61,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_12.17-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:12.13-alpine

--- a/catalog/kubedb/raw/postgres/postgres-12.14-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-12.14-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_12.17-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:12.14-bullseye
@@ -61,7 +61,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_12.17-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:12.14-alpine

--- a/catalog/kubedb/raw/postgres/postgres-12.15-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-12.15-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_12.17-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:12.15-bullseye
@@ -61,7 +61,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_12.17-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:12.15-alpine

--- a/catalog/kubedb/raw/postgres/postgres-12.6-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-12.6-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_12.17-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:12.6
@@ -61,7 +61,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_12.17-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:12.6-alpine

--- a/catalog/kubedb/raw/postgres/postgres-12.6-timescaledb.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-12.6-timescaledb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: timescaledb-2.1.0-pg12
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     image: timescale/timescaledb:2.1.0-pg12-oss
   distribution: TimescaleDB

--- a/catalog/kubedb/raw/postgres/postgres-12.9-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-12.9-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_12.17-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:12.9-bullseye
@@ -61,7 +61,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_12.17-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:12.9-alpine

--- a/catalog/kubedb/raw/postgres/postgres-12.9-postgis.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-12.9-postgis.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_12.17-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     image: postgis/postgis:12-3.1
   distribution: PostGIS

--- a/catalog/kubedb/raw/postgres/postgres-13.10-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-13.10-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_13.13-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:13.10-bullseye
@@ -60,7 +60,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_13.13-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:13.10-alpine

--- a/catalog/kubedb/raw/postgres/postgres-13.11-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-13.11-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_13.13-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:13.11-bullseye
@@ -60,7 +60,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_13.13-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:13.11-alpine

--- a/catalog/kubedb/raw/postgres/postgres-13.2-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-13.2-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_13.13-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:13.2
@@ -60,7 +60,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_13.13-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:13.2-alpine

--- a/catalog/kubedb/raw/postgres/postgres-13.2-timescaledb.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-13.2-timescaledb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: timescaledb-2.1.0-pg13
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     image: timescale/timescaledb:2.1.0-pg13-oss
   distribution: TimescaleDB

--- a/catalog/kubedb/raw/postgres/postgres-13.5-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-13.5-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_13.13-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:13.5-bullseye
@@ -60,7 +60,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_13.13-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:13.5-alpine

--- a/catalog/kubedb/raw/postgres/postgres-13.5-postgis.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-13.5-postgis.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_13.13-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     image: postgis/postgis:13-3.1
   distribution: PostGIS

--- a/catalog/kubedb/raw/postgres/postgres-13.6-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-13.6-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_13.13-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:13.6-bullseye
@@ -60,7 +60,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_13.13-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:13.6-alpine

--- a/catalog/kubedb/raw/postgres/postgres-13.9-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-13.9-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_13.13-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:13.9-bullseye
@@ -60,7 +60,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_13.13-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:13.9-alpine

--- a/catalog/kubedb/raw/postgres/postgres-14.1-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-14.1-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_14.10-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:14.1-bullseye
@@ -60,7 +60,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_14.10-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:14.1-alpine

--- a/catalog/kubedb/raw/postgres/postgres-14.1-postgis.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-14.1-postgis.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_14.10-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     image: postgis/postgis:14-3.1
   distribution: PostGIS

--- a/catalog/kubedb/raw/postgres/postgres-14.1-timescaledb.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-14.1-timescaledb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: timescaledb-2.5.0-pg14.1
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     image: timescale/timescaledb:2.5.0-pg14-oss
   distribution: TimescaleDB

--- a/catalog/kubedb/raw/postgres/postgres-14.2-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-14.2-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_14.10-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:14.2-bullseye
@@ -57,7 +57,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_14.10-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:14.2-alpine

--- a/catalog/kubedb/raw/postgres/postgres-14.6-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-14.6-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_14.10-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:14.6-bullseye
@@ -57,7 +57,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_14.10-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:14.6-alpine

--- a/catalog/kubedb/raw/postgres/postgres-14.7-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-14.7-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_14.10-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:14.7-bullseye
@@ -57,7 +57,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_14.10-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:14.7-alpine

--- a/catalog/kubedb/raw/postgres/postgres-14.8-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-14.8-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_14.10-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:14.8-bullseye
@@ -57,7 +57,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_14.10-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:14.8-alpine

--- a/catalog/kubedb/raw/postgres/postgres-15.1-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-15.1-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_15.5-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:15.1-bullseye
@@ -60,7 +60,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_15.5-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:15.1-alpine

--- a/catalog/kubedb/raw/postgres/postgres-15.2-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-15.2-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_15.5-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:15.2-bullseye
@@ -60,7 +60,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_15.5-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:15.2-alpine

--- a/catalog/kubedb/raw/postgres/postgres-15.3-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-15.3-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_15.5-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:15.3-bullseye
@@ -60,7 +60,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_15.5-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:15.3-alpine

--- a/catalog/kubedb/raw/postgres/postgres-16.1-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-16.1-official.yaml
@@ -16,7 +16,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_16.1-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:16.1-bullseye
@@ -60,7 +60,7 @@ spec:
     walg:
       image: ghcr.io/kubedb/postgres-archiver:v0.0.1_16.1-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:16.1-alpine

--- a/catalog/kubedb/raw/postgres/postgres-9.6.21-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-9.6.21-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 9.6.21-debian
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: debian
     image: postgres:9.6.21
@@ -37,7 +37,7 @@ metadata:
   name: 9.6.21
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:9.6.21-alpine

--- a/catalog/kubedb/raw/postgres/postgres-9.6.24-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-9.6.24-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 9.6.24-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:9.6.24-bullseye
@@ -36,7 +36,7 @@ metadata:
   name: 9.6.24
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.22.0-rc.1
   db:
     baseOS: alpine
     image: postgres:9.6.24-alpine

--- a/catalog/kubedb/raw/redis/deprecated-redis-4.0.yaml
+++ b/catalog/kubedb/raw/redis/deprecated-redis-4.0.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "4.0"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:4.0
   deprecated: true
@@ -23,7 +23,7 @@ metadata:
   name: 4.0-v1
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:4.0-v1
   deprecated: true
@@ -42,7 +42,7 @@ metadata:
   name: 4.0-v2
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:4.0-v2
   deprecated: true

--- a/catalog/kubedb/raw/redis/deprecated-redis-4.yaml
+++ b/catalog/kubedb/raw/redis/deprecated-redis-4.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "4"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:4
   deprecated: true
@@ -23,7 +23,7 @@ metadata:
   name: 4-v1
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:4-v1
   deprecated: true

--- a/catalog/kubedb/raw/redis/deprecated-redis-5.0.yaml
+++ b/catalog/kubedb/raw/redis/deprecated-redis-5.0.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "5.0"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:5.0
   deprecated: true
@@ -29,7 +29,7 @@ metadata:
   name: 5.0-v1
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:5.0-v1
   deprecated: true

--- a/catalog/kubedb/raw/redis/redis-4.0.11.yaml
+++ b/catalog/kubedb/raw/redis/redis-4.0.11.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 4.0.11
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:4.0.11
   exporter:

--- a/catalog/kubedb/raw/redis/redis-4.0.6.yaml
+++ b/catalog/kubedb/raw/redis/redis-4.0.6.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 4.0.6-v2
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:4.0.6-v2
   exporter:
@@ -24,7 +24,7 @@ metadata:
   name: 4.0.6
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:4.0.6
   deprecated: true
@@ -43,7 +43,7 @@ metadata:
   name: 4.0.6-v1
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:4.0.6-v1
   deprecated: true

--- a/catalog/kubedb/raw/redis/redis-5.0.14.yaml
+++ b/catalog/kubedb/raw/redis/redis-5.0.14.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 5.0.14
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: redis:5.0.14
   exporter:

--- a/catalog/kubedb/raw/redis/redis-5.0.3.yaml
+++ b/catalog/kubedb/raw/redis/redis-5.0.3.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 5.0.3-v1
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:5.0.3-v1
   exporter:
@@ -30,7 +30,7 @@ metadata:
   name: 5.0.3
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:5.0.3
   deprecated: true

--- a/catalog/kubedb/raw/redis/redis-6.0.18.yaml
+++ b/catalog/kubedb/raw/redis/redis-6.0.18.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 6.0.18
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: redis:6.0.18
   exporter:

--- a/catalog/kubedb/raw/redis/redis-6.0.6.yaml
+++ b/catalog/kubedb/raw/redis/redis-6.0.6.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 6.0.6
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:6.0.6
   exporter:

--- a/catalog/kubedb/raw/redis/redis-6.2.11.yaml
+++ b/catalog/kubedb/raw/redis/redis-6.2.11.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 6.2.11
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: redis:6.2.11
   exporter:

--- a/catalog/kubedb/raw/redis/redis-6.2.14.yaml
+++ b/catalog/kubedb/raw/redis/redis-6.2.14.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 6.2.14
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: redis:6.2.14
   exporter:

--- a/catalog/kubedb/raw/redis/redis-6.2.5.yaml
+++ b/catalog/kubedb/raw/redis/redis-6.2.5.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 6.2.5
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: redis:6.2.5
   exporter:

--- a/catalog/kubedb/raw/redis/redis-6.2.7.yaml
+++ b/catalog/kubedb/raw/redis/redis-6.2.7.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 6.2.7
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: redis:6.2.7
   exporter:

--- a/catalog/kubedb/raw/redis/redis-6.2.8.yaml
+++ b/catalog/kubedb/raw/redis/redis-6.2.8.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 6.2.8
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: redis:6.2.8
   exporter:

--- a/catalog/kubedb/raw/redis/redis-7.0.10.yaml
+++ b/catalog/kubedb/raw/redis/redis-7.0.10.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.0.10
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: redis:7.0.10
   exporter:

--- a/catalog/kubedb/raw/redis/redis-7.0.4.yaml
+++ b/catalog/kubedb/raw/redis/redis-7.0.4.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.0.4
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: redis:7.0.4
   exporter:

--- a/catalog/kubedb/raw/redis/redis-7.0.5.yaml
+++ b/catalog/kubedb/raw/redis/redis-7.0.5.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.0.5
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: redis:7.0.5
   exporter:

--- a/catalog/kubedb/raw/redis/redis-7.0.6.yaml
+++ b/catalog/kubedb/raw/redis/redis-7.0.6.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.0.6
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: redis:7.0.6
   exporter:

--- a/catalog/kubedb/raw/redis/redis-7.0.9.yaml
+++ b/catalog/kubedb/raw/redis/redis-7.0.9.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.0.9
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: redis:7.0.9
   exporter:

--- a/catalog/kubedb/raw/redis/redis-7.2.0.yaml
+++ b/catalog/kubedb/raw/redis/redis-7.2.0.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.2.0
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: redis:7.2.0
   exporter:

--- a/catalog/kubedb/raw/redis/redis-7.2.3.yaml
+++ b/catalog/kubedb/raw/redis/redis-7.2.3.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.2.3
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.17.0-rc.1
   db:
     image: redis:7.2.3
   exporter:

--- a/catalog/kubestash/raw/elasticsearch/elasticsearch-backup-function.yaml
+++ b/catalog/kubestash/raw/elasticsearch/elasticsearch-backup-function.yaml
@@ -12,4 +12,4 @@ spec:
   - --wait-timeout=${waitTimeout:=300}
   - --es-args=${args:=}
   - --interim-data-dir=${interimDataDir:=}
-  image: ghcr.io/kubedb/elasticsearch-restic-plugin:v0.1.0-rc.0
+  image: ghcr.io/kubedb/elasticsearch-restic-plugin:v0.1.0-rc.1

--- a/catalog/kubestash/raw/elasticsearch/elasticsearch-restore-function.yaml
+++ b/catalog/kubestash/raw/elasticsearch/elasticsearch-restore-function.yaml
@@ -13,4 +13,4 @@ spec:
   - --wait-timeout=${waitTimeout:=300}
   - --es-args=${args:=}
   - --interim-data-dir=${interimDataDir:=}
-  image: ghcr.io/kubedb/elasticsearch-restic-plugin:v0.1.0-rc.0
+  image: ghcr.io/kubedb/elasticsearch-restic-plugin:v0.1.0-rc.1

--- a/catalog/kubestash/raw/kubedbmanifest/kubedbmanifest-backup-function.yaml
+++ b/catalog/kubestash/raw/kubedbmanifest/kubedbmanifest-backup-function.yaml
@@ -9,4 +9,4 @@ spec:
   - --backupsession=${backupSession:=}
   - --enable-cache=${enableCache:=}
   - --scratch-dir=${scratchDir:=}
-  image: ghcr.io/kubedb/kubedb-manifest-plugin:v0.1.0-rc.0
+  image: ghcr.io/kubedb/kubedb-manifest-plugin:v0.1.0-rc.1

--- a/catalog/kubestash/raw/kubedbmanifest/kubedbmanifest-restore-function.yaml
+++ b/catalog/kubestash/raw/kubedbmanifest/kubedbmanifest-restore-function.yaml
@@ -10,4 +10,4 @@ spec:
   - --snapshot=${snapshot:=}
   - --enable-cache=${enableCache:=}
   - --scratch-dir=${scratchDir:=}
-  image: ghcr.io/kubedb/kubedb-manifest-plugin:v0.1.0-rc.0
+  image: ghcr.io/kubedb/kubedb-manifest-plugin:v0.1.0-rc.1

--- a/catalog/kubestash/raw/mongodb/mongodb-backup-function.yaml
+++ b/catalog/kubestash/raw/mongodb/mongodb-backup-function.yaml
@@ -14,4 +14,4 @@ spec:
   - --max-concurrency=${maxConcurrency:=3}
   - --authentication-database=${authenticationDatabase:=admin}
   - --db-version=${dbVersion:=}
-  image: ghcr.io/kubedb/mongodb-restic-plugin:v0.1.0-rc.0_${DB_VERSION}
+  image: ghcr.io/kubedb/mongodb-restic-plugin:v0.1.0-rc.1_${DB_VERSION}

--- a/catalog/kubestash/raw/mongodb/mongodb-restore-function.yaml
+++ b/catalog/kubestash/raw/mongodb/mongodb-restore-function.yaml
@@ -15,4 +15,4 @@ spec:
   - --max-concurrency=${maxConcurrency:=3}
   - --authentication-database=${authenticationDatabase:=admin}
   - --db-version=${dbVersion:=}
-  image: ghcr.io/kubedb/mongodb-restic-plugin:v0.1.0-rc.0_${DB_VERSION}
+  image: ghcr.io/kubedb/mongodb-restic-plugin:v0.1.0-rc.1_${DB_VERSION}

--- a/catalog/kubestash/raw/mysql/mysql-backup-function.yaml
+++ b/catalog/kubestash/raw/mysql/mysql-backup-function.yaml
@@ -13,4 +13,4 @@ spec:
   - --mysql-args=${args:=}
   - --db-version=${dbVersion:=}
   - --databases=${databases:=}
-  image: ghcr.io/kubedb/mysql-restic-plugin:v0.1.0-rc.0_${DB_VERSION}
+  image: ghcr.io/kubedb/mysql-restic-plugin:v0.1.0-rc.1_${DB_VERSION}

--- a/catalog/kubestash/raw/mysql/mysql-restore-function.yaml
+++ b/catalog/kubestash/raw/mysql/mysql-restore-function.yaml
@@ -13,4 +13,4 @@ spec:
   - --wait-timeout=${waitTimeout:=300}
   - --mysql-args=${args:=}
   - --db-version=${dbVersion:=}
-  image: ghcr.io/kubedb/mysql-restic-plugin:v0.1.0-rc.0_${DB_VERSION}
+  image: ghcr.io/kubedb/mysql-restic-plugin:v0.1.0-rc.1_${DB_VERSION}

--- a/catalog/kubestash/raw/opensearch/opensearch-backup-function.yaml
+++ b/catalog/kubestash/raw/opensearch/opensearch-backup-function.yaml
@@ -12,4 +12,4 @@ spec:
   - --wait-timeout=${waitTimeout:=300}
   - --os-args=${args:=}
   - --interim-data-dir=${interimDataDir:=}
-  image: ghcr.io/kubedb/elasticsearch-restic-plugin:v0.1.0-rc.0
+  image: ghcr.io/kubedb/elasticsearch-restic-plugin:v0.1.0-rc.1

--- a/catalog/kubestash/raw/opensearch/opensearch-restore-function.yaml
+++ b/catalog/kubestash/raw/opensearch/opensearch-restore-function.yaml
@@ -13,4 +13,4 @@ spec:
   - --wait-timeout=${waitTimeout:=300}
   - --os-args=${args:=}
   - --interim-data-dir=${interimDataDir:=}
-  image: ghcr.io/kubedb/elasticsearch-restic-plugin:v0.1.0-rc.0
+  image: ghcr.io/kubedb/elasticsearch-restic-plugin:v0.1.0-rc.1

--- a/catalog/kubestash/raw/postgres/postgres-backup-function.yaml
+++ b/catalog/kubestash/raw/postgres/postgres-backup-function.yaml
@@ -4,13 +4,13 @@ metadata:
   name: postgres-backup
 spec:
   args:
-    - backup
-    - --namespace=${namespace:=default}
-    - --backupsession=${backupSession:=}
-    - --enable-cache=${enableCache:=}
-    - --scratch-dir=${scratchDir:=}
-    - --wait-timeout=${waitTimeout:=300}
-    - --pg-args=${args:=}
-    - --backup-cmd=${backupCmd:=}
-    - --user=${user:=}
-  image: ghcr.io/kubedb/postgres-restic-plugin:v0.1.0-rc.0
+  - backup
+  - --namespace=${namespace:=default}
+  - --backupsession=${backupSession:=}
+  - --enable-cache=${enableCache:=}
+  - --scratch-dir=${scratchDir:=}
+  - --wait-timeout=${waitTimeout:=300}
+  - --pg-args=${args:=}
+  - --backup-cmd=${backupCmd:=}
+  - --user=${user:=}
+  image: ghcr.io/kubedb/postgres-restic-plugin:v0.1.0-rc.1

--- a/catalog/kubestash/raw/postgres/postgres-csi-snapshotter-function.yaml
+++ b/catalog/kubestash/raw/postgres/postgres-csi-snapshotter-function.yaml
@@ -4,8 +4,8 @@ metadata:
   name: postgres-csisnapshotter
 spec:
   args:
-    - backup
-    - --namespace=${namespace:=default}
-    - --volume-snapshot-class-name=${volumeSnapshotClassName:=}
-    - --backupsession=${backupSession:=}
-  image: ghcr.io/kubedb/postgres-csi-snapshotter-plugin:v0.0.1
+  - backup
+  - --namespace=${namespace:=default}
+  - --volume-snapshot-class-name=${volumeSnapshotClassName:=}
+  - --backupsession=${backupSession:=}
+  image: ghcr.io/kubedb/postgres-csi-snapshotter-plugin:v0.1.0-rc.1

--- a/catalog/kubestash/raw/postgres/postgres-restore-function.yaml
+++ b/catalog/kubestash/raw/postgres/postgres-restore-function.yaml
@@ -4,13 +4,13 @@ metadata:
   name: postgres-restore
 spec:
   args:
-    - restore
-    - --namespace=${namespace:=default}
-    - --restoresession=${restoreSession:=}
-    - --snapshot=${snapshot:=}
-    - --enable-cache=${enableCache:=}
-    - --scratch-dir=${scratchDir:=}
-    - --wait-timeout=${waitTimeout:=300}
-    - --pg-args=${args:=}
-    - --user=${user:=}
-  image: ghcr.io/kubedb/postgres-restic-plugin:v0.1.0-rc.0
+  - restore
+  - --namespace=${namespace:=default}
+  - --restoresession=${restoreSession:=}
+  - --snapshot=${snapshot:=}
+  - --enable-cache=${enableCache:=}
+  - --scratch-dir=${scratchDir:=}
+  - --wait-timeout=${waitTimeout:=300}
+  - --pg-args=${args:=}
+  - --user=${user:=}
+  image: ghcr.io/kubedb/postgres-restic-plugin:v0.1.0-rc.1

--- a/catalog/kubestash/raw/redis/redis-backup-function.yaml
+++ b/catalog/kubestash/raw/redis/redis-backup-function.yaml
@@ -11,4 +11,4 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --wait-timeout=${waitTimeout:=300}
   - --redis-args=${args:=}
-  image: ghcr.io/kubedb/redis-restic-plugin:v0.1.0-rc.0
+  image: ghcr.io/kubedb/redis-restic-plugin:v0.1.0-rc.1

--- a/catalog/kubestash/raw/redis/redis-restore-function.yaml
+++ b/catalog/kubestash/raw/redis/redis-restore-function.yaml
@@ -12,4 +12,4 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --wait-timeout=${waitTimeout:=300}
   - --redis-args=${args:=}
-  image: ghcr.io/kubedb/redis-restic-plugin:v0.1.0-rc.0
+  image: ghcr.io/kubedb/redis-restic-plugin:v0.1.0-rc.1

--- a/charts/kubedb-autoscaler/Chart.yaml
+++ b/charts/kubedb-autoscaler/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeDB Autoscaler by AppsCode - Autoscale KubeDB operated Databases
 name: kubedb-autoscaler
-version: v0.23.0-rc.0
-appVersion: v0.23.0-rc.0
+version: v0.23.0-rc.1
+appVersion: v0.23.0-rc.1
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-autoscaler-icon.png
 sources:

--- a/charts/kubedb-autoscaler/README.md
+++ b/charts/kubedb-autoscaler/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-autoscaler --version=v0.23.0-rc.0
-$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.23.0-rc.0
+$ helm search repo appscode/kubedb-autoscaler --version=v0.23.0-rc.1
+$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.23.0-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Autoscaler operator on a [Kubernetes](http://kuberne
 To install/upgrade the chart with the release name `kubedb-autoscaler`:
 
 ```bash
-$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.23.0-rc.0
+$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.23.0-rc.1
 ```
 
 The command deploys a KubeDB Autoscaler operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -86,12 +86,12 @@ The following table lists the configurable parameters of the `kubedb-autoscaler`
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.23.0-rc.0 --set replicaCount=1
+$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.23.0-rc.1 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.23.0-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.23.0-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-catalog/Chart.yaml
+++ b/charts/kubedb-catalog/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeDB Catalog by AppsCode - Catalog for database versions
 name: kubedb-catalog
-version: v2023.11.29-rc.0
-appVersion: v2023.11.29-rc.0
+version: v2023.12.1-rc.1
+appVersion: v2023.12.1-rc.1
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/icon/kubedb.png
 sources:

--- a/charts/kubedb-catalog/README.md
+++ b/charts/kubedb-catalog/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-catalog --version=v2023.11.29-rc.0
-$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2023.11.29-rc.0
+$ helm search repo appscode/kubedb-catalog --version=v2023.12.1-rc.1
+$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2023.12.1-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys KubeDB catalog on a [Kubernetes](http://kubernetes.io) cluste
 To install/upgrade the chart with the release name `kubedb-catalog`:
 
 ```bash
-$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2023.11.29-rc.0
+$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2023.12.1-rc.1
 ```
 
 The command deploys KubeDB catalog on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -93,12 +93,12 @@ The following table lists the configurable parameters of the `kubedb-catalog` ch
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2023.11.29-rc.0 --set proxies.ghcr=ghcr.io
+$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2023.12.1-rc.1 --set proxies.ghcr=ghcr.io
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2023.11.29-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2023.12.1-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-catalog/templates/mariadb/deprecated-mariadb-10.4.17.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/deprecated-mariadb-10.4.17.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "mariadb") $) }}:10.4.17'
   deprecated: true

--- a/charts/kubedb-catalog/templates/mariadb/deprecated-mariadb-10.5.8.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/deprecated-mariadb-10.5.8.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "mariadb") $) }}:10.5.8'
   deprecated: true

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-10.10.2.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-10.10.2.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:10.10.2-jammy'
   exporter:

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-10.10.7.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-10.10.7.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:10.10.7-jammy'
   exporter:

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-10.11.2.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-10.11.2.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:10.11.2-jammy'
   exporter:

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-10.11.6.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-10.11.6.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:10.11.6-jammy'
   exporter:

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-10.4.31.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-10.4.31.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:10.4.31-focal'
   exporter:

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-10.4.32.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-10.4.32.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:10.4.32-focal'
   exporter:

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-10.5.23.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-10.5.23.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:10.5.23-focal'
   exporter:

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-10.6.16.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-10.6.16.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:10.6.16-focal'
   exporter:

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-10.6.4.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-10.6.4.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:10.6.4-focal'
   exporter:

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-11.0.4.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-11.0.4.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:11.0.4-jammy'
   exporter:

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-11.1.3.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-11.1.3.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.18.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:11.1.3-jammy'
   exporter:

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.4-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.4-official.yaml
@@ -19,7 +19,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: "3.4"
 {{ end }}
 
@@ -45,7 +45,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: "3.4"
 {{ end }}
 
@@ -71,7 +71,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: "3.4"
 {{ end }}
 
@@ -97,6 +97,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: "3.4"
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.6-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.6-official.yaml
@@ -19,7 +19,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: "3.6"
 {{ end }}
 
@@ -45,7 +45,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: "3.6"
 {{ end }}
 
@@ -71,7 +71,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: "3.6"
 {{ end }}
 
@@ -97,6 +97,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: "3.6"
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-3.4.17-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-3.4.17-official.yaml
@@ -30,7 +30,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:
@@ -67,6 +67,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 3.4.17
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-3.4.22-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-3.4.22-official.yaml
@@ -30,7 +30,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:
@@ -67,7 +67,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 3.4.22
 {{ end }}
 
@@ -93,7 +93,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 3.4.22
 {{ end }}
 
@@ -119,6 +119,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 3.4.22
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-3.6.13-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-3.6.13-official.yaml
@@ -30,7 +30,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:
@@ -67,7 +67,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 3.6.13
 {{ end }}
 
@@ -93,7 +93,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 3.6.13
 {{ end }}
 
@@ -119,6 +119,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 3.6.13
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-3.6.18-percona.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-3.6.18-percona.yaml
@@ -30,7 +30,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-3.6.8-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-3.6.8-official.yaml
@@ -30,7 +30,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:
@@ -67,6 +67,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 3.6.8
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.0.10-percona.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.0.10-percona.yaml
@@ -18,7 +18,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.0.11-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.0.11-official.yaml
@@ -30,7 +30,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:
@@ -67,7 +67,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 4.0.11
 {{ end }}
 
@@ -93,7 +93,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 4.0.11
 {{ end }}
 
@@ -119,6 +119,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 4.0.11
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.0.3-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.0.3-official.yaml
@@ -30,7 +30,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:
@@ -67,6 +67,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 4.0.3
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.0.5-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.0.5-official.yaml
@@ -30,7 +30,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:
@@ -67,7 +67,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 4.0.5
 {{ end }}
 
@@ -93,7 +93,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 4.0.5
 {{ end }}
 
@@ -119,7 +119,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 4.0.5
 {{ end }}
 
@@ -145,7 +145,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 4.0.5
 {{ end }}
 
@@ -171,6 +171,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 4.0.5
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.1.13-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.1.13-official.yaml
@@ -30,7 +30,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:
@@ -67,7 +67,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 4.1.13
 {{ end }}
 
@@ -93,7 +93,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 4.1.13
 {{ end }}
 
@@ -119,6 +119,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 4.1.13
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.1.4-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.1.4-official.yaml
@@ -30,7 +30,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:
@@ -67,6 +67,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 4.1.4
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.1.7-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.1.7-official.yaml
@@ -30,7 +30,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:
@@ -67,7 +67,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 4.1.7
 {{ end }}
 
@@ -93,7 +93,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 4.1.7
 {{ end }}
 
@@ -119,6 +119,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 4.1.7
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.2.24-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.2.24-official.yaml
@@ -30,7 +30,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.2.3-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.2.3-official.yaml
@@ -30,7 +30,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:
@@ -67,6 +67,6 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   version: 4.2.3
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.2.7-percona.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.2.7-percona.yaml
@@ -30,7 +30,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.4.10-percona.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.4.10-percona.yaml
@@ -30,7 +30,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.4.6-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.4.6-official.yaml
@@ -30,7 +30,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-5.0.15-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-5.0.15-official.yaml
@@ -30,7 +30,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-5.0.2-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-5.0.2-official.yaml
@@ -30,7 +30,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-5.0.3-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-5.0.3-official.yaml
@@ -30,7 +30,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-6.0.5-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-6.0.5-official.yaml
@@ -30,7 +30,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5-official.yaml
@@ -19,7 +19,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -51,7 +51,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7-official.yaml
@@ -19,7 +19,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -51,7 +51,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.25-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.25-official.yaml
@@ -19,7 +19,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -49,7 +49,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -79,7 +79,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -109,7 +109,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -139,7 +139,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -175,7 +175,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.29-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.29-official.yaml
@@ -19,7 +19,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -51,7 +51,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -83,7 +83,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -121,7 +121,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.31-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.31-official.yaml
@@ -19,7 +19,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -51,7 +51,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -89,7 +89,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.33-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.33-official.yaml
@@ -19,7 +19,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -57,7 +57,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.35-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.35-official.yaml
@@ -19,7 +19,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -45,7 +45,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "mysql") $) }}:5.7.35'
   deprecated: true
@@ -59,7 +59,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.36-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.36-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "mysql") $) }}:5.7.36'
   deprecated: true
@@ -21,7 +21,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8-official.yaml
@@ -19,7 +19,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -51,7 +51,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0-official.yaml
@@ -19,7 +19,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.14-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.14-official.yaml
@@ -19,7 +19,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -51,7 +51,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -83,7 +83,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -115,7 +115,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -153,7 +153,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.17-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.17-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "mysql") $) }}:8.0.17'
   deprecated: true
@@ -21,7 +21,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.20-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.20-official.yaml
@@ -19,7 +19,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -51,7 +51,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -83,7 +83,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -121,7 +121,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.21-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.21-official.yaml
@@ -19,7 +19,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -51,7 +51,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -89,7 +89,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.23-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.23-official.yaml
@@ -19,7 +19,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -57,7 +57,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.26-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.26-official.yaml
@@ -19,7 +19,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.27-mysql.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.27-mysql.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "mysql/mysql-server") $) }}:8.0.27'
   deprecated: true
@@ -21,11 +21,11 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   router:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "mysql/mysql-router") $) }}:8.0.27'
   routerInitContainer:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-router-init") $) }}:v0.16.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-router-init") $) }}:v0.16.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.27-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.27-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "mysql") $) }}:8.0.27'
   deprecated: true
@@ -21,7 +21,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.29-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.29-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "mysql") $) }}:8.0.29'
   deprecated: true
@@ -21,7 +21,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.3-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.3-official.yaml
@@ -19,7 +19,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     allowlist:
       groupReplication:
@@ -51,7 +51,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     allowlist:
       groupReplication:
@@ -83,7 +83,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   updateConstraints:
     allowlist:
       groupReplication:
@@ -115,7 +115,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -153,7 +153,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -179,7 +179,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "mysql") $) }}:8.0.3'
   deprecated: true
@@ -193,7 +193,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.41-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.41-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mysql") $) }}:5.7.41-oracle'
   distribution: Official
@@ -20,7 +20,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.31-mysql.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.31-mysql.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mysql") $) }}:8.0.31-oracle'
   distribution: MySQL
@@ -20,11 +20,11 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   router:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "mysql/mysql-router") $) }}:8.0.31'
   routerInitContainer:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-router-init") $) }}:v0.16.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-router-init") $) }}:v0.16.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.31-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.31-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mysql") $) }}:8.0.31-oracle'
   distribution: Official
@@ -20,7 +20,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.32-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.32-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mysql") $) }}:8.0.32-oracle'
   distribution: Official
@@ -20,7 +20,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.1.0-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.1.0-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.16.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mysql") $) }}:8.1.0-oracle'
   distribution: Official
@@ -20,7 +20,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.25.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/perconaxtradb/perconaxtradb-8.0.26.yaml
+++ b/charts/kubedb-catalog/templates/perconaxtradb/perconaxtradb-8.0.26.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/percona-xtradb-coordinator") $) }}:v0.11.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/percona-xtradb-coordinator") $) }}:v0.11.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "percona/percona-xtradb-cluster") $) }}:8.0.26'
   exporter:

--- a/charts/kubedb-catalog/templates/perconaxtradb/perconaxtradb-8.0.28.yaml
+++ b/charts/kubedb-catalog/templates/perconaxtradb/perconaxtradb-8.0.28.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/percona-xtradb-coordinator") $) }}:v0.11.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/percona-xtradb-coordinator") $) }}:v0.11.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "percona/percona-xtradb-cluster") $) }}:8.0.28'
   exporter:

--- a/charts/kubedb-catalog/templates/perconaxtradb/perconaxtradb-8.0.31.yaml
+++ b/charts/kubedb-catalog/templates/perconaxtradb/perconaxtradb-8.0.31.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/percona-xtradb-coordinator") $) }}:v0.11.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/percona-xtradb-coordinator") $) }}:v0.11.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "percona/percona-xtradb-cluster") $) }}:8.0.31'
   exporter:

--- a/charts/kubedb-catalog/templates/postgres/postgres-10.16-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-10.16-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:10.16'
@@ -44,7 +44,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:10.16-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-10.19-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-10.19-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:10.19-bullseye'
@@ -43,7 +43,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:10.19-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/postgres-10.20-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-10.20-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:10.20-bullseye'
@@ -43,7 +43,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:10.20-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/postgres-11.11-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-11.11-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_11.22-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:11.11'
@@ -67,7 +67,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_11.22-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:11.11-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-11.11-timescaledb.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-11.11-timescaledb.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "timescale/timescaledb") $) }}:2.1.0-pg11-oss'
   distribution: TimescaleDB

--- a/charts/kubedb-catalog/templates/postgres/postgres-11.14-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-11.14-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_11.22-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:11.14-bullseye'
@@ -67,7 +67,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_11.22-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:11.14-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-11.14-postgis.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-11.14-postgis.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_11.22-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "postgis/postgis") $) }}:11-3.1'
   distribution: PostGIS

--- a/charts/kubedb-catalog/templates/postgres/postgres-11.15-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-11.15-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_11.22-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:11.15-bullseye'
@@ -67,7 +67,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_11.22-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:11.15-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-11.19-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-11.19-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_11.22-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:11.19-bullseye'
@@ -67,7 +67,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_11.22-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:11.19-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-11.20-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-11.20-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_11.22-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:11.20-bullseye'
@@ -67,7 +67,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_11.22-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:11.20-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-12.10-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-12.10-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_12.17-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.10-bullseye'
@@ -68,7 +68,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_12.17-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.10-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-12.13-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-12.13-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_12.17-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.13-bullseye'
@@ -68,7 +68,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_12.17-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.13-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-12.14-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-12.14-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_12.17-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.14-bullseye'
@@ -68,7 +68,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_12.17-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.14-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-12.15-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-12.15-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_12.17-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.15-bullseye'
@@ -68,7 +68,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_12.17-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.15-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-12.6-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-12.6-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_12.17-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.6'
@@ -68,7 +68,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_12.17-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.6-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-12.6-timescaledb.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-12.6-timescaledb.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "timescale/timescaledb") $) }}:2.1.0-pg12-oss'
   distribution: TimescaleDB

--- a/charts/kubedb-catalog/templates/postgres/postgres-12.9-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-12.9-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_12.17-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.9-bullseye'
@@ -68,7 +68,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_12.17-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.9-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-12.9-postgis.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-12.9-postgis.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_12.17-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "postgis/postgis") $) }}:12-3.1'
   distribution: PostGIS

--- a/charts/kubedb-catalog/templates/postgres/postgres-13.10-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-13.10-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_13.13-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.10-bullseye'
@@ -67,7 +67,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_13.13-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.10-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-13.11-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-13.11-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_13.13-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.11-bullseye'
@@ -67,7 +67,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_13.13-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.11-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-13.2-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-13.2-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_13.13-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.2'
@@ -67,7 +67,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_13.13-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.2-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-13.2-timescaledb.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-13.2-timescaledb.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "timescale/timescaledb") $) }}:2.1.0-pg13-oss'
   distribution: TimescaleDB

--- a/charts/kubedb-catalog/templates/postgres/postgres-13.5-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-13.5-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_13.13-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.5-bullseye'
@@ -67,7 +67,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_13.13-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.5-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-13.5-postgis.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-13.5-postgis.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_13.13-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "postgis/postgis") $) }}:13-3.1'
   distribution: PostGIS

--- a/charts/kubedb-catalog/templates/postgres/postgres-13.6-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-13.6-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_13.13-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.6-bullseye'
@@ -67,7 +67,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_13.13-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.6-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-13.9-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-13.9-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_13.13-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.9-bullseye'
@@ -67,7 +67,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_13.13-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.9-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-14.1-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-14.1-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_14.10-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:14.1-bullseye'
@@ -67,7 +67,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_14.10-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:14.1-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-14.1-postgis.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-14.1-postgis.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_14.10-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "postgis/postgis") $) }}:14-3.1'
   distribution: PostGIS

--- a/charts/kubedb-catalog/templates/postgres/postgres-14.1-timescaledb.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-14.1-timescaledb.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "timescale/timescaledb") $) }}:2.5.0-pg14-oss'
   distribution: TimescaleDB

--- a/charts/kubedb-catalog/templates/postgres/postgres-14.2-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-14.2-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_14.10-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:14.2-bullseye'
@@ -64,7 +64,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_14.10-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:14.2-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-14.6-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-14.6-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_14.10-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:14.6-bullseye'
@@ -64,7 +64,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_14.10-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:14.6-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-14.7-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-14.7-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_14.10-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:14.7-bullseye'
@@ -64,7 +64,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_14.10-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:14.7-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-14.8-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-14.8-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_14.10-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:14.8-bullseye'
@@ -64,7 +64,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_14.10-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:14.8-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-15.1-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-15.1-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_15.5-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:15.1-bullseye'
@@ -67,7 +67,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_15.5-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:15.1-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-15.2-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-15.2-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_15.5-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:15.2-bullseye'
@@ -67,7 +67,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_15.5-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:15.2-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-15.3-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-15.3-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_15.5-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:15.3-bullseye'
@@ -67,7 +67,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_15.5-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:15.3-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-16.1-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-16.1-official.yaml
@@ -19,7 +19,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_16.1-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:16.1-bullseye'
@@ -67,7 +67,7 @@ spec:
     walg:
       image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.0.1_16.1-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:16.1-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-9.6.21-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-9.6.21-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: debian
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:9.6.21'
@@ -44,7 +44,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:9.6.21-alpine'

--- a/charts/kubedb-catalog/templates/postgres/postgres-9.6.24-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-9.6.24-official.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:9.6.24-bullseye'
@@ -43,7 +43,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.22.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:9.6.24-alpine'

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-4.0.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-4.0.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:4.0'
   deprecated: true
@@ -30,7 +30,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:4.0-v1'
   deprecated: true
@@ -53,7 +53,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:4.0-v2'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-4.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-4.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:4'
   deprecated: true
@@ -30,7 +30,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:4-v1'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-5.0.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-5.0.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:5.0'
   deprecated: true
@@ -36,7 +36,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:5.0-v1'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/redis-4.0.11.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-4.0.11.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:4.0.11'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-4.0.6.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-4.0.6.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:4.0.6-v2'
   exporter:
@@ -31,7 +31,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:4.0.6'
   deprecated: true
@@ -54,7 +54,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:4.0.6-v1'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/redis-5.0.14.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-5.0.14.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:5.0.14'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-5.0.3.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-5.0.3.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:5.0.3-v1'
   exporter:
@@ -37,7 +37,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:5.0.3'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/redis-6.0.18.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-6.0.18.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:6.0.18'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-6.0.6.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-6.0.6.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:6.0.6'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-6.2.11.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-6.2.11.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:6.2.11'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-6.2.14.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-6.2.14.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:6.2.14'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-6.2.5.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-6.2.5.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:6.2.5'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-6.2.7.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-6.2.7.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:6.2.7'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-6.2.8.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-6.2.8.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:6.2.8'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-7.0.10.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-7.0.10.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:7.0.10'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-7.0.4.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-7.0.4.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:7.0.4'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-7.0.5.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-7.0.5.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:7.0.5'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-7.0.6.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-7.0.6.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:7.0.6'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-7.0.9.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-7.0.9.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:7.0.9'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-7.2.0.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-7.2.0.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:7.2.0'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-7.2.3.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-7.2.3.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.17.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:7.2.3'
   exporter:

--- a/charts/kubedb-crds/Chart.yaml
+++ b/charts/kubedb-crds/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-crds
 description: KubeDB Custom Resource Definitions
 type: application
-version: v2023.11.29-rc.0
-appVersion: v2023.11.29-rc.0
+version: v2023.12.1-rc.1
+appVersion: v2023.12.1-rc.1
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-community-icon.png
 sources:

--- a/charts/kubedb-crds/README.md
+++ b/charts/kubedb-crds/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-crds --version=v2023.11.29-rc.0
-$ helm upgrade -i kubedb-crds appscode/kubedb-crds -n kubedb --create-namespace --version=v2023.11.29-rc.0
+$ helm search repo appscode/kubedb-crds --version=v2023.12.1-rc.1
+$ helm upgrade -i kubedb-crds appscode/kubedb-crds -n kubedb --create-namespace --version=v2023.12.1-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys KubeDB crds on a [Kubernetes](http://kubernetes.io) cluster u
 To install/upgrade the chart with the release name `kubedb-crds`:
 
 ```bash
-$ helm upgrade -i kubedb-crds appscode/kubedb-crds -n kubedb --create-namespace --version=v2023.11.29-rc.0
+$ helm upgrade -i kubedb-crds appscode/kubedb-crds -n kubedb --create-namespace --version=v2023.12.1-rc.1
 ```
 
 The command deploys KubeDB crds on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.

--- a/charts/kubedb-dashboard/Chart.yaml
+++ b/charts/kubedb-dashboard/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 description: KubeDB Dashboard by AppsCode
 name: kubedb-dashboard
 type: application
-version: v0.14.0-rc.0
-appVersion: v0.14.0-rc.0
+version: v0.14.0-rc.1
+appVersion: v0.14.0-rc.1
 home: https://github.com/kubedb
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-icon.png
 sources:

--- a/charts/kubedb-dashboard/README.md
+++ b/charts/kubedb-dashboard/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-dashboard --version=v0.14.0-rc.0
-$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.14.0-rc.0
+$ helm search repo appscode/kubedb-dashboard --version=v0.14.0-rc.1
+$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.14.0-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Dashboard operator on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `kubedb-dashboard`:
 
 ```bash
-$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.14.0-rc.0
+$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.14.0-rc.1
 ```
 
 The command deploys a KubeDB Dashboard operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -83,12 +83,12 @@ The following table lists the configurable parameters of the `kubedb-dashboard` 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.14.0-rc.0 --set replicaCount=1
+$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.14.0-rc.1 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.14.0-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.14.0-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-grafana-dashboards/Chart.yaml
+++ b/charts/kubedb-grafana-dashboards/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-grafana-dashboards
 description: A Helm chart for kubedb-grafana-dashboards by AppsCode
 type: application
-version: v2023.11.29-rc.0
-appVersion: v2023.11.29-rc.0
+version: v2023.12.1-rc.1
+appVersion: v2023.12.1-rc.1
 home: https://github.com/kubedb
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-icon.png
 sources:

--- a/charts/kubedb-grafana-dashboards/README.md
+++ b/charts/kubedb-grafana-dashboards/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-grafana-dashboards --version=v2023.11.29-rc.0
-$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2023.11.29-rc.0
+$ helm search repo appscode/kubedb-grafana-dashboards --version=v2023.12.1-rc.1
+$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2023.12.1-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Grafana Dashboards on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `kubedb-grafana-dashboards`:
 
 ```bash
-$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2023.11.29-rc.0
+$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2023.12.1-rc.1
 ```
 
 The command deploys a KubeDB Grafana Dashboards on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -61,12 +61,12 @@ The following table lists the configurable parameters of the `kubedb-grafana-das
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2023.11.29-rc.0 --set resources=["elasticsearch","mariadb","mongodb","mysql","postgres","redis","proxysql"]
+$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2023.12.1-rc.1 --set resources=["elasticsearch","mariadb","mongodb","mysql","postgres","redis","proxysql"]
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2023.11.29-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2023.12.1-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-kubestash-catalog/Chart.yaml
+++ b/charts/kubedb-kubestash-catalog/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-kubestash-catalog
 description: KubeStash Catalog by AppsCode - Catalog of KubeStash Addons
 type: application
-version: v2023.11.29-rc.0
-appVersion: v2023.11.29-rc.0
+version: v2023.12.1-rc.1
+appVersion: v2023.12.1-rc.1
 home: https://kubestash.com
 icon: https://cdn.appscode.com/images/products/stash/stash-community-icon.png
 sources:

--- a/charts/kubedb-kubestash-catalog/README.md
+++ b/charts/kubedb-kubestash-catalog/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-kubestash-catalog --version=v2023.11.29-rc.0
-$ helm upgrade -i kubedb-kubestash-catalog appscode/kubedb-kubestash-catalog -n stash --create-namespace --version=v2023.11.29-rc.0
+$ helm search repo appscode/kubedb-kubestash-catalog --version=v2023.12.1-rc.1
+$ helm upgrade -i kubedb-kubestash-catalog appscode/kubedb-kubestash-catalog -n stash --create-namespace --version=v2023.12.1-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys Stash catalog on a [Kubernetes](http://kubernetes.io) cluster
 To install/upgrade the chart with the release name `kubedb-kubestash-catalog`:
 
 ```bash
-$ helm upgrade -i kubedb-kubestash-catalog appscode/kubedb-kubestash-catalog -n stash --create-namespace --version=v2023.11.29-rc.0
+$ helm upgrade -i kubedb-kubestash-catalog appscode/kubedb-kubestash-catalog -n stash --create-namespace --version=v2023.12.1-rc.1
 ```
 
 The command deploys Stash catalog on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -79,12 +79,12 @@ The following table lists the configurable parameters of the `kubedb-kubestash-c
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-kubestash-catalog appscode/kubedb-kubestash-catalog -n stash --create-namespace --version=v2023.11.29-rc.0 --set proxies.ghcr=ghcr.io
+$ helm upgrade -i kubedb-kubestash-catalog appscode/kubedb-kubestash-catalog -n stash --create-namespace --version=v2023.12.1-rc.1 --set proxies.ghcr=ghcr.io
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-kubestash-catalog appscode/kubedb-kubestash-catalog -n stash --create-namespace --version=v2023.11.29-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-kubestash-catalog appscode/kubedb-kubestash-catalog -n stash --create-namespace --version=v2023.12.1-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-kubestash-catalog/templates/elasticsearch/elasticsearch-backup.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/elasticsearch/elasticsearch-backup.yaml
@@ -15,6 +15,6 @@ spec:
   - --wait-timeout=${waitTimeout:={{ .Values.waitTimeout}}}
   - --es-args=${args:={{ .Values.elasticsearch.args }}}
   - --interim-data-dir=${interimDataDir:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/elasticsearch-restic-plugin") $) }}:v0.1.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/elasticsearch-restic-plugin") $) }}:v0.1.0-rc.1'
 {{ end }}
 

--- a/charts/kubedb-kubestash-catalog/templates/elasticsearch/elasticsearch-restore.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/elasticsearch/elasticsearch-restore.yaml
@@ -16,6 +16,6 @@ spec:
   - --wait-timeout=${waitTimeout:={{ .Values.waitTimeout}}}
   - --es-args=${args:={{ .Values.elasticsearch.args }}}
   - --interim-data-dir=${interimDataDir:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/elasticsearch-restic-plugin") $) }}:v0.1.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/elasticsearch-restic-plugin") $) }}:v0.1.0-rc.1'
 {{ end }}
 

--- a/charts/kubedb-kubestash-catalog/templates/kubedbmanifest/kubedbmanifest-backup.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/kubedbmanifest/kubedbmanifest-backup.yaml
@@ -12,6 +12,6 @@ spec:
   - --backupsession=${backupSession:=}
   - --enable-cache=${enableCache:=}
   - --scratch-dir=${scratchDir:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/kubedb-manifest-plugin") $) }}:v0.1.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/kubedb-manifest-plugin") $) }}:v0.1.0-rc.1'
 {{ end }}
 

--- a/charts/kubedb-kubestash-catalog/templates/kubedbmanifest/kubedbmanifest-restore.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/kubedbmanifest/kubedbmanifest-restore.yaml
@@ -13,6 +13,6 @@ spec:
   - --snapshot=${snapshot:=}
   - --enable-cache=${enableCache:=}
   - --scratch-dir=${scratchDir:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/kubedb-manifest-plugin") $) }}:v0.1.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/kubedb-manifest-plugin") $) }}:v0.1.0-rc.1'
 {{ end }}
 

--- a/charts/kubedb-kubestash-catalog/templates/mongodb/mongodb-backup.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/mongodb/mongodb-backup.yaml
@@ -17,6 +17,6 @@ spec:
   - --max-concurrency=${maxConcurrency:={{ .Values.mongodb.maxConcurrency}}}
   - --authentication-database=${authenticationDatabase:=admin}
   - --db-version=${dbVersion:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mongodb-restic-plugin") $) }}:v0.1.0-rc.0_${DB_VERSION}'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mongodb-restic-plugin") $) }}:v0.1.0-rc.1_${DB_VERSION}'
 {{ end }}
 

--- a/charts/kubedb-kubestash-catalog/templates/mongodb/mongodb-restore.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/mongodb/mongodb-restore.yaml
@@ -18,6 +18,6 @@ spec:
   - --max-concurrency=${maxConcurrency:={{ .Values.mongodb.maxConcurrency}}}
   - --authentication-database=${authenticationDatabase:=admin}
   - --db-version=${dbVersion:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mongodb-restic-plugin") $) }}:v0.1.0-rc.0_${DB_VERSION}'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mongodb-restic-plugin") $) }}:v0.1.0-rc.1_${DB_VERSION}'
 {{ end }}
 

--- a/charts/kubedb-kubestash-catalog/templates/mysql/mysql-backup.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/mysql/mysql-backup.yaml
@@ -16,6 +16,6 @@ spec:
   - --mysql-args=${args:={{ .Values.mysql.args }}}
   - --db-version=${dbVersion:=}
   - --databases=${databases:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-restic-plugin") $) }}:v0.1.0-rc.0_${DB_VERSION}'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-restic-plugin") $) }}:v0.1.0-rc.1_${DB_VERSION}'
 {{ end }}
 

--- a/charts/kubedb-kubestash-catalog/templates/mysql/mysql-restore.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/mysql/mysql-restore.yaml
@@ -16,6 +16,6 @@ spec:
   - --wait-timeout=${waitTimeout:={{ .Values.waitTimeout}}}
   - --mysql-args=${args:={{ .Values.mysql.args }}}
   - --db-version=${dbVersion:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-restic-plugin") $) }}:v0.1.0-rc.0_${DB_VERSION}'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-restic-plugin") $) }}:v0.1.0-rc.1_${DB_VERSION}'
 {{ end }}
 

--- a/charts/kubedb-kubestash-catalog/templates/opensearch/opensearch-backup.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/opensearch/opensearch-backup.yaml
@@ -15,6 +15,6 @@ spec:
   - --wait-timeout=${waitTimeout:={{ .Values.waitTimeout}}}
   - --os-args=${args:={{ .Values.opensearch.args }}}
   - --interim-data-dir=${interimDataDir:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/elasticsearch-restic-plugin") $) }}:v0.1.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/elasticsearch-restic-plugin") $) }}:v0.1.0-rc.1'
 {{ end }}
 

--- a/charts/kubedb-kubestash-catalog/templates/opensearch/opensearch-restore.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/opensearch/opensearch-restore.yaml
@@ -16,6 +16,6 @@ spec:
   - --wait-timeout=${waitTimeout:={{ .Values.waitTimeout}}}
   - --os-args=${args:={{ .Values.opensearch.args }}}
   - --interim-data-dir=${interimDataDir:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/elasticsearch-restic-plugin") $) }}:v0.1.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/elasticsearch-restic-plugin") $) }}:v0.1.0-rc.1'
 {{ end }}
 

--- a/charts/kubedb-kubestash-catalog/templates/postgres/postgres-backup.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/postgres/postgres-backup.yaml
@@ -16,6 +16,6 @@ spec:
   - --pg-args=${args:={{ .Values.postgres.args }}}
   - --backup-cmd=${backupCmd:=}
   - --user=${user:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-restic-plugin") $) }}:v0.1.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-restic-plugin") $) }}:v0.1.0-rc.1'
 {{ end }}
 

--- a/charts/kubedb-kubestash-catalog/templates/postgres/postgres-csisnapshotter.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/postgres/postgres-csisnapshotter.yaml
@@ -11,6 +11,6 @@ spec:
   - --namespace=${namespace:=default}
   - --volume-snapshot-class-name=${volumeSnapshotClassName:=}
   - --backupsession=${backupSession:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-csi-snapshotter-plugin") $) }}:v0.0.1'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-csi-snapshotter-plugin") $) }}:v0.1.0-rc.1'
 {{ end }}
 

--- a/charts/kubedb-kubestash-catalog/templates/postgres/postgres-restore.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/postgres/postgres-restore.yaml
@@ -16,6 +16,6 @@ spec:
   - --wait-timeout=${waitTimeout:={{ .Values.waitTimeout}}}
   - --pg-args=${args:={{ .Values.postgres.args }}}
   - --user=${user:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-restic-plugin") $) }}:v0.1.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-restic-plugin") $) }}:v0.1.0-rc.1'
 {{ end }}
 

--- a/charts/kubedb-kubestash-catalog/templates/redis/redis-backup.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/redis/redis-backup.yaml
@@ -14,6 +14,6 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --wait-timeout=${waitTimeout:={{ .Values.waitTimeout}}}
   - --redis-args=${args:={{ .Values.redis.args }}}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-restic-plugin") $) }}:v0.1.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-restic-plugin") $) }}:v0.1.0-rc.1'
 {{ end }}
 

--- a/charts/kubedb-kubestash-catalog/templates/redis/redis-restore.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/redis/redis-restore.yaml
@@ -15,6 +15,6 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --wait-timeout=${waitTimeout:={{ .Values.waitTimeout}}}
   - --redis-args=${args:={{ .Values.redis.args }}}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-restic-plugin") $) }}:v0.1.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-restic-plugin") $) }}:v0.1.0-rc.1'
 {{ end }}
 

--- a/charts/kubedb-metrics/Chart.yaml
+++ b/charts/kubedb-metrics/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-metrics
 description: KubeDB State Metrics
 type: application
-version: v2023.11.29-rc.0
-appVersion: v2023.11.29-rc.0
+version: v2023.12.1-rc.1
+appVersion: v2023.12.1-rc.1
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-community-icon.png
 sources:

--- a/charts/kubedb-metrics/README.md
+++ b/charts/kubedb-metrics/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-metrics --version=v2023.11.29-rc.0
-$ helm upgrade -i kubedb-metrics appscode/kubedb-metrics -n kubedb --create-namespace --version=v2023.11.29-rc.0
+$ helm search repo appscode/kubedb-metrics --version=v2023.12.1-rc.1
+$ helm upgrade -i kubedb-metrics appscode/kubedb-metrics -n kubedb --create-namespace --version=v2023.12.1-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys KubeDB metrics configurations on a [Kubernetes](http://kubern
 To install/upgrade the chart with the release name `kubedb-metrics`:
 
 ```bash
-$ helm upgrade -i kubedb-metrics appscode/kubedb-metrics -n kubedb --create-namespace --version=v2023.11.29-rc.0
+$ helm upgrade -i kubedb-metrics appscode/kubedb-metrics -n kubedb --create-namespace --version=v2023.12.1-rc.1
 ```
 
 The command deploys KubeDB metrics configurations on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.

--- a/charts/kubedb-one/Chart.lock
+++ b/charts/kubedb-one/Chart.lock
@@ -1,28 +1,28 @@
 dependencies:
 - name: kubedb-catalog
   repository: file://../kubedb-catalog
-  version: v2023.11.29-rc.0
+  version: v2023.12.1-rc.1
 - name: kubedb-provisioner
   repository: file://../kubedb-provisioner
-  version: v0.38.0-rc.0
+  version: v0.38.0-rc.1
 - name: kubedb-ops-manager
   repository: file://../kubedb-ops-manager
-  version: v0.25.0-rc.0
+  version: v0.25.0-rc.1
 - name: kubedb-autoscaler
   repository: file://../kubedb-autoscaler
-  version: v0.23.0-rc.0
+  version: v0.23.0-rc.1
 - name: kubedb-dashboard
   repository: file://../kubedb-dashboard
-  version: v0.14.0-rc.0
+  version: v0.14.0-rc.1
 - name: kubedb-schema-manager
   repository: file://../kubedb-schema-manager
-  version: v0.14.0-rc.0
+  version: v0.14.0-rc.1
 - name: kubedb-webhook-server
   repository: file://../kubedb-webhook-server
-  version: v0.14.0-rc.0
+  version: v0.14.0-rc.1
 - name: kubedb-metrics
   repository: file://../kubedb-metrics
-  version: v2023.11.29-rc.0
+  version: v2023.12.1-rc.1
 - name: stash-enterprise
   repository: https://charts.appscode.com/stable/
   version: v0.32.0
@@ -32,5 +32,5 @@ dependencies:
 - name: stash-metrics
   repository: https://charts.appscode.com/stable/
   version: v2023.10.9
-digest: sha256:d962dfa49708bb186eea3411151bc4bfb7bc6abfb438c8b427c159b061951f27
-generated: "2023-11-30T05:51:40.888125702Z"
+digest: sha256:9d971913188def4872fa8184fd3c2ef114b105ee1b1eb89bfecd64d921215e9c
+generated: "2023-12-01T13:32:33.799306574Z"

--- a/charts/kubedb-one/Chart.yaml
+++ b/charts/kubedb-one/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-one
 description: KubeDB and Stash by AppsCode - Production ready databases on Kubernetes
 type: application
-version: v2023.11.29-rc.0
-appVersion: v2023.11.29-rc.0
+version: v2023.12.1-rc.1
+appVersion: v2023.12.1-rc.1
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-icon.png
 sources:
@@ -15,35 +15,35 @@ dependencies:
 - name: kubedb-catalog
   repository: file://../kubedb-catalog
   condition: kubedb-catalog.enabled
-  version: v2023.11.29-rc.0
+  version: v2023.12.1-rc.1
 - name: kubedb-provisioner
   repository: file://../kubedb-provisioner
   condition: kubedb-provisioner.enabled
-  version: v0.38.0-rc.0
+  version: v0.38.0-rc.1
 - name: kubedb-ops-manager
   repository: file://../kubedb-ops-manager
   condition: kubedb-ops-manager.enabled
-  version: v0.25.0-rc.0
+  version: v0.25.0-rc.1
 - name: kubedb-autoscaler
   repository: file://../kubedb-autoscaler
   condition: kubedb-autoscaler.enabled
-  version: v0.23.0-rc.0
+  version: v0.23.0-rc.1
 - name: kubedb-dashboard
   repository: file://../kubedb-dashboard
   condition: kubedb-dashboard.enabled
-  version: v0.14.0-rc.0
+  version: v0.14.0-rc.1
 - name: kubedb-schema-manager
   repository: file://../kubedb-schema-manager
   condition: kubedb-schema-manager.enabled
-  version: v0.14.0-rc.0
+  version: v0.14.0-rc.1
 - name: kubedb-webhook-server
   repository: file://../kubedb-webhook-server
   condition: kubedb-webhook-server.enabled
-  version: v0.14.0-rc.0
+  version: v0.14.0-rc.1
 - name: kubedb-metrics
   repository: file://../kubedb-metrics
   condition: kubedb-metrics.enabled
-  version: v2023.11.29-rc.0
+  version: v2023.12.1-rc.1
 - name: stash-enterprise
   repository: https://charts.appscode.com/stable/
   version: v0.32.0

--- a/charts/kubedb-one/README.md
+++ b/charts/kubedb-one/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-one --version=v2023.11.29-rc.0
-$ helm upgrade -i kubedb appscode/kubedb-one -n kubedb --create-namespace --version=v2023.11.29-rc.0
+$ helm search repo appscode/kubedb-one --version=v2023.12.1-rc.1
+$ helm upgrade -i kubedb appscode/kubedb-one -n kubedb --create-namespace --version=v2023.12.1-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB operator on a [Kubernetes](http://kubernetes.io) clu
 To install/upgrade the chart with the release name `kubedb`:
 
 ```bash
-$ helm upgrade -i kubedb appscode/kubedb-one -n kubedb --create-namespace --version=v2023.11.29-rc.0
+$ helm upgrade -i kubedb appscode/kubedb-one -n kubedb --create-namespace --version=v2023.12.1-rc.1
 ```
 
 The command deploys a KubeDB operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -71,12 +71,12 @@ The following table lists the configurable parameters of the `kubedb-one` chart 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb appscode/kubedb-one -n kubedb --create-namespace --version=v2023.11.29-rc.0 --set global.registry=kubedb
+$ helm upgrade -i kubedb appscode/kubedb-one -n kubedb --create-namespace --version=v2023.12.1-rc.1 --set global.registry=kubedb
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb appscode/kubedb-one -n kubedb --create-namespace --version=v2023.11.29-rc.0 --values values.yaml
+$ helm upgrade -i kubedb appscode/kubedb-one -n kubedb --create-namespace --version=v2023.12.1-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-ops-manager/Chart.yaml
+++ b/charts/kubedb-ops-manager/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeDB Ops Manager by AppsCode - Enterprise features for KubeDB
 name: kubedb-ops-manager
-version: v0.25.0-rc.0
-appVersion: v0.25.0-rc.0
+version: v0.25.0-rc.1
+appVersion: v0.25.0-rc.1
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-ops-manager-icon.png
 sources:

--- a/charts/kubedb-ops-manager/README.md
+++ b/charts/kubedb-ops-manager/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-ops-manager --version=v0.25.0-rc.0
-$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.25.0-rc.0
+$ helm search repo appscode/kubedb-ops-manager --version=v0.25.0-rc.1
+$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.25.0-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Ops Manager operator on a [Kubernetes](http://kubern
 To install/upgrade the chart with the release name `kubedb-ops-manager`:
 
 ```bash
-$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.25.0-rc.0
+$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.25.0-rc.1
 ```
 
 The command deploys a KubeDB Ops Manager operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -88,12 +88,12 @@ The following table lists the configurable parameters of the `kubedb-ops-manager
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.25.0-rc.0 --set replicaCount=1
+$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.25.0-rc.1 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.25.0-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.25.0-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-opscenter/Chart.lock
+++ b/charts/kubedb-opscenter/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kubedb-metrics
   repository: file://../kubedb-metrics
-  version: v2023.11.29-rc.0
+  version: v2023.12.1-rc.1
 - name: kubedb-ui-server
   repository: file://../kubedb-ui-server
-  version: v0.14.0-rc.0
+  version: v0.14.0-rc.1
 - name: kubedb-grafana-dashboards
   repository: file://../kubedb-grafana-dashboards
-  version: v2023.11.29-rc.0
-digest: sha256:ea04b53479ba4a7bdae1a0153780ba7f5ee49615aa99edc83c7e44ee2b775c82
-generated: "2023-11-30T05:51:41.721743033Z"
+  version: v2023.12.1-rc.1
+digest: sha256:78dbb684d3c6d3a5a28921979334bf592991406a3f9d2136699d99a838760e89
+generated: "2023-12-01T13:32:34.916980724Z"

--- a/charts/kubedb-opscenter/Chart.yaml
+++ b/charts/kubedb-opscenter/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-opscenter
 description: KubeDB Opscenter by AppsCode
 type: application
-version: v2023.11.29-rc.0
-appVersion: v2023.11.29-rc.0
+version: v2023.12.1-rc.1
+appVersion: v2023.12.1-rc.1
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-icon.png
 sources:
@@ -15,12 +15,12 @@ dependencies:
 - name: kubedb-metrics
   repository: file://../kubedb-metrics
   condition: kubedb-metrics.enabled
-  version: v2023.11.29-rc.0
+  version: v2023.12.1-rc.1
 - name: kubedb-ui-server
   repository: file://../kubedb-ui-server
   condition: kubedb-ui-server.enabled
-  version: v0.14.0-rc.0
+  version: v0.14.0-rc.1
 - name: kubedb-grafana-dashboards
   repository: file://../kubedb-grafana-dashboards
   condition: kubedb-grafana-dashboards.enabled
-  version: v2023.11.29-rc.0
+  version: v2023.12.1-rc.1

--- a/charts/kubedb-opscenter/README.md
+++ b/charts/kubedb-opscenter/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-opscenter --version=v2023.11.29-rc.0
-$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2023.11.29-rc.0
+$ helm search repo appscode/kubedb-opscenter --version=v2023.12.1-rc.1
+$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2023.12.1-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Opscenter on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `kubedb-opscenter`:
 
 ```bash
-$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2023.11.29-rc.0
+$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2023.12.1-rc.1
 ```
 
 The command deploys a KubeDB Opscenter on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -62,12 +62,12 @@ The following table lists the configurable parameters of the `kubedb-opscenter` 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2023.11.29-rc.0 --set global.registryFQDN=ghcr.io
+$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2023.12.1-rc.1 --set global.registryFQDN=ghcr.io
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2023.11.29-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2023.12.1-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-provisioner/Chart.yaml
+++ b/charts/kubedb-provisioner/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeDB Provisioner by AppsCode - Community features for KubeDB
 name: kubedb-provisioner
-version: v0.38.0-rc.0
-appVersion: v0.38.0-rc.0
+version: v0.38.0-rc.1
+appVersion: v0.38.0-rc.1
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-community-icon.png
 sources:

--- a/charts/kubedb-provisioner/README.md
+++ b/charts/kubedb-provisioner/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-provisioner --version=v0.38.0-rc.0
-$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.38.0-rc.0
+$ helm search repo appscode/kubedb-provisioner --version=v0.38.0-rc.1
+$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.38.0-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Provisioner operator on a [Kubernetes](http://kubern
 To install/upgrade the chart with the release name `kubedb-provisioner`:
 
 ```bash
-$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.38.0-rc.0
+$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.38.0-rc.1
 ```
 
 The command deploys a KubeDB Provisioner operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -87,12 +87,12 @@ The following table lists the configurable parameters of the `kubedb-provisioner
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.38.0-rc.0 --set replicaCount=1
+$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.38.0-rc.1 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.38.0-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.38.0-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-schema-manager/Chart.yaml
+++ b/charts/kubedb-schema-manager/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 description: KubeDB Schema Manager by AppsCode
 name: kubedb-schema-manager
 type: application
-version: v0.14.0-rc.0
-appVersion: v0.14.0-rc.0
+version: v0.14.0-rc.1
+appVersion: v0.14.0-rc.1
 home: https://github.com/kubedb
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-icon.png
 sources:

--- a/charts/kubedb-schema-manager/README.md
+++ b/charts/kubedb-schema-manager/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-schema-manager --version=v0.14.0-rc.0
-$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.14.0-rc.0
+$ helm search repo appscode/kubedb-schema-manager --version=v0.14.0-rc.1
+$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.14.0-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB schema manager operator on a [Kubernetes](http://kub
 To install/upgrade the chart with the release name `kubedb-schema-manager`:
 
 ```bash
-$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.14.0-rc.0
+$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.14.0-rc.1
 ```
 
 The command deploys a KubeDB schema manager operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -83,12 +83,12 @@ The following table lists the configurable parameters of the `kubedb-schema-mana
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.14.0-rc.0 --set replicaCount=1
+$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.14.0-rc.1 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.14.0-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.14.0-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-ui-server/Chart.yaml
+++ b/charts/kubedb-ui-server/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-ui-server
 description: A Helm chart for kubedb-ui-server by AppsCode
 type: application
-version: v0.14.0-rc.0
-appVersion: v0.14.0-rc.0
+version: v0.14.0-rc.1
+appVersion: v0.14.0-rc.1
 home: https://github.com/kubedb/kubedb-ui-server
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-icon.png
 sources:

--- a/charts/kubedb-ui-server/README.md
+++ b/charts/kubedb-ui-server/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-ui-server --version=v0.14.0-rc.0
-$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.14.0-rc.0
+$ helm search repo appscode/kubedb-ui-server --version=v0.14.0-rc.1
+$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.14.0-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB UI Server on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `kubedb-ui-server`:
 
 ```bash
-$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.14.0-rc.0
+$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.14.0-rc.1
 ```
 
 The command deploys a KubeDB UI Server on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -84,12 +84,12 @@ The following table lists the configurable parameters of the `kubedb-ui-server` 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.14.0-rc.0 --set replicaCount=1
+$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.14.0-rc.1 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.14.0-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.14.0-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-webhook-server/Chart.yaml
+++ b/charts/kubedb-webhook-server/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeDB Webhook Server by AppsCode
 name: kubedb-webhook-server
-version: v0.14.0-rc.0
-appVersion: v0.14.0-rc.0
+version: v0.14.0-rc.1
+appVersion: v0.14.0-rc.1
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-community-icon.png
 sources:

--- a/charts/kubedb-webhook-server/README.md
+++ b/charts/kubedb-webhook-server/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-webhook-server --version=v0.14.0-rc.0
-$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.14.0-rc.0
+$ helm search repo appscode/kubedb-webhook-server --version=v0.14.0-rc.1
+$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.14.0-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Provisioner operator on a [Kubernetes](http://kubern
 To install/upgrade the chart with the release name `kubedb-webhook-server`:
 
 ```bash
-$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.14.0-rc.0
+$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.14.0-rc.1
 ```
 
 The command deploys a KubeDB Provisioner operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -92,12 +92,12 @@ The following table lists the configurable parameters of the `kubedb-webhook-ser
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.14.0-rc.0 --set replicaCount=1
+$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.14.0-rc.1 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.14.0-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.14.0-rc.1 --values values.yaml
 ```

--- a/charts/kubedb/Chart.lock
+++ b/charts/kubedb/Chart.lock
@@ -1,30 +1,30 @@
 dependencies:
 - name: kubedb-catalog
   repository: file://../kubedb-catalog
-  version: v2023.11.29-rc.0
+  version: v2023.12.1-rc.1
 - name: kubedb-kubestash-catalog
   repository: file://../kubedb-kubestash-catalog
-  version: v2023.11.29-rc.0
+  version: v2023.12.1-rc.1
 - name: kubedb-provisioner
   repository: file://../kubedb-provisioner
-  version: v0.38.0-rc.0
+  version: v0.38.0-rc.1
 - name: kubedb-ops-manager
   repository: file://../kubedb-ops-manager
-  version: v0.25.0-rc.0
+  version: v0.25.0-rc.1
 - name: kubedb-autoscaler
   repository: file://../kubedb-autoscaler
-  version: v0.23.0-rc.0
+  version: v0.23.0-rc.1
 - name: kubedb-dashboard
   repository: file://../kubedb-dashboard
-  version: v0.14.0-rc.0
+  version: v0.14.0-rc.1
 - name: kubedb-schema-manager
   repository: file://../kubedb-schema-manager
-  version: v0.14.0-rc.0
+  version: v0.14.0-rc.1
 - name: kubedb-webhook-server
   repository: file://../kubedb-webhook-server
-  version: v0.14.0-rc.0
+  version: v0.14.0-rc.1
 - name: kubedb-metrics
   repository: file://../kubedb-metrics
-  version: v2023.11.29-rc.0
-digest: sha256:301eb8a721db641b9f97a033b2b24af0297e3ddc1ec217960c717197f29d8d29
-generated: "2023-11-30T05:51:40.287120987Z"
+  version: v2023.12.1-rc.1
+digest: sha256:d8431b1585a5c836309e090185e2fd652027db99145ad8612ca630624f6b94d9
+generated: "2023-12-01T13:32:33.117148993Z"

--- a/charts/kubedb/Chart.yaml
+++ b/charts/kubedb/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb
 description: KubeDB by AppsCode - Production ready databases on Kubernetes
 type: application
-version: v2023.11.29-rc.0
-appVersion: v2023.11.29-rc.0
+version: v2023.12.1-rc.1
+appVersion: v2023.12.1-rc.1
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-icon.png
 sources:
@@ -15,36 +15,36 @@ dependencies:
 - name: kubedb-catalog
   repository: file://../kubedb-catalog
   condition: kubedb-catalog.enabled
-  version: v2023.11.29-rc.0
+  version: v2023.12.1-rc.1
 - name: kubedb-kubestash-catalog
   repository: file://../kubedb-kubestash-catalog
   condition: kubedb-kubestash-catalog.enabled
-  version: v2023.11.29-rc.0
+  version: v2023.12.1-rc.1
 - name: kubedb-provisioner
   repository: file://../kubedb-provisioner
   condition: kubedb-provisioner.enabled
-  version: v0.38.0-rc.0
+  version: v0.38.0-rc.1
 - name: kubedb-ops-manager
   repository: file://../kubedb-ops-manager
   condition: kubedb-ops-manager.enabled
-  version: v0.25.0-rc.0
+  version: v0.25.0-rc.1
 - name: kubedb-autoscaler
   repository: file://../kubedb-autoscaler
   condition: kubedb-autoscaler.enabled
-  version: v0.23.0-rc.0
+  version: v0.23.0-rc.1
 - name: kubedb-dashboard
   repository: file://../kubedb-dashboard
   condition: kubedb-dashboard.enabled
-  version: v0.14.0-rc.0
+  version: v0.14.0-rc.1
 - name: kubedb-schema-manager
   repository: file://../kubedb-schema-manager
   condition: kubedb-schema-manager.enabled
-  version: v0.14.0-rc.0
+  version: v0.14.0-rc.1
 - name: kubedb-webhook-server
   repository: file://../kubedb-webhook-server
   condition: kubedb-webhook-server.enabled
-  version: v0.14.0-rc.0
+  version: v0.14.0-rc.1
 - name: kubedb-metrics
   repository: file://../kubedb-metrics
   condition: kubedb-metrics.enabled
-  version: v2023.11.29-rc.0
+  version: v2023.12.1-rc.1

--- a/charts/kubedb/README.md
+++ b/charts/kubedb/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb --version=v2023.11.29-rc.0
-$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2023.11.29-rc.0
+$ helm search repo appscode/kubedb --version=v2023.12.1-rc.1
+$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2023.12.1-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB operator on a [Kubernetes](http://kubernetes.io) clu
 To install/upgrade the chart with the release name `kubedb`:
 
 ```bash
-$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2023.11.29-rc.0
+$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2023.12.1-rc.1
 ```
 
 The command deploys a KubeDB operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -69,12 +69,12 @@ The following table lists the configurable parameters of the `kubedb` chart and 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2023.11.29-rc.0 --set global.registry=kubedb
+$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2023.12.1-rc.1 --set global.registry=kubedb
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2023.11.29-rc.0 --values values.yaml
+$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2023.12.1-rc.1 --values values.yaml
 ```

--- a/charts/prepare-cluster/Chart.yaml
+++ b/charts/prepare-cluster/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: prepare-cluster
 description: Prepare Kubernetes Cluster by AppsCode
 type: application
-version: v2023.11.29-rc.0
-appVersion: v2023.11.29-rc.0
+version: v2023.12.1-rc.1
+appVersion: v2023.12.1-rc.1
 home: https://appscode.com
 icon: https://cdn.appscode.com/images/products/appscode/appscode-512x512.png
 sources:

--- a/charts/prepare-cluster/README.md
+++ b/charts/prepare-cluster/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/prepare-cluster --version=v2023.11.29-rc.0
-$ helm upgrade -i prepare-cluster appscode/prepare-cluster -n kube-system --create-namespace --version=v2023.11.29-rc.0
+$ helm search repo appscode/prepare-cluster --version=v2023.12.1-rc.1
+$ helm upgrade -i prepare-cluster appscode/prepare-cluster -n kube-system --create-namespace --version=v2023.12.1-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Kubernetes Job on a [Kubernetes](http://kubernetes.io) clus
 To install/upgrade the chart with the release name `prepare-cluster`:
 
 ```bash
-$ helm upgrade -i prepare-cluster appscode/prepare-cluster -n kube-system --create-namespace --version=v2023.11.29-rc.0
+$ helm upgrade -i prepare-cluster appscode/prepare-cluster -n kube-system --create-namespace --version=v2023.12.1-rc.1
 ```
 
 The command deploys a Kubernetes Job on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -75,12 +75,12 @@ The following table lists the configurable parameters of the `prepare-cluster` c
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i prepare-cluster appscode/prepare-cluster -n kube-system --create-namespace --version=v2023.11.29-rc.0 --set preparer.repository=tianon/toybox
+$ helm upgrade -i prepare-cluster appscode/prepare-cluster -n kube-system --create-namespace --version=v2023.12.1-rc.1 --set preparer.repository=tianon/toybox
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i prepare-cluster appscode/prepare-cluster -n kube-system --create-namespace --version=v2023.11.29-rc.0 --values values.yaml
+$ helm upgrade -i prepare-cluster appscode/prepare-cluster -n kube-system --create-namespace --version=v2023.12.1-rc.1 --values values.yaml
 ```


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2023.12.1-rc.1
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/76
Signed-off-by: 1gtm <1gtm@appscode.com>