### PR TITLE
Prepare for release v2024.1.28-rc.1

### DIFF
--- a/catalog/kubedb/raw/mariadb/deprecated-mariadb-10.10.2.yaml
+++ b/catalog/kubedb/raw/mariadb/deprecated-mariadb-10.10.2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.10.2
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:10.10.2-jammy
   deprecated: true

--- a/catalog/kubedb/raw/mariadb/deprecated-mariadb-10.11.2.yaml
+++ b/catalog/kubedb/raw/mariadb/deprecated-mariadb-10.11.2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.11.2
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:10.11.2-jammy
   deprecated: true

--- a/catalog/kubedb/raw/mariadb/deprecated-mariadb-10.4.17.yaml
+++ b/catalog/kubedb/raw/mariadb/deprecated-mariadb-10.4.17.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.4.17
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.1
   db:
     image: mariadb:10.4.17
   deprecated: true

--- a/catalog/kubedb/raw/mariadb/deprecated-mariadb-10.4.31.yaml
+++ b/catalog/kubedb/raw/mariadb/deprecated-mariadb-10.4.31.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.4.31
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:10.4.31-focal
   deprecated: true

--- a/catalog/kubedb/raw/mariadb/deprecated-mariadb-10.5.8.yaml
+++ b/catalog/kubedb/raw/mariadb/deprecated-mariadb-10.5.8.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.5.8
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.1
   db:
     image: mariadb:10.5.8
   deprecated: true

--- a/catalog/kubedb/raw/mariadb/deprecated-mariadb-10.6.4.yaml
+++ b/catalog/kubedb/raw/mariadb/deprecated-mariadb-10.6.4.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.6.4
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:10.6.4-focal
   deprecated: true

--- a/catalog/kubedb/raw/mariadb/mariadb-10.10.7.yaml
+++ b/catalog/kubedb/raw/mariadb/mariadb-10.10.7.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.10.7
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:10.10.7-jammy
   exporter:

--- a/catalog/kubedb/raw/mariadb/mariadb-10.11.6.yaml
+++ b/catalog/kubedb/raw/mariadb/mariadb-10.11.6.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.11.6
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:10.11.6-jammy
   exporter:

--- a/catalog/kubedb/raw/mariadb/mariadb-10.4.32.yaml
+++ b/catalog/kubedb/raw/mariadb/mariadb-10.4.32.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.4.32
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:10.4.32-focal
   exporter:

--- a/catalog/kubedb/raw/mariadb/mariadb-10.5.23.yaml
+++ b/catalog/kubedb/raw/mariadb/mariadb-10.5.23.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.5.23
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:10.5.23-focal
   exporter:

--- a/catalog/kubedb/raw/mariadb/mariadb-10.6.16.yaml
+++ b/catalog/kubedb/raw/mariadb/mariadb-10.6.16.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 10.6.16
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:10.6.16-focal
   exporter:

--- a/catalog/kubedb/raw/mariadb/mariadb-11.0.4.yaml
+++ b/catalog/kubedb/raw/mariadb/mariadb-11.0.4.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 11.0.4
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:11.0.4-jammy
   exporter:

--- a/catalog/kubedb/raw/mariadb/mariadb-11.1.3.yaml
+++ b/catalog/kubedb/raw/mariadb/mariadb-11.1.3.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 11.1.3
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:11.1.3-jammy
   exporter:

--- a/catalog/kubedb/raw/mariadb/mariadb-11.2.2.yaml
+++ b/catalog/kubedb/raw/mariadb/mariadb-11.2.2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 11.2.2
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.0
+    image: ghcr.io/kubedb/mariadb-coordinator:v0.21.0-rc.1
   db:
     image: ghcr.io/appscode-images/mariadb:11.2.2-jammy
   exporter:

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-3.4-official.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-3.4-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: "3.4"
 
 ---
@@ -38,7 +38,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: "3.4"
 
 ---
@@ -60,7 +60,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: "3.4"
 
 ---
@@ -82,5 +82,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: "3.4"

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-3.4.17-official.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-3.4.17-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 3.4.17
 
 ---
@@ -50,7 +50,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-3.4.22-official.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-3.4.22-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 3.4.22
 
 ---
@@ -38,7 +38,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 3.4.22
 
 ---
@@ -60,7 +60,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 3.4.22
 
 ---
@@ -94,7 +94,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-3.6-official.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-3.6-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: "3.6"
 
 ---
@@ -38,7 +38,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: "3.6"
 
 ---
@@ -60,7 +60,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: "3.6"
 
 ---
@@ -82,5 +82,5 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: "3.6"

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-3.6.13-official.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-3.6.13-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 3.6.13
 
 ---
@@ -38,7 +38,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 3.6.13
 
 ---
@@ -60,7 +60,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 3.6.13
 
 ---
@@ -94,7 +94,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-3.6.18-percona.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-3.6.18-percona.yaml
@@ -28,7 +28,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 1001
     runAsUser: 0

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-3.6.8-official.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-3.6.8-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 3.6.8
 
 ---
@@ -50,7 +50,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.0.10-percona.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.0.10-percona.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 1001
     runAsUser: 0

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.0.11-official.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.0.11-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 4.0.11
 
 ---
@@ -38,7 +38,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 4.0.11
 
 ---
@@ -60,7 +60,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 4.0.11
 
 ---
@@ -94,7 +94,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.0.3-official.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.0.3-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 4.0.3
 
 ---
@@ -50,7 +50,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.0.5-official.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.0.5-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 4.0.5
 
 ---
@@ -38,7 +38,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 4.0.5
 
 ---
@@ -60,7 +60,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 4.0.5
 
 ---
@@ -82,7 +82,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 4.0.5
 
 ---
@@ -104,7 +104,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 4.0.5
 
 ---
@@ -138,7 +138,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.1.13-official.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.1.13-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 4.1.13
 
 ---
@@ -38,7 +38,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 4.1.13
 
 ---
@@ -60,7 +60,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 4.1.13
 
 ---
@@ -94,7 +94,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.1.4-official.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.1.4-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 4.1.4
 
 ---
@@ -50,7 +50,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.1.7-official.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.1.7-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 4.1.7
 
 ---
@@ -38,7 +38,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 4.1.7
 
 ---
@@ -60,7 +60,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 4.1.7
 
 ---
@@ -94,7 +94,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.2.3-official.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.2.3-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   version: 4.2.3
 
 ---
@@ -50,7 +50,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.2.7-percona.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.2.7-percona.yaml
@@ -28,7 +28,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 1001
     runAsUser: 0

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.4.10-percona.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.4.10-percona.yaml
@@ -28,7 +28,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 1001
     runAsUser: 0

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.4.6-official.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-4.4.6-official.yaml
@@ -28,7 +28,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-5.0.15-official.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-5.0.15-official.yaml
@@ -28,7 +28,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-5.0.2-official.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-5.0.2-official.yaml
@@ -28,7 +28,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-5.0.3-official.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-5.0.3-official.yaml
@@ -28,7 +28,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/catalog/kubedb/raw/mongodb/deprecated-mongodb-6.0.5-official.yaml
+++ b/catalog/kubedb/raw/mongodb/deprecated-mongodb-6.0.5-official.yaml
@@ -28,7 +28,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/catalog/kubedb/raw/mongodb/mongodb-4.2.24-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-4.2.24-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/catalog/kubedb/raw/mongodb/mongodb-4.2.24-percona.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-4.2.24-percona.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 0
     runAsUser: 1001

--- a/catalog/kubedb/raw/mongodb/mongodb-4.4.26-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-4.4.26-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/catalog/kubedb/raw/mongodb/mongodb-4.4.26-percona.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-4.4.26-percona.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 0
     runAsUser: 1001

--- a/catalog/kubedb/raw/mongodb/mongodb-5.0.23-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-5.0.23-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/catalog/kubedb/raw/mongodb/mongodb-5.0.23-percona.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-5.0.23-percona.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 0
     runAsUser: 1001

--- a/catalog/kubedb/raw/mongodb/mongodb-6.0.12-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-6.0.12-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/catalog/kubedb/raw/mongodb/mongodb-6.0.12-percona.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-6.0.12-percona.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 0
     runAsUser: 1001

--- a/catalog/kubedb/raw/mongodb/mongodb-7.0.4-percona.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-7.0.4-percona.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 0
     runAsUser: 1001

--- a/catalog/kubedb/raw/mongodb/mongodb-7.0.5-official.yaml
+++ b/catalog/kubedb/raw/mongodb/mongodb-7.0.5-official.yaml
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-5-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-5-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -44,7 +44,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-5.7-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-5.7-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -44,7 +44,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.25-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.25-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -42,7 +42,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -68,7 +68,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -94,7 +94,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -120,7 +120,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:
@@ -152,7 +152,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.29-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.29-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -44,7 +44,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -72,7 +72,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:
@@ -106,7 +106,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.31-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.31-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -44,7 +44,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:
@@ -78,7 +78,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.33-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.33-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:
@@ -50,7 +50,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.35-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.35-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:
@@ -38,7 +38,7 @@ metadata:
   name: 5.7.35-v1
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.1
   db:
     image: mysql:5.7.35
   deprecated: true
@@ -52,7 +52,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.36-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.36-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 5.7.36
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.1
   db:
     image: mysql:5.7.36
   deprecated: true
@@ -18,7 +18,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.41-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-5.7.41-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 5.7.41
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.1
   db:
     image: ghcr.io/appscode-images/mysql:5.7.41-oracle
   deprecated: true
@@ -18,7 +18,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -44,7 +44,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.14-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.14-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -44,7 +44,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -72,7 +72,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -100,7 +100,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:
@@ -134,7 +134,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.17-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.17-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.17
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.1
   db:
     image: mysql:8.0.17
   deprecated: true
@@ -18,7 +18,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.20-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.20-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -44,7 +44,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -72,7 +72,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:
@@ -106,7 +106,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.21-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.21-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     denylist:
       groupReplication:
@@ -44,7 +44,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:
@@ -78,7 +78,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.23-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.23-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:
@@ -50,7 +50,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.26-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.26-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.27-mysql.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.27-mysql.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.27-innodb
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.1
   db:
     image: mysql/mysql-server:8.0.27
   deprecated: true
@@ -18,11 +18,11 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   router:
     image: mysql/mysql-router:8.0.27
   routerInitContainer:
-    image: ghcr.io/kubedb/mysql-router-init:v0.19.0-rc.0
+    image: ghcr.io/kubedb/mysql-router-init:v0.19.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.27-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.27-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.27
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.1
   db:
     image: mysql:8.0.27
   deprecated: true
@@ -18,7 +18,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.29-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.29-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.29
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.1
   db:
     image: mysql:8.0.29
   deprecated: true
@@ -18,7 +18,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.3-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.3-official.yaml
@@ -16,7 +16,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     allowlist:
       groupReplication:
@@ -44,7 +44,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     allowlist:
       groupReplication:
@@ -72,7 +72,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   updateConstraints:
     allowlist:
       groupReplication:
@@ -100,7 +100,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:
@@ -134,7 +134,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:
@@ -156,7 +156,7 @@ metadata:
   name: 8.0.3-v4
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.1
   db:
     image: mysql:8.0.3
   deprecated: true
@@ -170,7 +170,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   stash:
     addon:
       backupTask:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.31-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.31-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.31
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.1
   db:
     image: ghcr.io/appscode-images/mysql:8.0.31-oracle
   deprecated: true
@@ -18,7 +18,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.32-official.yaml
+++ b/catalog/kubedb/raw/mysql/deprecated-mysql-8.0.32-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.32
 spec:
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.1
   db:
     image: ghcr.io/appscode-images/mysql:8.0.32-oracle
   deprecated: true
@@ -18,7 +18,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mysql/mysql-5.7.42-official.yaml
+++ b/catalog/kubedb/raw/mysql/mysql-5.7.42-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: VolumeSnapshot
     walg:
-      image: ghcr.io/kubedb/mysql-archiver:(v0.2.0-rc.0)_5.7.44
+      image: ghcr.io/kubedb/mysql-archiver:(v0.2.0-rc.1)_5.7.44
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.1
   db:
     image: ghcr.io/appscode-images/mysql:5.7.42-debian
   distribution: Official
@@ -29,7 +29,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mysql/mysql-5.7.44-official.yaml
+++ b/catalog/kubedb/raw/mysql/mysql-5.7.44-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/mysql-archiver:(v0.2.0-rc.0)_5.7.44
+      image: ghcr.io/kubedb/mysql-archiver:(v0.2.0-rc.1)_5.7.44
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.1
   db:
     image: ghcr.io/appscode-images/mysql:5.7.44-oracle
   distribution: Official
@@ -29,7 +29,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mysql/mysql-8.0.31-mysql.yaml
+++ b/catalog/kubedb/raw/mysql/mysql-8.0.31-mysql.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/mysql-archiver:(v0.2.0-rc.0)_8.0.35
+      image: ghcr.io/kubedb/mysql-archiver:(v0.2.0-rc.1)_8.0.35
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.1
   db:
     image: ghcr.io/appscode-images/mysql:8.0.31-oracle
   distribution: MySQL
@@ -29,11 +29,11 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   router:
     image: mysql/mysql-router:8.0.31
   routerInitContainer:
-    image: ghcr.io/kubedb/mysql-router-init:v0.19.0-rc.0
+    image: ghcr.io/kubedb/mysql-router-init:v0.19.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mysql/mysql-8.0.35-official.yaml
+++ b/catalog/kubedb/raw/mysql/mysql-8.0.35-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/mysql-archiver:(v0.2.0-rc.0)_8.0.35
+      image: ghcr.io/kubedb/mysql-archiver:(v0.2.0-rc.1)_8.0.35
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.1
   db:
     image: ghcr.io/appscode-images/mysql:8.0.35-oracle
   distribution: Official
@@ -29,7 +29,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mysql/mysql-8.1.0-official.yaml
+++ b/catalog/kubedb/raw/mysql/mysql-8.1.0-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/mysql-archiver:(v0.2.0-rc.0)_8.1.0
+      image: ghcr.io/kubedb/mysql-archiver:(v0.2.0-rc.1)_8.1.0
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.1
   db:
     image: ghcr.io/appscode-images/mysql:8.1.0-oracle
   distribution: Official
@@ -29,7 +29,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/mysql/mysql-8.2.0-official.yaml
+++ b/catalog/kubedb/raw/mysql/mysql-8.2.0-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/mysql-archiver:(v0.2.0-rc.0)_8.2.0
+      image: ghcr.io/kubedb/mysql-archiver:(v0.2.0-rc.1)_8.2.0
   coordinator:
-    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.0
+    image: ghcr.io/kubedb/mysql-coordinator:v0.19.0-rc.1
   db:
     image: ghcr.io/appscode-images/mysql:8.2.0-oracle
   distribution: Official
@@ -29,7 +29,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.0
+    image: ghcr.io/kubedb/replication-mode-detector:v0.28.0-rc.1
   securityContext:
     runAsUser: 999
   stash:

--- a/catalog/kubedb/raw/perconaxtradb/perconaxtradb-8.0.26.yaml
+++ b/catalog/kubedb/raw/perconaxtradb/perconaxtradb-8.0.26.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.26
 spec:
   coordinator:
-    image: ghcr.io/kubedb/percona-xtradb-coordinator:v0.14.0-rc.0
+    image: ghcr.io/kubedb/percona-xtradb-coordinator:v0.14.0-rc.1
   db:
     image: percona/percona-xtradb-cluster:8.0.26
   exporter:

--- a/catalog/kubedb/raw/perconaxtradb/perconaxtradb-8.0.28.yaml
+++ b/catalog/kubedb/raw/perconaxtradb/perconaxtradb-8.0.28.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.28
 spec:
   coordinator:
-    image: ghcr.io/kubedb/percona-xtradb-coordinator:v0.14.0-rc.0
+    image: ghcr.io/kubedb/percona-xtradb-coordinator:v0.14.0-rc.1
   db:
     image: percona/percona-xtradb-cluster:8.0.28
   exporter:

--- a/catalog/kubedb/raw/perconaxtradb/perconaxtradb-8.0.31.yaml
+++ b/catalog/kubedb/raw/perconaxtradb/perconaxtradb-8.0.31.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.0.31
 spec:
   coordinator:
-    image: ghcr.io/kubedb/percona-xtradb-coordinator:v0.14.0-rc.0
+    image: ghcr.io/kubedb/percona-xtradb-coordinator:v0.14.0-rc.1
   db:
     image: percona/percona-xtradb-cluster:8.0.31
   exporter:

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-10.16-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-10.16-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "10.16"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:10.16-alpine
@@ -37,7 +37,7 @@ metadata:
   name: 10.16-debian
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:10.16

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-10.19-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-10.19-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "10.19"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:10.19-bullseye
@@ -37,7 +37,7 @@ metadata:
   name: 10.19-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:10.19-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-10.20-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-10.20-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "10.20"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:10.20-bullseye
@@ -37,7 +37,7 @@ metadata:
   name: 10.20-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:10.20-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-11.11-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-11.11-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:11.11-alpine
@@ -59,9 +59,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:11.11

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-11.14-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-11.14-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:11.14-alpine
@@ -59,9 +59,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:11.14-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-11.15-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-11.15-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:11.15-alpine
@@ -59,9 +59,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:11.15-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-11.19-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-11.19-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:11.19-alpine
@@ -59,9 +59,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:11.19-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-11.20-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-11.20-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:11.20-alpine
@@ -59,9 +59,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:11.20-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-12.10-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-12.10-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:12.10-alpine
@@ -60,9 +60,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:12.10-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-12.13-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-12.13-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:12.13-alpine
@@ -60,9 +60,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:12.13-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-12.14-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-12.14-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:12.14-alpine
@@ -60,9 +60,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:12.14-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-12.15-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-12.15-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:12.15-alpine
@@ -60,9 +60,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:12.15-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-12.6-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-12.6-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:12.6-alpine
@@ -60,9 +60,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:12.6

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-12.9-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-12.9-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:12.9-alpine
@@ -60,9 +60,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:12.9-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-13.10-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-13.10-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:13.10-alpine
@@ -59,9 +59,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:13.10-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-13.11-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-13.11-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:13.11-alpine
@@ -59,9 +59,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:13.11-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-13.2-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-13.2-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:13.2-alpine
@@ -59,9 +59,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:13.2

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-13.5-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-13.5-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:13.5-alpine
@@ -59,9 +59,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:13.5-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-13.6-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-13.6-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:13.6-alpine
@@ -59,9 +59,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:13.6-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-13.9-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-13.9-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:13.9-alpine
@@ -59,9 +59,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:13.9-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-14.1-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-14.1-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:14.1-alpine
@@ -59,9 +59,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:14.1-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-14.2-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-14.2-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:14.2-alpine
@@ -56,9 +56,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:14.2-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-14.6-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-14.6-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:14.6-alpine
@@ -56,9 +56,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:14.6-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-14.7-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-14.7-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:14.7-alpine
@@ -56,9 +56,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:14.7-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-14.8-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-14.8-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:14.8-alpine
@@ -56,9 +56,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:14.8-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-15.1-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-15.1-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:15.1-alpine
@@ -59,9 +59,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:15.1-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-15.2-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-15.2-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:15.2-alpine
@@ -59,9 +59,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:15.2-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-15.3-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-15.3-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:15.3-alpine
@@ -59,9 +59,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: v0.2.0-rc.0
+      image: v0.2.0-rc.1
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:15.3-bullseye

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-9.6.21-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-9.6.21-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 9.6.21
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:9.6.21-alpine
@@ -37,7 +37,7 @@ metadata:
   name: 9.6.21-debian
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: debian
     image: postgres:9.6.21

--- a/catalog/kubedb/raw/postgres/deprecated-postgres-9.6.24-official.yaml
+++ b/catalog/kubedb/raw/postgres/deprecated-postgres-9.6.24-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 9.6.24
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: postgres:9.6.24-alpine
@@ -37,7 +37,7 @@ metadata:
   name: 9.6.24-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: postgres:9.6.24-bullseye

--- a/catalog/kubedb/raw/postgres/postgres-10.23-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-10.23-official.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "10.23"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: ghcr.io/appscode-images/postgres:10.23-alpine
@@ -36,7 +36,7 @@ metadata:
   name: 10.23-bullseye
 spec:
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bullseye
     image: ghcr.io/appscode-images/postgres:10.23-bullseye

--- a/catalog/kubedb/raw/postgres/postgres-11.11-timescaledb.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-11.11-timescaledb.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.0)_11.22-alpine
+      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.1)_11.22-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     image: timescale/timescaledb:2.1.0-pg11-oss
   distribution: TimescaleDB

--- a/catalog/kubedb/raw/postgres/postgres-11.14-postgis.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-11.14-postgis.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.0)_11.22-bookworm
+      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.1)_11.22-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     image: postgis/postgis:11-3.1
   distribution: PostGIS

--- a/catalog/kubedb/raw/postgres/postgres-11.22-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-11.22-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.0)_11.22-alpine
+      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.1)_11.22-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: ghcr.io/appscode-images/postgres:11.22-alpine
@@ -58,9 +58,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.0)_11.22-bookworm
+      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.1)_11.22-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bookworm
     image: ghcr.io/appscode-images/postgres:11.22-bookworm

--- a/catalog/kubedb/raw/postgres/postgres-12.17-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-12.17-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.0)_12.17-alpine
+      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.1)_12.17-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: ghcr.io/appscode-images/postgres:12.17-alpine
@@ -59,9 +59,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.0)_12.17-bookworm
+      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.1)_12.17-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bookworm
     image: ghcr.io/appscode-images/postgres:12.17-bookworm

--- a/catalog/kubedb/raw/postgres/postgres-12.6-timescaledb.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-12.6-timescaledb.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.0)_12.17-alpine
+      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.1)_12.17-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     image: timescale/timescaledb:2.1.0-pg12-oss
   distribution: TimescaleDB

--- a/catalog/kubedb/raw/postgres/postgres-12.9-postgis.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-12.9-postgis.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.0)_12.17-bookworm
+      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.1)_12.17-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     image: postgis/postgis:12-3.1
   distribution: PostGIS

--- a/catalog/kubedb/raw/postgres/postgres-13.13-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-13.13-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.0)_13.13-alpine
+      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.1)_13.13-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: ghcr.io/appscode-images/postgres:13.13-alpine
@@ -58,9 +58,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.0)_13.13-bookworm
+      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.1)_13.13-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bookworm
     image: ghcr.io/appscode-images/postgres:13.13-bookworm

--- a/catalog/kubedb/raw/postgres/postgres-13.2-timescaledb.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-13.2-timescaledb.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.0)_13.13-alpine
+      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.1)_13.13-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     image: timescale/timescaledb:2.1.0-pg13-oss
   distribution: TimescaleDB

--- a/catalog/kubedb/raw/postgres/postgres-13.5-postgis.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-13.5-postgis.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.0)_13.13-bookworm
+      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.1)_13.13-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     image: postgis/postgis:13-3.1
   distribution: PostGIS

--- a/catalog/kubedb/raw/postgres/postgres-14.1-postgis.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-14.1-postgis.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.0)_14.10-bookworm
+      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.1)_14.10-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     image: postgis/postgis:14-3.1
   distribution: PostGIS

--- a/catalog/kubedb/raw/postgres/postgres-14.1-timescaledb.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-14.1-timescaledb.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.0)_14.10-alpine
+      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.1)_14.10-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     image: timescale/timescaledb:2.5.0-pg14-oss
   distribution: TimescaleDB

--- a/catalog/kubedb/raw/postgres/postgres-14.10-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-14.10-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.0)_14.10-alpine
+      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.1)_14.10-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: ghcr.io/appscode-images/postgres:14.10-alpine
@@ -55,9 +55,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.0)_14.10-bookworm
+      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.1)_14.10-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bookworm
     image: ghcr.io/appscode-images/postgres:14.10-bookworm

--- a/catalog/kubedb/raw/postgres/postgres-15.5-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-15.5-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.0)_15.5-alpine
+      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.1)_15.5-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: ghcr.io/appscode-images/postgres:15.5-alpine
@@ -58,9 +58,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.0)_15.5-bookworm
+      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.1)_15.5-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bookworm
     image: ghcr.io/appscode-images/postgres:15.5-bookworm

--- a/catalog/kubedb/raw/postgres/postgres-16.1-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-16.1-official.yaml
@@ -14,9 +14,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.0)_16.1-alpine
+      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.1)_16.1-alpine
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: alpine
     image: ghcr.io/appscode-images/postgres:16.1-alpine
@@ -58,9 +58,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.0)_16.1-bookworm
+      image: ghcr.io/kubedb/postgres-archiver:(v0.2.0-rc.1)_16.1-bookworm
   coordinator:
-    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.0
+    image: ghcr.io/kubedb/pg-coordinator:v0.25.0-rc.1
   db:
     baseOS: bookworm
     image: ghcr.io/appscode-images/postgres:16.1-bookworm

--- a/catalog/kubedb/raw/redis/deprecated-redis-4.0.6.yaml
+++ b/catalog/kubedb/raw/redis/deprecated-redis-4.0.6.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 4.0.6
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:4.0.6
   deprecated: true
@@ -23,7 +23,7 @@ metadata:
   name: 4.0.6-v1
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:4.0.6-v1
   deprecated: true
@@ -42,7 +42,7 @@ metadata:
   name: 4.0.6-v2
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:4.0.6-v2
   deprecated: true

--- a/catalog/kubedb/raw/redis/deprecated-redis-4.0.yaml
+++ b/catalog/kubedb/raw/redis/deprecated-redis-4.0.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "4.0"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:4.0
   deprecated: true
@@ -23,7 +23,7 @@ metadata:
   name: 4.0-v1
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:4.0-v1
   deprecated: true
@@ -42,7 +42,7 @@ metadata:
   name: 4.0-v2
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:4.0-v2
   deprecated: true

--- a/catalog/kubedb/raw/redis/deprecated-redis-4.yaml
+++ b/catalog/kubedb/raw/redis/deprecated-redis-4.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "4"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:4
   deprecated: true
@@ -23,7 +23,7 @@ metadata:
   name: 4-v1
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:4-v1
   deprecated: true

--- a/catalog/kubedb/raw/redis/deprecated-redis-5.0.3.yaml
+++ b/catalog/kubedb/raw/redis/deprecated-redis-5.0.3.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 5.0.3
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:5.0.3
   deprecated: true
@@ -29,7 +29,7 @@ metadata:
   name: 5.0.3-v1
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:5.0.3-v1
   deprecated: true

--- a/catalog/kubedb/raw/redis/deprecated-redis-5.0.yaml
+++ b/catalog/kubedb/raw/redis/deprecated-redis-5.0.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "5.0"
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:5.0
   deprecated: true
@@ -29,7 +29,7 @@ metadata:
   name: 5.0-v1
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:5.0-v1
   deprecated: true

--- a/catalog/kubedb/raw/redis/deprecated-redis-6.0.18.yaml
+++ b/catalog/kubedb/raw/redis/deprecated-redis-6.0.18.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 6.0.18
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: redis:6.0.18
   deprecated: true

--- a/catalog/kubedb/raw/redis/deprecated-redis-6.0.6.yaml
+++ b/catalog/kubedb/raw/redis/deprecated-redis-6.0.6.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 6.0.6
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:6.0.6
   deprecated: true

--- a/catalog/kubedb/raw/redis/deprecated-redis-6.2.11.yaml
+++ b/catalog/kubedb/raw/redis/deprecated-redis-6.2.11.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 6.2.11
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: redis:6.2.11
   deprecated: true

--- a/catalog/kubedb/raw/redis/deprecated-redis-6.2.5.yaml
+++ b/catalog/kubedb/raw/redis/deprecated-redis-6.2.5.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 6.2.5
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: redis:6.2.5
   deprecated: true

--- a/catalog/kubedb/raw/redis/deprecated-redis-6.2.7.yaml
+++ b/catalog/kubedb/raw/redis/deprecated-redis-6.2.7.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 6.2.7
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: redis:6.2.7
   deprecated: true

--- a/catalog/kubedb/raw/redis/deprecated-redis-6.2.8.yaml
+++ b/catalog/kubedb/raw/redis/deprecated-redis-6.2.8.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 6.2.8
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: redis:6.2.8
   deprecated: true

--- a/catalog/kubedb/raw/redis/deprecated-redis-7.0.10.yaml
+++ b/catalog/kubedb/raw/redis/deprecated-redis-7.0.10.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.0.10
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: redis:7.0.10
   deprecated: true

--- a/catalog/kubedb/raw/redis/deprecated-redis-7.0.4.yaml
+++ b/catalog/kubedb/raw/redis/deprecated-redis-7.0.4.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.0.4
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: redis:7.0.4
   deprecated: true

--- a/catalog/kubedb/raw/redis/deprecated-redis-7.0.5.yaml
+++ b/catalog/kubedb/raw/redis/deprecated-redis-7.0.5.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.0.5
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: redis:7.0.5
   deprecated: true

--- a/catalog/kubedb/raw/redis/deprecated-redis-7.0.6.yaml
+++ b/catalog/kubedb/raw/redis/deprecated-redis-7.0.6.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.0.6
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: redis:7.0.6
   deprecated: true

--- a/catalog/kubedb/raw/redis/deprecated-redis-7.0.9.yaml
+++ b/catalog/kubedb/raw/redis/deprecated-redis-7.0.9.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.0.9
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: redis:7.0.9
   deprecated: true

--- a/catalog/kubedb/raw/redis/deprecated-redis-7.2.0.yaml
+++ b/catalog/kubedb/raw/redis/deprecated-redis-7.2.0.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.2.0
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: redis:7.2.0
   deprecated: true

--- a/catalog/kubedb/raw/redis/redis-4.0.11.yaml
+++ b/catalog/kubedb/raw/redis/redis-4.0.11.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 4.0.11
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: ghcr.io/kubedb/redis:4.0.11
   exporter:

--- a/catalog/kubedb/raw/redis/redis-5.0.14.yaml
+++ b/catalog/kubedb/raw/redis/redis-5.0.14.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 5.0.14
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: ghcr.io/appscode-images/redis:5.0.14-bullseye
   exporter:

--- a/catalog/kubedb/raw/redis/redis-6.0.20.yaml
+++ b/catalog/kubedb/raw/redis/redis-6.0.20.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 6.0.20
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: ghcr.io/appscode-images/redis:6.0.20-bookworm
   exporter:

--- a/catalog/kubedb/raw/redis/redis-6.2.14.yaml
+++ b/catalog/kubedb/raw/redis/redis-6.2.14.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 6.2.14
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: ghcr.io/appscode-images/redis:6.2.14-bookworm
   exporter:

--- a/catalog/kubedb/raw/redis/redis-7.0.14.yaml
+++ b/catalog/kubedb/raw/redis/redis-7.0.14.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.0.14
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: ghcr.io/appscode-images/redis:7.0.14-bookworm
   exporter:

--- a/catalog/kubedb/raw/redis/redis-7.0.15.yaml
+++ b/catalog/kubedb/raw/redis/redis-7.0.15.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.0.15
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: ghcr.io/appscode-images/redis:7.0.15-bookworm
   exporter:

--- a/catalog/kubedb/raw/redis/redis-7.2.3.yaml
+++ b/catalog/kubedb/raw/redis/redis-7.2.3.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.2.3
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: ghcr.io/appscode-images/redis:7.2.3-bookworm
   exporter:

--- a/catalog/kubedb/raw/redis/redis-7.2.4.yaml
+++ b/catalog/kubedb/raw/redis/redis-7.2.4.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 7.2.4
 spec:
   coordinator:
-    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.0
+    image: ghcr.io/kubedb/redis-coordinator:v0.20.0-rc.1
   db:
     image: ghcr.io/appscode-images/redis:7.2.4-bookworm
   exporter:

--- a/catalog/kubedb/raw/singlestore/singlestore-8.1.32.yaml
+++ b/catalog/kubedb/raw/singlestore/singlestore-8.1.32.yaml
@@ -4,7 +4,7 @@ metadata:
   name: 8.1.32
 spec:
   coordinator:
-    image: ghcr.io/kubedb/singlestore-coordinator:v0.0.2
+    image: ghcr.io/kubedb/singlestore-coordinator:v0.0.3
   db:
     image: singlestore/node:alma-8.1.32-e3d3cde6da
   initContainer:

--- a/catalog/kubestash/raw/elasticsearch/elasticsearch-backup-function.yaml
+++ b/catalog/kubestash/raw/elasticsearch/elasticsearch-backup-function.yaml
@@ -12,4 +12,4 @@ spec:
   - --wait-timeout=${waitTimeout:=300}
   - --es-args=${args:=}
   - --interim-data-dir=${interimDataDir:=}
-  image: ghcr.io/kubedb/elasticsearch-restic-plugin:v0.4.0-rc.0
+  image: ghcr.io/kubedb/elasticsearch-restic-plugin:v0.4.0-rc.1

--- a/catalog/kubestash/raw/elasticsearch/elasticsearch-restore-function.yaml
+++ b/catalog/kubestash/raw/elasticsearch/elasticsearch-restore-function.yaml
@@ -13,4 +13,4 @@ spec:
   - --wait-timeout=${waitTimeout:=300}
   - --es-args=${args:=}
   - --interim-data-dir=${interimDataDir:=}
-  image: ghcr.io/kubedb/elasticsearch-restic-plugin:v0.4.0-rc.0
+  image: ghcr.io/kubedb/elasticsearch-restic-plugin:v0.4.0-rc.1

--- a/catalog/kubestash/raw/kubedbmanifest/kubedbmanifest-backup-function.yaml
+++ b/catalog/kubestash/raw/kubedbmanifest/kubedbmanifest-backup-function.yaml
@@ -9,4 +9,4 @@ spec:
   - --backupsession=${backupSession:=}
   - --enable-cache=${enableCache:=}
   - --scratch-dir=${scratchDir:=}
-  image: ghcr.io/kubedb/kubedb-manifest-plugin:v0.4.0-rc.0
+  image: ghcr.io/kubedb/kubedb-manifest-plugin:v0.4.0-rc.1

--- a/catalog/kubestash/raw/kubedbmanifest/kubedbmanifest-restore-function.yaml
+++ b/catalog/kubestash/raw/kubedbmanifest/kubedbmanifest-restore-function.yaml
@@ -10,4 +10,4 @@ spec:
   - --snapshot=${snapshot:=}
   - --enable-cache=${enableCache:=}
   - --scratch-dir=${scratchDir:=}
-  image: ghcr.io/kubedb/kubedb-manifest-plugin:v0.4.0-rc.0
+  image: ghcr.io/kubedb/kubedb-manifest-plugin:v0.4.0-rc.1

--- a/catalog/kubestash/raw/mongodb/mongodb-backup-function.yaml
+++ b/catalog/kubestash/raw/mongodb/mongodb-backup-function.yaml
@@ -14,4 +14,4 @@ spec:
   - --max-concurrency=${maxConcurrency:=3}
   - --authentication-database=${authenticationDatabase:=admin}
   - --db-version=${dbVersion:=}
-  image: ghcr.io/kubedb/mongodb-restic-plugin:v0.4.0-rc.0_${DB_VERSION}
+  image: ghcr.io/kubedb/mongodb-restic-plugin:v0.4.0-rc.1_${DB_VERSION}

--- a/catalog/kubestash/raw/mongodb/mongodb-csi-snapshotter-function.yaml
+++ b/catalog/kubestash/raw/mongodb/mongodb-csi-snapshotter-function.yaml
@@ -8,4 +8,4 @@ spec:
   - --namespace=${namespace:=default}
   - --volume-snapshot-class-name=${volumeSnapshotClassName:=}
   - --backupsession=${backupSession:=}
-  image: ghcr.io/kubedb/mongodb-csi-snapshotter-plugin:v0.2.0-rc.0
+  image: ghcr.io/kubedb/mongodb-csi-snapshotter-plugin:v0.2.0-rc.1

--- a/catalog/kubestash/raw/mongodb/mongodb-restore-function.yaml
+++ b/catalog/kubestash/raw/mongodb/mongodb-restore-function.yaml
@@ -15,4 +15,4 @@ spec:
   - --max-concurrency=${maxConcurrency:=3}
   - --authentication-database=${authenticationDatabase:=admin}
   - --db-version=${dbVersion:=}
-  image: ghcr.io/kubedb/mongodb-restic-plugin:v0.4.0-rc.0_${DB_VERSION}
+  image: ghcr.io/kubedb/mongodb-restic-plugin:v0.4.0-rc.1_${DB_VERSION}

--- a/catalog/kubestash/raw/mysql/mysql-backup-function.yaml
+++ b/catalog/kubestash/raw/mysql/mysql-backup-function.yaml
@@ -13,4 +13,4 @@ spec:
   - --mysql-args=${args:=}
   - --db-version=${dbVersion:=}
   - --databases=${databases:=}
-  image: ghcr.io/kubedb/mysql-restic-plugin:v0.4.0-rc.0_${DB_VERSION}
+  image: ghcr.io/kubedb/mysql-restic-plugin:v0.4.0-rc.1_${DB_VERSION}

--- a/catalog/kubestash/raw/mysql/mysql-csi-snapshotter-function.yaml
+++ b/catalog/kubestash/raw/mysql/mysql-csi-snapshotter-function.yaml
@@ -8,4 +8,4 @@ spec:
   - --namespace=${namespace:=default}
   - --volume-snapshot-class-name=${volumeSnapshotClassName:=}
   - --backupsession=${backupSession:=}
-  image: ghcr.io/kubedb/mysql-csi-snapshotter-plugin:v0.2.0-rc.0
+  image: ghcr.io/kubedb/mysql-csi-snapshotter-plugin:v0.2.0-rc.1

--- a/catalog/kubestash/raw/mysql/mysql-restore-function.yaml
+++ b/catalog/kubestash/raw/mysql/mysql-restore-function.yaml
@@ -13,4 +13,4 @@ spec:
   - --wait-timeout=${waitTimeout:=300}
   - --mysql-args=${args:=}
   - --db-version=${dbVersion:=}
-  image: ghcr.io/kubedb/mysql-restic-plugin:v0.4.0-rc.0_${DB_VERSION}
+  image: ghcr.io/kubedb/mysql-restic-plugin:v0.4.0-rc.1_${DB_VERSION}

--- a/catalog/kubestash/raw/opensearch/opensearch-backup-function.yaml
+++ b/catalog/kubestash/raw/opensearch/opensearch-backup-function.yaml
@@ -12,4 +12,4 @@ spec:
   - --wait-timeout=${waitTimeout:=300}
   - --os-args=${args:=}
   - --interim-data-dir=${interimDataDir:=}
-  image: ghcr.io/kubedb/elasticsearch-restic-plugin:v0.4.0-rc.0
+  image: ghcr.io/kubedb/elasticsearch-restic-plugin:v0.4.0-rc.1

--- a/catalog/kubestash/raw/opensearch/opensearch-restore-function.yaml
+++ b/catalog/kubestash/raw/opensearch/opensearch-restore-function.yaml
@@ -13,4 +13,4 @@ spec:
   - --wait-timeout=${waitTimeout:=300}
   - --os-args=${args:=}
   - --interim-data-dir=${interimDataDir:=}
-  image: ghcr.io/kubedb/elasticsearch-restic-plugin:v0.4.0-rc.0
+  image: ghcr.io/kubedb/elasticsearch-restic-plugin:v0.4.0-rc.1

--- a/catalog/kubestash/raw/postgres/postgres-backup-function.yaml
+++ b/catalog/kubestash/raw/postgres/postgres-backup-function.yaml
@@ -13,4 +13,4 @@ spec:
   - --pg-args=${args:=}
   - --backup-cmd=${backupCmd:=}
   - --user=${user:=}
-  image: ghcr.io/kubedb/postgres-restic-plugin:v0.4.0-rc.0
+  image: ghcr.io/kubedb/postgres-restic-plugin:v0.4.0-rc.1

--- a/catalog/kubestash/raw/postgres/postgres-csi-snapshotter-function.yaml
+++ b/catalog/kubestash/raw/postgres/postgres-csi-snapshotter-function.yaml
@@ -8,4 +8,4 @@ spec:
   - --namespace=${namespace:=default}
   - --volume-snapshot-class-name=${volumeSnapshotClassName:=}
   - --backupsession=${backupSession:=}
-  image: ghcr.io/kubedb/postgres-csi-snapshotter-plugin:v0.2.0-rc.0
+  image: ghcr.io/kubedb/postgres-csi-snapshotter-plugin:v0.2.0-rc.1

--- a/catalog/kubestash/raw/postgres/postgres-restore-function.yaml
+++ b/catalog/kubestash/raw/postgres/postgres-restore-function.yaml
@@ -13,4 +13,4 @@ spec:
   - --wait-timeout=${waitTimeout:=300}
   - --pg-args=${args:=}
   - --user=${user:=}
-  image: ghcr.io/kubedb/postgres-restic-plugin:v0.4.0-rc.0
+  image: ghcr.io/kubedb/postgres-restic-plugin:v0.4.0-rc.1

--- a/catalog/kubestash/raw/redis/redis-backup-function.yaml
+++ b/catalog/kubestash/raw/redis/redis-backup-function.yaml
@@ -11,4 +11,4 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --wait-timeout=${waitTimeout:=300}
   - --redis-args=${args:=}
-  image: ghcr.io/kubedb/redis-restic-plugin:v0.4.0-rc.0
+  image: ghcr.io/kubedb/redis-restic-plugin:v0.4.0-rc.1

--- a/catalog/kubestash/raw/redis/redis-restore-function.yaml
+++ b/catalog/kubestash/raw/redis/redis-restore-function.yaml
@@ -12,4 +12,4 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --wait-timeout=${waitTimeout:=300}
   - --redis-args=${args:=}
-  image: ghcr.io/kubedb/redis-restic-plugin:v0.4.0-rc.0
+  image: ghcr.io/kubedb/redis-restic-plugin:v0.4.0-rc.1

--- a/charts/kubedb-autoscaler/Chart.yaml
+++ b/charts/kubedb-autoscaler/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeDB Autoscaler by AppsCode - Autoscale KubeDB operated Databases
 name: kubedb-autoscaler
-version: v0.26.0-rc.0
-appVersion: v0.26.0-rc.0
+version: v0.26.0-rc.1
+appVersion: v0.26.0-rc.1
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-autoscaler-icon.png
 sources:

--- a/charts/kubedb-autoscaler/README.md
+++ b/charts/kubedb-autoscaler/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-autoscaler --version=v0.26.0-rc.0
-$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.26.0-rc.0
+$ helm search repo appscode/kubedb-autoscaler --version=v0.26.0-rc.1
+$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.26.0-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Autoscaler operator on a [Kubernetes](http://kuberne
 To install/upgrade the chart with the release name `kubedb-autoscaler`:
 
 ```bash
-$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.26.0-rc.0
+$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.26.0-rc.1
 ```
 
 The command deploys a KubeDB Autoscaler operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -90,12 +90,12 @@ The following table lists the configurable parameters of the `kubedb-autoscaler`
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.26.0-rc.0 --set replicaCount=1
+$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.26.0-rc.1 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.26.0-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-autoscaler appscode/kubedb-autoscaler -n kubedb --create-namespace --version=v0.26.0-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-catalog/Chart.yaml
+++ b/charts/kubedb-catalog/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeDB Catalog by AppsCode - Catalog for database versions
 name: kubedb-catalog
-version: v2024.1.26-rc.0
-appVersion: v2024.1.26-rc.0
+version: v2024.1.28-rc.1
+appVersion: v2024.1.28-rc.1
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/icon/kubedb.png
 sources:

--- a/charts/kubedb-catalog/README.md
+++ b/charts/kubedb-catalog/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-catalog --version=v2024.1.26-rc.0
-$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2024.1.26-rc.0
+$ helm search repo appscode/kubedb-catalog --version=v2024.1.28-rc.1
+$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2024.1.28-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys KubeDB catalog on a [Kubernetes](http://kubernetes.io) cluste
 To install/upgrade the chart with the release name `kubedb-catalog`:
 
 ```bash
-$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2024.1.26-rc.0
+$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2024.1.28-rc.1
 ```
 
 The command deploys KubeDB catalog on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -100,12 +100,12 @@ The following table lists the configurable parameters of the `kubedb-catalog` ch
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2024.1.26-rc.0 --set proxies.ghcr=ghcr.io
+$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2024.1.28-rc.1 --set proxies.ghcr=ghcr.io
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2024.1.26-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-catalog appscode/kubedb-catalog -n kubedb --create-namespace --version=v2024.1.28-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-catalog/templates/mariadb/deprecated-mariadb-10.10.2.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/deprecated-mariadb-10.10.2.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:10.10.2-jammy'
   deprecated: true

--- a/charts/kubedb-catalog/templates/mariadb/deprecated-mariadb-10.11.2.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/deprecated-mariadb-10.11.2.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:10.11.2-jammy'
   deprecated: true

--- a/charts/kubedb-catalog/templates/mariadb/deprecated-mariadb-10.4.17.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/deprecated-mariadb-10.4.17.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "mariadb") $) }}:10.4.17'
   deprecated: true

--- a/charts/kubedb-catalog/templates/mariadb/deprecated-mariadb-10.4.31.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/deprecated-mariadb-10.4.31.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:10.4.31-focal'
   deprecated: true

--- a/charts/kubedb-catalog/templates/mariadb/deprecated-mariadb-10.5.8.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/deprecated-mariadb-10.5.8.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "mariadb") $) }}:10.5.8'
   deprecated: true

--- a/charts/kubedb-catalog/templates/mariadb/deprecated-mariadb-10.6.4.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/deprecated-mariadb-10.6.4.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:10.6.4-focal'
   deprecated: true

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-10.10.7.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-10.10.7.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:10.10.7-jammy'
   exporter:

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-10.11.6.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-10.11.6.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:10.11.6-jammy'
   exporter:

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-10.4.32.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-10.4.32.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:10.4.32-focal'
   exporter:

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-10.5.23.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-10.5.23.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:10.5.23-focal'
   exporter:

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-10.6.16.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-10.6.16.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:10.6.16-focal'
   exporter:

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-11.0.4.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-11.0.4.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:11.0.4-jammy'
   exporter:

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-11.1.3.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-11.1.3.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:11.1.3-jammy'
   exporter:

--- a/charts/kubedb-catalog/templates/mariadb/mariadb-11.2.2.yaml
+++ b/charts/kubedb-catalog/templates/mariadb/mariadb-11.2.2.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mariadb-coordinator") $) }}:v0.21.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mariadb") $) }}:11.2.2-jammy'
   exporter:

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.4-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.4-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: "3.4"
 {{ end }}
 
@@ -51,7 +51,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: "3.4"
 {{ end }}
 
@@ -77,7 +77,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: "3.4"
 {{ end }}
 
@@ -103,7 +103,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: "3.4"
 {{ end }}
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.4.17-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.4.17-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 3.4.17
 {{ end }}
 
@@ -63,7 +63,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.4.22-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.4.22-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 3.4.22
 {{ end }}
 
@@ -51,7 +51,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 3.4.22
 {{ end }}
 
@@ -77,7 +77,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 3.4.22
 {{ end }}
 
@@ -115,7 +115,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.6-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.6-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: "3.6"
 {{ end }}
 
@@ -51,7 +51,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: "3.6"
 {{ end }}
 
@@ -77,7 +77,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: "3.6"
 {{ end }}
 
@@ -103,7 +103,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: "3.6"
 {{ end }}
 {{ end }}

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.6.13-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.6.13-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 3.6.13
 {{ end }}
 
@@ -51,7 +51,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 3.6.13
 {{ end }}
 
@@ -77,7 +77,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 3.6.13
 {{ end }}
 
@@ -115,7 +115,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.6.18-percona.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.6.18-percona.yaml
@@ -37,7 +37,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 1001
     runAsUser: 0

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.6.8-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-3.6.8-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 3.6.8
 {{ end }}
 
@@ -63,7 +63,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.0.10-percona.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.0.10-percona.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 1001
     runAsUser: 0

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.0.11-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.0.11-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 4.0.11
 {{ end }}
 
@@ -51,7 +51,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 4.0.11
 {{ end }}
 
@@ -77,7 +77,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 4.0.11
 {{ end }}
 
@@ -115,7 +115,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.0.3-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.0.3-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 4.0.3
 {{ end }}
 
@@ -63,7 +63,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.0.5-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.0.5-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 4.0.5
 {{ end }}
 
@@ -51,7 +51,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 4.0.5
 {{ end }}
 
@@ -77,7 +77,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 4.0.5
 {{ end }}
 
@@ -103,7 +103,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 4.0.5
 {{ end }}
 
@@ -129,7 +129,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 4.0.5
 {{ end }}
 
@@ -167,7 +167,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.1.13-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.1.13-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 4.1.13
 {{ end }}
 
@@ -51,7 +51,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 4.1.13
 {{ end }}
 
@@ -77,7 +77,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 4.1.13
 {{ end }}
 
@@ -115,7 +115,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.1.4-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.1.4-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 4.1.4
 {{ end }}
 
@@ -63,7 +63,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.1.7-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.1.7-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 4.1.7
 {{ end }}
 
@@ -51,7 +51,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 4.1.7
 {{ end }}
 
@@ -77,7 +77,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 4.1.7
 {{ end }}
 
@@ -115,7 +115,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.2.3-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.2.3-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   version: 4.2.3
 {{ end }}
 
@@ -63,7 +63,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.2.7-percona.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.2.7-percona.yaml
@@ -37,7 +37,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 1001
     runAsUser: 0

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.4.10-percona.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.4.10-percona.yaml
@@ -37,7 +37,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 1001
     runAsUser: 0

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.4.6-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-4.4.6-official.yaml
@@ -37,7 +37,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-5.0.15-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-5.0.15-official.yaml
@@ -37,7 +37,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-5.0.2-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-5.0.2-official.yaml
@@ -37,7 +37,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-5.0.3-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-5.0.3-official.yaml
@@ -37,7 +37,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-6.0.5-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/deprecated-mongodb-6.0.5-official.yaml
@@ -37,7 +37,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.2.24-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.2.24-official.yaml
@@ -36,7 +36,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.2.24-percona.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.2.24-percona.yaml
@@ -36,7 +36,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 0
     runAsUser: 1001

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.4.26-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.4.26-official.yaml
@@ -36,7 +36,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-4.4.26-percona.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-4.4.26-percona.yaml
@@ -36,7 +36,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 0
     runAsUser: 1001

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-5.0.23-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-5.0.23-official.yaml
@@ -36,7 +36,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-5.0.23-percona.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-5.0.23-percona.yaml
@@ -36,7 +36,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 0
     runAsUser: 1001

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-6.0.12-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-6.0.12-official.yaml
@@ -36,7 +36,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-6.0.12-percona.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-6.0.12-percona.yaml
@@ -36,7 +36,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 0
     runAsUser: 1001

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-7.0.4-percona.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-7.0.4-percona.yaml
@@ -36,7 +36,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 0
     runAsUser: 1001

--- a/charts/kubedb-catalog/templates/mongodb/mongodb-7.0.5-official.yaml
+++ b/charts/kubedb-catalog/templates/mongodb/mongodb-7.0.5-official.yaml
@@ -36,7 +36,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mongodb-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsGroup: 999
     runAsUser: 999

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -57,7 +57,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -57,7 +57,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.25-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.25-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -55,7 +55,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -85,7 +85,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -115,7 +115,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -145,7 +145,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -181,7 +181,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.29-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.29-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -57,7 +57,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -89,7 +89,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -127,7 +127,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.31-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.31-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -57,7 +57,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -95,7 +95,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.33-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.33-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -63,7 +63,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.35-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.35-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -51,7 +51,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "mysql") $) }}:5.7.35'
   deprecated: true
@@ -65,7 +65,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.36-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.36-official.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "mysql") $) }}:5.7.36'
   deprecated: true
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.41-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-5.7.41-official.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mysql") $) }}:5.7.41-oracle'
   deprecated: true
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -57,7 +57,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.14-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.14-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -57,7 +57,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -89,7 +89,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -121,7 +121,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -159,7 +159,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.17-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.17-official.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "mysql") $) }}:8.0.17'
   deprecated: true
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.20-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.20-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -57,7 +57,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -89,7 +89,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -127,7 +127,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.21-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.21-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     denylist:
       groupReplication:
@@ -57,7 +57,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -95,7 +95,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.23-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.23-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -63,7 +63,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.26-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.26-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.27-mysql.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.27-mysql.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "mysql/mysql-server") $) }}:8.0.27'
   deprecated: true
@@ -27,11 +27,11 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   router:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "mysql/mysql-router") $) }}:8.0.27'
   routerInitContainer:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-router-init") $) }}:v0.19.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-router-init") $) }}:v0.19.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.27-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.27-official.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "mysql") $) }}:8.0.27'
   deprecated: true
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.29-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.29-official.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "mysql") $) }}:8.0.29'
   deprecated: true
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.3-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.3-official.yaml
@@ -25,7 +25,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     allowlist:
       groupReplication:
@@ -57,7 +57,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     allowlist:
       groupReplication:
@@ -89,7 +89,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   updateConstraints:
     allowlist:
       groupReplication:
@@ -121,7 +121,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -159,7 +159,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:
@@ -185,7 +185,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "mysql") $) }}:8.0.3'
   deprecated: true
@@ -199,7 +199,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   stash:
     addon:
       backupTask:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.31-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.31-official.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mysql") $) }}:8.0.31-oracle'
   deprecated: true
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.32-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/deprecated-mysql-8.0.32-official.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mysql") $) }}:8.0.32-oracle'
   deprecated: true
@@ -27,7 +27,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.42-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.42-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: VolumeSnapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-archiver") $) }}:v0.2.0-rc.0_5.7.44'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-archiver") $) }}:v0.2.0-rc.1_5.7.44'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mysql") $) }}:5.7.42-debian'
   distribution: Official
@@ -38,7 +38,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mysql/mysql-5.7.44-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-5.7.44-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-archiver") $) }}:v0.2.0-rc.0_5.7.44'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-archiver") $) }}:v0.2.0-rc.1_5.7.44'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mysql") $) }}:5.7.44-oracle'
   distribution: Official
@@ -38,7 +38,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.31-mysql.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.31-mysql.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-archiver") $) }}:v0.2.0-rc.0_8.0.35'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-archiver") $) }}:v0.2.0-rc.1_8.0.35'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mysql") $) }}:8.0.31-oracle'
   distribution: MySQL
@@ -38,11 +38,11 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   router:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "mysql/mysql-router") $) }}:8.0.31'
   routerInitContainer:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-router-init") $) }}:v0.19.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-router-init") $) }}:v0.19.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.0.35-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.0.35-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-archiver") $) }}:v0.2.0-rc.0_8.0.35'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-archiver") $) }}:v0.2.0-rc.1_8.0.35'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mysql") $) }}:8.0.35-oracle'
   distribution: Official
@@ -38,7 +38,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.1.0-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.1.0-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-archiver") $) }}:v0.2.0-rc.0_8.1.0'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-archiver") $) }}:v0.2.0-rc.1_8.1.0'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mysql") $) }}:8.1.0-oracle'
   distribution: Official
@@ -38,7 +38,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/mysql/mysql-8.2.0-official.yaml
+++ b/charts/kubedb-catalog/templates/mysql/mysql-8.2.0-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-archiver") $) }}:v0.2.0-rc.0_8.2.0'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-archiver") $) }}:v0.2.0-rc.1_8.2.0'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-coordinator") $) }}:v0.19.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/mysql") $) }}:8.2.0-oracle'
   distribution: Official
@@ -38,7 +38,7 @@ spec:
   podSecurityPolicies:
     databasePolicyName: mysql-db
   replicationModeDetector:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/replication-mode-detector") $) }}:v0.28.0-rc.1'
   securityContext:
     runAsUser: 999
   stash:

--- a/charts/kubedb-catalog/templates/perconaxtradb/perconaxtradb-8.0.26.yaml
+++ b/charts/kubedb-catalog/templates/perconaxtradb/perconaxtradb-8.0.26.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/percona-xtradb-coordinator") $) }}:v0.14.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/percona-xtradb-coordinator") $) }}:v0.14.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "percona/percona-xtradb-cluster") $) }}:8.0.26'
   exporter:

--- a/charts/kubedb-catalog/templates/perconaxtradb/perconaxtradb-8.0.28.yaml
+++ b/charts/kubedb-catalog/templates/perconaxtradb/perconaxtradb-8.0.28.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/percona-xtradb-coordinator") $) }}:v0.14.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/percona-xtradb-coordinator") $) }}:v0.14.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "percona/percona-xtradb-cluster") $) }}:8.0.28'
   exporter:

--- a/charts/kubedb-catalog/templates/perconaxtradb/perconaxtradb-8.0.31.yaml
+++ b/charts/kubedb-catalog/templates/perconaxtradb/perconaxtradb-8.0.31.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/percona-xtradb-coordinator") $) }}:v0.14.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/percona-xtradb-coordinator") $) }}:v0.14.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "percona/percona-xtradb-cluster") $) }}:8.0.31'
   exporter:

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-10.16-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-10.16-official.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:10.16-alpine'
@@ -50,7 +50,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:10.16'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-10.19-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-10.19-official.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:10.19-bullseye'
@@ -50,7 +50,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:10.19-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-10.20-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-10.20-official.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:10.20-bullseye'
@@ -50,7 +50,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:10.20-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-11.11-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-11.11-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:11.11-alpine'
@@ -72,9 +72,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:11.11'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-11.14-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-11.14-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:11.14-alpine'
@@ -72,9 +72,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:11.14-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-11.15-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-11.15-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:11.15-alpine'
@@ -72,9 +72,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:11.15-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-11.19-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-11.19-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:11.19-alpine'
@@ -72,9 +72,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:11.19-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-11.20-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-11.20-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:11.20-alpine'
@@ -72,9 +72,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:11.20-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-12.10-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-12.10-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.10-alpine'
@@ -73,9 +73,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.10-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-12.13-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-12.13-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.13-alpine'
@@ -73,9 +73,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.13-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-12.14-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-12.14-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.14-alpine'
@@ -73,9 +73,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.14-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-12.15-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-12.15-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.15-alpine'
@@ -73,9 +73,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.15-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-12.6-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-12.6-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.6-alpine'
@@ -73,9 +73,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.6'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-12.9-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-12.9-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.9-alpine'
@@ -73,9 +73,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:12.9-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-13.10-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-13.10-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.10-alpine'
@@ -72,9 +72,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.10-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-13.11-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-13.11-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.11-alpine'
@@ -72,9 +72,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.11-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-13.2-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-13.2-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.2-alpine'
@@ -72,9 +72,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.2'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-13.5-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-13.5-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.5-alpine'
@@ -72,9 +72,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.5-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-13.6-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-13.6-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.6-alpine'
@@ -72,9 +72,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.6-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-13.9-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-13.9-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.9-alpine'
@@ -72,9 +72,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:13.9-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-14.1-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-14.1-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:14.1-alpine'
@@ -72,9 +72,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:14.1-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-14.2-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-14.2-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:14.2-alpine'
@@ -69,9 +69,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:14.2-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-14.6-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-14.6-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:14.6-alpine'
@@ -69,9 +69,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:14.6-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-14.7-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-14.7-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:14.7-alpine'
@@ -69,9 +69,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:14.7-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-14.8-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-14.8-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:14.8-alpine'
@@ -69,9 +69,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:14.8-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-15.1-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-15.1-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:15.1-alpine'
@@ -72,9 +72,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:15.1-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-15.2-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-15.2-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:15.2-alpine'
@@ -72,9 +72,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:15.2-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-15.3-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-15.3-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:15.3-alpine'
@@ -72,9 +72,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.0") $) }}'
+      image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "v0.2.0-rc.1") $) }}'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:15.3-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-9.6.21-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-9.6.21-official.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:9.6.21-alpine'
@@ -50,7 +50,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: debian
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:9.6.21'

--- a/charts/kubedb-catalog/templates/postgres/deprecated-postgres-9.6.24-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/deprecated-postgres-9.6.24-official.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:9.6.24-alpine'
@@ -50,7 +50,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "postgres") $) }}:9.6.24-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/postgres-10.23-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-10.23-official.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/postgres") $) }}:10.23-alpine'
@@ -48,7 +48,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bullseye
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/postgres") $) }}:10.23-bullseye'

--- a/charts/kubedb-catalog/templates/postgres/postgres-11.11-timescaledb.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-11.11-timescaledb.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.0_11.22-alpine'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.1_11.22-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "timescale/timescaledb") $) }}:2.1.0-pg11-oss'
   distribution: TimescaleDB

--- a/charts/kubedb-catalog/templates/postgres/postgres-11.14-postgis.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-11.14-postgis.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.0_11.22-bookworm'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.1_11.22-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "postgis/postgis") $) }}:11-3.1'
   distribution: PostGIS

--- a/charts/kubedb-catalog/templates/postgres/postgres-11.22-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-11.22-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.0_11.22-alpine'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.1_11.22-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/postgres") $) }}:11.22-alpine'
@@ -70,9 +70,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.0_11.22-bookworm'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.1_11.22-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bookworm
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/postgres") $) }}:11.22-bookworm'

--- a/charts/kubedb-catalog/templates/postgres/postgres-12.17-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-12.17-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.0_12.17-alpine'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.1_12.17-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/postgres") $) }}:12.17-alpine'
@@ -71,9 +71,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.0_12.17-bookworm'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.1_12.17-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bookworm
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/postgres") $) }}:12.17-bookworm'

--- a/charts/kubedb-catalog/templates/postgres/postgres-12.6-timescaledb.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-12.6-timescaledb.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.0_12.17-alpine'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.1_12.17-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "timescale/timescaledb") $) }}:2.1.0-pg12-oss'
   distribution: TimescaleDB

--- a/charts/kubedb-catalog/templates/postgres/postgres-12.9-postgis.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-12.9-postgis.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.0_12.17-bookworm'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.1_12.17-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "postgis/postgis") $) }}:12-3.1'
   distribution: PostGIS

--- a/charts/kubedb-catalog/templates/postgres/postgres-13.13-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-13.13-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.0_13.13-alpine'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.1_13.13-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/postgres") $) }}:13.13-alpine'
@@ -70,9 +70,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.0_13.13-bookworm'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.1_13.13-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bookworm
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/postgres") $) }}:13.13-bookworm'

--- a/charts/kubedb-catalog/templates/postgres/postgres-13.2-timescaledb.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-13.2-timescaledb.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.0_13.13-alpine'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.1_13.13-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "timescale/timescaledb") $) }}:2.1.0-pg13-oss'
   distribution: TimescaleDB

--- a/charts/kubedb-catalog/templates/postgres/postgres-13.5-postgis.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-13.5-postgis.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.0_13.13-bookworm'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.1_13.13-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "postgis/postgis") $) }}:13-3.1'
   distribution: PostGIS

--- a/charts/kubedb-catalog/templates/postgres/postgres-14.1-postgis.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-14.1-postgis.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.0_14.10-bookworm'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.1_14.10-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "postgis/postgis") $) }}:14-3.1'
   distribution: PostGIS

--- a/charts/kubedb-catalog/templates/postgres/postgres-14.1-timescaledb.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-14.1-timescaledb.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.0_14.10-alpine'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.1_14.10-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "timescale/timescaledb") $) }}:2.5.0-pg14-oss'
   distribution: TimescaleDB

--- a/charts/kubedb-catalog/templates/postgres/postgres-14.10-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-14.10-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.0_14.10-alpine'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.1_14.10-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/postgres") $) }}:14.10-alpine'
@@ -67,9 +67,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.0_14.10-bookworm'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.1_14.10-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bookworm
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/postgres") $) }}:14.10-bookworm'

--- a/charts/kubedb-catalog/templates/postgres/postgres-15.5-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-15.5-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.0_15.5-alpine'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.1_15.5-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/postgres") $) }}:15.5-alpine'
@@ -70,9 +70,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.0_15.5-bookworm'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.1_15.5-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bookworm
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/postgres") $) }}:15.5-bookworm'

--- a/charts/kubedb-catalog/templates/postgres/postgres-16.1-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-16.1-official.yaml
@@ -23,9 +23,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.0_16.1-alpine'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.1_16.1-alpine'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: alpine
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/postgres") $) }}:16.1-alpine'
@@ -70,9 +70,9 @@ spec:
         volumeSnapshot:
           name: volume-snapshot
     walg:
-      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.0_16.1-bookworm'
+      image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-archiver") $) }}:v0.2.0-rc.1_16.1-bookworm'
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/pg-coordinator") $) }}:v0.25.0-rc.1'
   db:
     baseOS: bookworm
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/postgres") $) }}:16.1-bookworm'

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-4.0.6.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-4.0.6.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:4.0.6'
   deprecated: true
@@ -36,7 +36,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:4.0.6-v1'
   deprecated: true
@@ -59,7 +59,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:4.0.6-v2'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-4.0.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-4.0.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:4.0'
   deprecated: true
@@ -36,7 +36,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:4.0-v1'
   deprecated: true
@@ -59,7 +59,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:4.0-v2'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-4.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-4.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:4'
   deprecated: true
@@ -36,7 +36,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:4-v1'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-5.0.3.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-5.0.3.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:5.0.3'
   deprecated: true
@@ -42,7 +42,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:5.0.3-v1'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-5.0.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-5.0.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:5.0'
   deprecated: true
@@ -42,7 +42,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:5.0-v1'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-6.0.18.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-6.0.18.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:6.0.18'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-6.0.6.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-6.0.6.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:6.0.6'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-6.2.11.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-6.2.11.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:6.2.11'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-6.2.5.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-6.2.5.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:6.2.5'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-6.2.7.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-6.2.7.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:6.2.7'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-6.2.8.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-6.2.8.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:6.2.8'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-7.0.10.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-7.0.10.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:7.0.10'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-7.0.4.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-7.0.4.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:7.0.4'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-7.0.5.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-7.0.5.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:7.0.5'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-7.0.6.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-7.0.6.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:7.0.6'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-7.0.9.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-7.0.9.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:7.0.9'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/deprecated-redis-7.2.0.yaml
+++ b/charts/kubedb-catalog/templates/redis/deprecated-redis-7.2.0.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.dockerLibrary" (merge (dict "_repo" "redis") $) }}:7.2.0'
   deprecated: true

--- a/charts/kubedb-catalog/templates/redis/redis-4.0.11.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-4.0.11.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis") $) }}:4.0.11'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-5.0.14.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-5.0.14.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/redis") $) }}:5.0.14-bullseye'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-6.0.20.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-6.0.20.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/redis") $) }}:6.0.20-bookworm'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-6.2.14.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-6.2.14.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/redis") $) }}:6.2.14-bookworm'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-7.0.14.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-7.0.14.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/redis") $) }}:7.0.14-bookworm'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-7.0.15.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-7.0.15.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/redis") $) }}:7.0.15-bookworm'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-7.2.3.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-7.2.3.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/redis") $) }}:7.2.3-bookworm'
   exporter:

--- a/charts/kubedb-catalog/templates/redis/redis-7.2.4.yaml
+++ b/charts/kubedb-catalog/templates/redis/redis-7.2.4.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-coordinator") $) }}:v0.20.0-rc.1'
   db:
     image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/redis") $) }}:7.2.4-bookworm'
   exporter:

--- a/charts/kubedb-catalog/templates/singlestore/singlestore-8.1.32.yaml
+++ b/charts/kubedb-catalog/templates/singlestore/singlestore-8.1.32.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- include "kubedb-catalog.labels" . | nindent 4 }}
 spec:
   coordinator:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/singlestore-coordinator") $) }}:v0.0.2'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/singlestore-coordinator") $) }}:v0.0.3'
   db:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "singlestore/node") $) }}:alma-8.1.32-e3d3cde6da'
   initContainer:

--- a/charts/kubedb-crd-manager/Chart.yaml
+++ b/charts/kubedb-crd-manager/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeDB CRD Manager by AppsCode
 name: kubedb-crd-manager
-version: v0.0.2
-appVersion: v0.0.2
+version: v0.0.3
+appVersion: v0.0.3
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-ops-manager-icon.png
 sources:

--- a/charts/kubedb-crd-manager/README.md
+++ b/charts/kubedb-crd-manager/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-crd-manager --version=v0.0.2
-$ helm upgrade -i kubedb-ops-manager appscode/kubedb-crd-manager -n kubedb --create-namespace --version=v0.0.2
+$ helm search repo appscode/kubedb-crd-manager --version=v0.0.3
+$ helm upgrade -i kubedb-ops-manager appscode/kubedb-crd-manager -n kubedb --create-namespace --version=v0.0.3
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB CRD Manager operator on a [Kubernetes](http://kubern
 To install/upgrade the chart with the release name `kubedb-ops-manager`:
 
 ```bash
-$ helm upgrade -i kubedb-ops-manager appscode/kubedb-crd-manager -n kubedb --create-namespace --version=v0.0.2
+$ helm upgrade -i kubedb-ops-manager appscode/kubedb-crd-manager -n kubedb --create-namespace --version=v0.0.3
 ```
 
 The command deploys a KubeDB CRD Manager operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -93,12 +93,12 @@ The following table lists the configurable parameters of the `kubedb-crd-manager
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-ops-manager appscode/kubedb-crd-manager -n kubedb --create-namespace --version=v0.0.2 --set registryFQDN=ghcr.io
+$ helm upgrade -i kubedb-ops-manager appscode/kubedb-crd-manager -n kubedb --create-namespace --version=v0.0.3 --set registryFQDN=ghcr.io
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-ops-manager appscode/kubedb-crd-manager -n kubedb --create-namespace --version=v0.0.2 --values values.yaml
+$ helm upgrade -i kubedb-ops-manager appscode/kubedb-crd-manager -n kubedb --create-namespace --version=v0.0.3 --values values.yaml
 ```

--- a/charts/kubedb-crds/Chart.yaml
+++ b/charts/kubedb-crds/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-crds
 description: KubeDB Custom Resource Definitions
 type: application
-version: v2024.1.26-rc.0
-appVersion: v2024.1.26-rc.0
+version: v2024.1.28-rc.1
+appVersion: v2024.1.28-rc.1
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-community-icon.png
 sources:

--- a/charts/kubedb-crds/README.md
+++ b/charts/kubedb-crds/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-crds --version=v2024.1.26-rc.0
-$ helm upgrade -i kubedb-crds appscode/kubedb-crds -n kubedb --create-namespace --version=v2024.1.26-rc.0
+$ helm search repo appscode/kubedb-crds --version=v2024.1.28-rc.1
+$ helm upgrade -i kubedb-crds appscode/kubedb-crds -n kubedb --create-namespace --version=v2024.1.28-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys KubeDB crds on a [Kubernetes](http://kubernetes.io) cluster u
 To install/upgrade the chart with the release name `kubedb-crds`:
 
 ```bash
-$ helm upgrade -i kubedb-crds appscode/kubedb-crds -n kubedb --create-namespace --version=v2024.1.26-rc.0
+$ helm upgrade -i kubedb-crds appscode/kubedb-crds -n kubedb --create-namespace --version=v2024.1.28-rc.1
 ```
 
 The command deploys KubeDB crds on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.

--- a/charts/kubedb-dashboard/Chart.yaml
+++ b/charts/kubedb-dashboard/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 description: KubeDB Dashboard by AppsCode
 name: kubedb-dashboard
 type: application
-version: v0.17.0-rc.0
-appVersion: v0.17.0-rc.0
+version: v0.17.0-rc.1
+appVersion: v0.17.0-rc.1
 home: https://github.com/kubedb
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-icon.png
 sources:

--- a/charts/kubedb-dashboard/README.md
+++ b/charts/kubedb-dashboard/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-dashboard --version=v0.17.0-rc.0
-$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.17.0-rc.0
+$ helm search repo appscode/kubedb-dashboard --version=v0.17.0-rc.1
+$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.17.0-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Dashboard operator on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `kubedb-dashboard`:
 
 ```bash
-$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.17.0-rc.0
+$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.17.0-rc.1
 ```
 
 The command deploys a KubeDB Dashboard operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -83,12 +83,12 @@ The following table lists the configurable parameters of the `kubedb-dashboard` 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.17.0-rc.0 --set replicaCount=1
+$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.17.0-rc.1 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.17.0-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-dashboard appscode/kubedb-dashboard -n kubedb --create-namespace --version=v0.17.0-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-grafana-dashboards/Chart.yaml
+++ b/charts/kubedb-grafana-dashboards/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-grafana-dashboards
 description: A Helm chart for kubedb-grafana-dashboards by AppsCode
 type: application
-version: v2024.1.26-rc.0
-appVersion: v2024.1.26-rc.0
+version: v2024.1.28-rc.1
+appVersion: v2024.1.28-rc.1
 home: https://github.com/kubedb
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-icon.png
 sources:

--- a/charts/kubedb-grafana-dashboards/README.md
+++ b/charts/kubedb-grafana-dashboards/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-grafana-dashboards --version=v2024.1.26-rc.0
-$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2024.1.26-rc.0
+$ helm search repo appscode/kubedb-grafana-dashboards --version=v2024.1.28-rc.1
+$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2024.1.28-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Grafana Dashboards on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `kubedb-grafana-dashboards`:
 
 ```bash
-$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2024.1.26-rc.0
+$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2024.1.28-rc.1
 ```
 
 The command deploys a KubeDB Grafana Dashboards on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -68,12 +68,12 @@ The following table lists the configurable parameters of the `kubedb-grafana-das
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2024.1.26-rc.0 --set resources=["elasticsearch","kafka","mariadb","mongodb","mysql","perconaxtradb","postgres","proxysql","redis"]
+$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2024.1.28-rc.1 --set resources=["elasticsearch","kafka","mariadb","mongodb","mysql","perconaxtradb","postgres","proxysql","redis"]
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2024.1.26-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-grafana-dashboards appscode/kubedb-grafana-dashboards -n kubeops --create-namespace --version=v2024.1.28-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-kubestash-catalog/Chart.yaml
+++ b/charts/kubedb-kubestash-catalog/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-kubestash-catalog
 description: KubeStash Catalog by AppsCode - Catalog of KubeStash Addons
 type: application
-version: v2024.1.26-rc.0
-appVersion: v2024.1.26-rc.0
+version: v2024.1.28-rc.1
+appVersion: v2024.1.28-rc.1
 home: https://kubestash.com
 icon: https://cdn.appscode.com/images/products/stash/stash-community-icon.png
 sources:

--- a/charts/kubedb-kubestash-catalog/README.md
+++ b/charts/kubedb-kubestash-catalog/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-kubestash-catalog --version=v2024.1.26-rc.0
-$ helm upgrade -i kubedb-kubestash-catalog appscode/kubedb-kubestash-catalog -n stash --create-namespace --version=v2024.1.26-rc.0
+$ helm search repo appscode/kubedb-kubestash-catalog --version=v2024.1.28-rc.1
+$ helm upgrade -i kubedb-kubestash-catalog appscode/kubedb-kubestash-catalog -n stash --create-namespace --version=v2024.1.28-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys Stash catalog on a [Kubernetes](http://kubernetes.io) cluster
 To install/upgrade the chart with the release name `kubedb-kubestash-catalog`:
 
 ```bash
-$ helm upgrade -i kubedb-kubestash-catalog appscode/kubedb-kubestash-catalog -n stash --create-namespace --version=v2024.1.26-rc.0
+$ helm upgrade -i kubedb-kubestash-catalog appscode/kubedb-kubestash-catalog -n stash --create-namespace --version=v2024.1.28-rc.1
 ```
 
 The command deploys Stash catalog on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -92,12 +92,12 @@ The following table lists the configurable parameters of the `kubedb-kubestash-c
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-kubestash-catalog appscode/kubedb-kubestash-catalog -n stash --create-namespace --version=v2024.1.26-rc.0 --set proxies.ghcr=ghcr.io
+$ helm upgrade -i kubedb-kubestash-catalog appscode/kubedb-kubestash-catalog -n stash --create-namespace --version=v2024.1.28-rc.1 --set proxies.ghcr=ghcr.io
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-kubestash-catalog appscode/kubedb-kubestash-catalog -n stash --create-namespace --version=v2024.1.26-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-kubestash-catalog appscode/kubedb-kubestash-catalog -n stash --create-namespace --version=v2024.1.28-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-kubestash-catalog/templates/elasticsearch/elasticsearch-backup.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/elasticsearch/elasticsearch-backup.yaml
@@ -20,5 +20,5 @@ spec:
   - --wait-timeout=${waitTimeout:={{ .Values.waitTimeout}}}
   - --es-args=${args:={{ .Values.elasticsearch.args }}}
   - --interim-data-dir=${interimDataDir:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/elasticsearch-restic-plugin") $) }}:v0.4.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/elasticsearch-restic-plugin") $) }}:v0.4.0-rc.1'
 {{ end }}

--- a/charts/kubedb-kubestash-catalog/templates/elasticsearch/elasticsearch-restore.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/elasticsearch/elasticsearch-restore.yaml
@@ -21,5 +21,5 @@ spec:
   - --wait-timeout=${waitTimeout:={{ .Values.waitTimeout}}}
   - --es-args=${args:={{ .Values.elasticsearch.args }}}
   - --interim-data-dir=${interimDataDir:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/elasticsearch-restic-plugin") $) }}:v0.4.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/elasticsearch-restic-plugin") $) }}:v0.4.0-rc.1'
 {{ end }}

--- a/charts/kubedb-kubestash-catalog/templates/kubedbmanifest/kubedbmanifest-backup.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/kubedbmanifest/kubedbmanifest-backup.yaml
@@ -12,5 +12,5 @@ spec:
   - --backupsession=${backupSession:=}
   - --enable-cache=${enableCache:=}
   - --scratch-dir=${scratchDir:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/kubedb-manifest-plugin") $) }}:v0.4.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/kubedb-manifest-plugin") $) }}:v0.4.0-rc.1'
 {{ end }}

--- a/charts/kubedb-kubestash-catalog/templates/kubedbmanifest/kubedbmanifest-restore.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/kubedbmanifest/kubedbmanifest-restore.yaml
@@ -13,5 +13,5 @@ spec:
   - --snapshot=${snapshot:=}
   - --enable-cache=${enableCache:=}
   - --scratch-dir=${scratchDir:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/kubedb-manifest-plugin") $) }}:v0.4.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/kubedb-manifest-plugin") $) }}:v0.4.0-rc.1'
 {{ end }}

--- a/charts/kubedb-kubestash-catalog/templates/mongodb/mongodb-backup.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/mongodb/mongodb-backup.yaml
@@ -22,5 +22,5 @@ spec:
   - --max-concurrency=${maxConcurrency:={{ .Values.mongodb.maxConcurrency}}}
   - --authentication-database=${authenticationDatabase:=admin}
   - --db-version=${dbVersion:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mongodb-restic-plugin") $) }}:v0.4.0-rc.0_${DB_VERSION}'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mongodb-restic-plugin") $) }}:v0.4.0-rc.1_${DB_VERSION}'
 {{ end }}

--- a/charts/kubedb-kubestash-catalog/templates/mongodb/mongodb-csi-snapshotter.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/mongodb/mongodb-csi-snapshotter.yaml
@@ -16,5 +16,5 @@ spec:
   - --namespace=${namespace:=default}
   - --volume-snapshot-class-name=${volumeSnapshotClassName:=}
   - --backupsession=${backupSession:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mongodb-csi-snapshotter-plugin") $) }}:v0.2.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mongodb-csi-snapshotter-plugin") $) }}:v0.2.0-rc.1'
 {{ end }}

--- a/charts/kubedb-kubestash-catalog/templates/mongodb/mongodb-restore.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/mongodb/mongodb-restore.yaml
@@ -23,5 +23,5 @@ spec:
   - --max-concurrency=${maxConcurrency:={{ .Values.mongodb.maxConcurrency}}}
   - --authentication-database=${authenticationDatabase:=admin}
   - --db-version=${dbVersion:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mongodb-restic-plugin") $) }}:v0.4.0-rc.0_${DB_VERSION}'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mongodb-restic-plugin") $) }}:v0.4.0-rc.1_${DB_VERSION}'
 {{ end }}

--- a/charts/kubedb-kubestash-catalog/templates/mysql/mysql-backup.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/mysql/mysql-backup.yaml
@@ -21,5 +21,5 @@ spec:
   - --mysql-args=${args:={{ .Values.mysql.args }}}
   - --db-version=${dbVersion:=}
   - --databases=${databases:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-restic-plugin") $) }}:v0.4.0-rc.0_${DB_VERSION}'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-restic-plugin") $) }}:v0.4.0-rc.1_${DB_VERSION}'
 {{ end }}

--- a/charts/kubedb-kubestash-catalog/templates/mysql/mysql-csi-snapshotter.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/mysql/mysql-csi-snapshotter.yaml
@@ -16,5 +16,5 @@ spec:
   - --namespace=${namespace:=default}
   - --volume-snapshot-class-name=${volumeSnapshotClassName:=}
   - --backupsession=${backupSession:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-csi-snapshotter-plugin") $) }}:v0.2.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-csi-snapshotter-plugin") $) }}:v0.2.0-rc.1'
 {{ end }}

--- a/charts/kubedb-kubestash-catalog/templates/mysql/mysql-restore.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/mysql/mysql-restore.yaml
@@ -21,5 +21,5 @@ spec:
   - --wait-timeout=${waitTimeout:={{ .Values.waitTimeout}}}
   - --mysql-args=${args:={{ .Values.mysql.args }}}
   - --db-version=${dbVersion:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-restic-plugin") $) }}:v0.4.0-rc.0_${DB_VERSION}'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/mysql-restic-plugin") $) }}:v0.4.0-rc.1_${DB_VERSION}'
 {{ end }}

--- a/charts/kubedb-kubestash-catalog/templates/opensearch/opensearch-backup.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/opensearch/opensearch-backup.yaml
@@ -20,5 +20,5 @@ spec:
   - --wait-timeout=${waitTimeout:={{ .Values.waitTimeout}}}
   - --os-args=${args:={{ .Values.opensearch.args }}}
   - --interim-data-dir=${interimDataDir:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/elasticsearch-restic-plugin") $) }}:v0.4.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/elasticsearch-restic-plugin") $) }}:v0.4.0-rc.1'
 {{ end }}

--- a/charts/kubedb-kubestash-catalog/templates/opensearch/opensearch-restore.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/opensearch/opensearch-restore.yaml
@@ -21,5 +21,5 @@ spec:
   - --wait-timeout=${waitTimeout:={{ .Values.waitTimeout}}}
   - --os-args=${args:={{ .Values.opensearch.args }}}
   - --interim-data-dir=${interimDataDir:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/elasticsearch-restic-plugin") $) }}:v0.4.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/elasticsearch-restic-plugin") $) }}:v0.4.0-rc.1'
 {{ end }}

--- a/charts/kubedb-kubestash-catalog/templates/postgres/postgres-backup.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/postgres/postgres-backup.yaml
@@ -21,5 +21,5 @@ spec:
   - --pg-args=${args:={{ .Values.postgres.args }}}
   - --backup-cmd=${backupCmd:=}
   - --user=${user:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-restic-plugin") $) }}:v0.4.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-restic-plugin") $) }}:v0.4.0-rc.1'
 {{ end }}

--- a/charts/kubedb-kubestash-catalog/templates/postgres/postgres-csi-snapshotter.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/postgres/postgres-csi-snapshotter.yaml
@@ -16,5 +16,5 @@ spec:
   - --namespace=${namespace:=default}
   - --volume-snapshot-class-name=${volumeSnapshotClassName:=}
   - --backupsession=${backupSession:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-csi-snapshotter-plugin") $) }}:v0.2.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-csi-snapshotter-plugin") $) }}:v0.2.0-rc.1'
 {{ end }}

--- a/charts/kubedb-kubestash-catalog/templates/postgres/postgres-restore.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/postgres/postgres-restore.yaml
@@ -21,5 +21,5 @@ spec:
   - --wait-timeout=${waitTimeout:={{ .Values.waitTimeout}}}
   - --pg-args=${args:={{ .Values.postgres.args }}}
   - --user=${user:=}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-restic-plugin") $) }}:v0.4.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-restic-plugin") $) }}:v0.4.0-rc.1'
 {{ end }}

--- a/charts/kubedb-kubestash-catalog/templates/redis/redis-backup.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/redis/redis-backup.yaml
@@ -19,5 +19,5 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --wait-timeout=${waitTimeout:={{ .Values.waitTimeout}}}
   - --redis-args=${args:={{ .Values.redis.args }}}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-restic-plugin") $) }}:v0.4.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-restic-plugin") $) }}:v0.4.0-rc.1'
 {{ end }}

--- a/charts/kubedb-kubestash-catalog/templates/redis/redis-restore.yaml
+++ b/charts/kubedb-kubestash-catalog/templates/redis/redis-restore.yaml
@@ -20,5 +20,5 @@ spec:
   - --scratch-dir=${scratchDir:=}
   - --wait-timeout=${waitTimeout:={{ .Values.waitTimeout}}}
   - --redis-args=${args:={{ .Values.redis.args }}}
-  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-restic-plugin") $) }}:v0.4.0-rc.0'
+  image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/redis-restic-plugin") $) }}:v0.4.0-rc.1'
 {{ end }}

--- a/charts/kubedb-metrics/Chart.yaml
+++ b/charts/kubedb-metrics/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-metrics
 description: KubeDB State Metrics
 type: application
-version: v2024.1.26-rc.0
-appVersion: v2024.1.26-rc.0
+version: v2024.1.28-rc.1
+appVersion: v2024.1.28-rc.1
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-community-icon.png
 sources:

--- a/charts/kubedb-metrics/README.md
+++ b/charts/kubedb-metrics/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-metrics --version=v2024.1.26-rc.0
-$ helm upgrade -i kubedb-metrics appscode/kubedb-metrics -n kubedb --create-namespace --version=v2024.1.26-rc.0
+$ helm search repo appscode/kubedb-metrics --version=v2024.1.28-rc.1
+$ helm upgrade -i kubedb-metrics appscode/kubedb-metrics -n kubedb --create-namespace --version=v2024.1.28-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys KubeDB metrics configurations on a [Kubernetes](http://kubern
 To install/upgrade the chart with the release name `kubedb-metrics`:
 
 ```bash
-$ helm upgrade -i kubedb-metrics appscode/kubedb-metrics -n kubedb --create-namespace --version=v2024.1.26-rc.0
+$ helm upgrade -i kubedb-metrics appscode/kubedb-metrics -n kubedb --create-namespace --version=v2024.1.28-rc.1
 ```
 
 The command deploys KubeDB metrics configurations on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.

--- a/charts/kubedb-ops-manager/Chart.yaml
+++ b/charts/kubedb-ops-manager/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeDB Ops Manager by AppsCode - Enterprise features for KubeDB
 name: kubedb-ops-manager
-version: v0.28.0-rc.0
-appVersion: v0.28.0-rc.0
+version: v0.28.0-rc.1
+appVersion: v0.28.0-rc.1
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-ops-manager-icon.png
 sources:

--- a/charts/kubedb-ops-manager/README.md
+++ b/charts/kubedb-ops-manager/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-ops-manager --version=v0.28.0-rc.0
-$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.28.0-rc.0
+$ helm search repo appscode/kubedb-ops-manager --version=v0.28.0-rc.1
+$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.28.0-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Ops Manager operator on a [Kubernetes](http://kubern
 To install/upgrade the chart with the release name `kubedb-ops-manager`:
 
 ```bash
-$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.28.0-rc.0
+$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.28.0-rc.1
 ```
 
 The command deploys a KubeDB Ops Manager operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -88,12 +88,12 @@ The following table lists the configurable parameters of the `kubedb-ops-manager
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.28.0-rc.0 --set replicaCount=1
+$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.28.0-rc.1 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.28.0-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-ops-manager appscode/kubedb-ops-manager -n kubedb --create-namespace --version=v0.28.0-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-opscenter/Chart.lock
+++ b/charts/kubedb-opscenter/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: kubedb-metrics
   repository: file://../kubedb-metrics
-  version: v2024.1.26-rc.0
+  version: v2024.1.28-rc.1
 - name: kubedb-ui-server
   repository: file://../kubedb-ui-server
-  version: v0.17.0-rc.0
+  version: v0.17.0-rc.1
 - name: kubedb-grafana-dashboards
   repository: file://../kubedb-grafana-dashboards
-  version: v2024.1.26-rc.0
-digest: sha256:4e0e8cdb031eb5648e8d53a7623a30c38074f31c90a9fb9c3848f3a6dda87621
-generated: "2024-01-27T06:21:53.141962166Z"
+  version: v2024.1.28-rc.1
+digest: sha256:58bc74c55bf75ac1357f619994fc496c86dffb293382dd6fb06c2c207b41762c
+generated: "2024-01-29T00:32:41.292883469Z"

--- a/charts/kubedb-opscenter/Chart.yaml
+++ b/charts/kubedb-opscenter/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-opscenter
 description: KubeDB Opscenter by AppsCode
 type: application
-version: v2024.1.26-rc.0
-appVersion: v2024.1.26-rc.0
+version: v2024.1.28-rc.1
+appVersion: v2024.1.28-rc.1
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-icon.png
 sources:
@@ -15,12 +15,12 @@ dependencies:
 - name: kubedb-metrics
   repository: file://../kubedb-metrics
   condition: kubedb-metrics.enabled
-  version: v2024.1.26-rc.0
+  version: v2024.1.28-rc.1
 - name: kubedb-ui-server
   repository: file://../kubedb-ui-server
   condition: kubedb-ui-server.enabled
-  version: v0.17.0-rc.0
+  version: v0.17.0-rc.1
 - name: kubedb-grafana-dashboards
   repository: file://../kubedb-grafana-dashboards
   condition: kubedb-grafana-dashboards.enabled
-  version: v2024.1.26-rc.0
+  version: v2024.1.28-rc.1

--- a/charts/kubedb-opscenter/README.md
+++ b/charts/kubedb-opscenter/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-opscenter --version=v2024.1.26-rc.0
-$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2024.1.26-rc.0
+$ helm search repo appscode/kubedb-opscenter --version=v2024.1.28-rc.1
+$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2024.1.28-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Opscenter on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `kubedb-opscenter`:
 
 ```bash
-$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2024.1.26-rc.0
+$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2024.1.28-rc.1
 ```
 
 The command deploys a KubeDB Opscenter on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -62,12 +62,12 @@ The following table lists the configurable parameters of the `kubedb-opscenter` 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2024.1.26-rc.0 --set global.registryFQDN=ghcr.io
+$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2024.1.28-rc.1 --set global.registryFQDN=ghcr.io
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2024.1.26-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-opscenter appscode/kubedb-opscenter -n kubedb --create-namespace --version=v2024.1.28-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-provider-aws/Chart.yaml
+++ b/charts/kubedb-provider-aws/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-provider-aws
 description: A Helm chart for KubeDB AWS Provider for Crossplane
 type: application
-version: v2024.1.26-rc.0
-appVersion: v0.3.0-rc.0
+version: v2024.1.28-rc.1
+appVersion: v0.3.0-rc.1
 home: https://github.com/kubedb/provider-aws
 icon: https://cdn.appscode.com/images/products/searchlight/icons/android-icon-192x192.png
 sources:

--- a/charts/kubedb-provider-aws/README.md
+++ b/charts/kubedb-provider-aws/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-provider-aws --version=v2024.1.26-rc.0
-$ helm upgrade -i kubedb-provider-aws appscode/kubedb-provider-aws -n crossplane-system --create-namespace --version=v2024.1.26-rc.0
+$ helm search repo appscode/kubedb-provider-aws --version=v2024.1.28-rc.1
+$ helm upgrade -i kubedb-provider-aws appscode/kubedb-provider-aws -n crossplane-system --create-namespace --version=v2024.1.28-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB AWS provider on a [Kubernetes](http://kubernetes.io)
 To install/upgrade the chart with the release name `kubedb-provider-aws`:
 
 ```bash
-$ helm upgrade -i kubedb-provider-aws appscode/kubedb-provider-aws -n crossplane-system --create-namespace --version=v2024.1.26-rc.0
+$ helm upgrade -i kubedb-provider-aws appscode/kubedb-provider-aws -n crossplane-system --create-namespace --version=v2024.1.28-rc.1
 ```
 
 The command deploys a KubeDB AWS provider on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -74,12 +74,12 @@ The following table lists the configurable parameters of the `kubedb-provider-aw
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-provider-aws appscode/kubedb-provider-aws -n crossplane-system --create-namespace --version=v2024.1.26-rc.0 --set replicaCount=1
+$ helm upgrade -i kubedb-provider-aws appscode/kubedb-provider-aws -n crossplane-system --create-namespace --version=v2024.1.28-rc.1 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-provider-aws appscode/kubedb-provider-aws -n crossplane-system --create-namespace --version=v2024.1.26-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-provider-aws appscode/kubedb-provider-aws -n crossplane-system --create-namespace --version=v2024.1.28-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-provider-azure/Chart.yaml
+++ b/charts/kubedb-provider-azure/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-provider-azure
 description: A Helm chart for KubeDB Azure Provider for Crossplane
 type: application
-version: v2024.1.26-rc.0
-appVersion: v0.3.0-rc.0
+version: v2024.1.28-rc.1
+appVersion: v0.3.0-rc.1
 home: https://github.com/kubedb/provider-azure
 icon: https://cdn.appscode.com/images/products/searchlight/icons/android-icon-192x192.png
 sources:

--- a/charts/kubedb-provider-azure/README.md
+++ b/charts/kubedb-provider-azure/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-provider-azure --version=v2024.1.26-rc.0
-$ helm upgrade -i kubedb-provider-azure appscode/kubedb-provider-azure -n crossplane-system --create-namespace --version=v2024.1.26-rc.0
+$ helm search repo appscode/kubedb-provider-azure --version=v2024.1.28-rc.1
+$ helm upgrade -i kubedb-provider-azure appscode/kubedb-provider-azure -n crossplane-system --create-namespace --version=v2024.1.28-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Azure provider on a [Kubernetes](http://kubernetes.i
 To install/upgrade the chart with the release name `kubedb-provider-azure`:
 
 ```bash
-$ helm upgrade -i kubedb-provider-azure appscode/kubedb-provider-azure -n crossplane-system --create-namespace --version=v2024.1.26-rc.0
+$ helm upgrade -i kubedb-provider-azure appscode/kubedb-provider-azure -n crossplane-system --create-namespace --version=v2024.1.28-rc.1
 ```
 
 The command deploys a KubeDB Azure provider on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -74,12 +74,12 @@ The following table lists the configurable parameters of the `kubedb-provider-az
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-provider-azure appscode/kubedb-provider-azure -n crossplane-system --create-namespace --version=v2024.1.26-rc.0 --set replicaCount=1
+$ helm upgrade -i kubedb-provider-azure appscode/kubedb-provider-azure -n crossplane-system --create-namespace --version=v2024.1.28-rc.1 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-provider-azure appscode/kubedb-provider-azure -n crossplane-system --create-namespace --version=v2024.1.26-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-provider-azure appscode/kubedb-provider-azure -n crossplane-system --create-namespace --version=v2024.1.28-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-provider-gcp/Chart.yaml
+++ b/charts/kubedb-provider-gcp/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-provider-gcp
 description: A Helm chart for KubeDB GCP Provider for Crossplane
 type: application
-version: v2024.1.26-rc.0
-appVersion: v0.3.0-rc.0
+version: v2024.1.28-rc.1
+appVersion: v0.3.0-rc.1
 home: https://github.com/kubedb/provider-gcp
 icon: https://cdn.appscode.com/images/products/searchlight/icons/android-icon-192x192.png
 sources:

--- a/charts/kubedb-provider-gcp/README.md
+++ b/charts/kubedb-provider-gcp/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-provider-gcp --version=v2024.1.26-rc.0
-$ helm upgrade -i kubedb-provider-gcp appscode/kubedb-provider-gcp -n crossplane-system --create-namespace --version=v2024.1.26-rc.0
+$ helm search repo appscode/kubedb-provider-gcp --version=v2024.1.28-rc.1
+$ helm upgrade -i kubedb-provider-gcp appscode/kubedb-provider-gcp -n crossplane-system --create-namespace --version=v2024.1.28-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB GCP provider on a [Kubernetes](http://kubernetes.io)
 To install/upgrade the chart with the release name `kubedb-provider-gcp`:
 
 ```bash
-$ helm upgrade -i kubedb-provider-gcp appscode/kubedb-provider-gcp -n crossplane-system --create-namespace --version=v2024.1.26-rc.0
+$ helm upgrade -i kubedb-provider-gcp appscode/kubedb-provider-gcp -n crossplane-system --create-namespace --version=v2024.1.28-rc.1
 ```
 
 The command deploys a KubeDB GCP provider on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -75,12 +75,12 @@ The following table lists the configurable parameters of the `kubedb-provider-gc
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-provider-gcp appscode/kubedb-provider-gcp -n crossplane-system --create-namespace --version=v2024.1.26-rc.0 --set replicaCount=1
+$ helm upgrade -i kubedb-provider-gcp appscode/kubedb-provider-gcp -n crossplane-system --create-namespace --version=v2024.1.28-rc.1 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-provider-gcp appscode/kubedb-provider-gcp -n crossplane-system --create-namespace --version=v2024.1.26-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-provider-gcp appscode/kubedb-provider-gcp -n crossplane-system --create-namespace --version=v2024.1.28-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-provisioner/Chart.yaml
+++ b/charts/kubedb-provisioner/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeDB Provisioner by AppsCode - Community features for KubeDB
 name: kubedb-provisioner
-version: v0.41.0-rc.0
-appVersion: v0.41.0-rc.0
+version: v0.41.0-rc.1
+appVersion: v0.41.0-rc.1
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-community-icon.png
 sources:

--- a/charts/kubedb-provisioner/README.md
+++ b/charts/kubedb-provisioner/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-provisioner --version=v0.41.0-rc.0
-$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.41.0-rc.0
+$ helm search repo appscode/kubedb-provisioner --version=v0.41.0-rc.1
+$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.41.0-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Provisioner operator on a [Kubernetes](http://kubern
 To install/upgrade the chart with the release name `kubedb-provisioner`:
 
 ```bash
-$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.41.0-rc.0
+$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.41.0-rc.1
 ```
 
 The command deploys a KubeDB Provisioner operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -86,12 +86,12 @@ The following table lists the configurable parameters of the `kubedb-provisioner
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.41.0-rc.0 --set replicaCount=1
+$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.41.0-rc.1 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.41.0-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-provisioner appscode/kubedb-provisioner -n kubedb --create-namespace --version=v0.41.0-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-schema-manager/Chart.yaml
+++ b/charts/kubedb-schema-manager/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 description: KubeDB Schema Manager by AppsCode
 name: kubedb-schema-manager
 type: application
-version: v0.17.0-rc.0
-appVersion: v0.17.0-rc.0
+version: v0.17.0-rc.1
+appVersion: v0.17.0-rc.1
 home: https://github.com/kubedb
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-icon.png
 sources:

--- a/charts/kubedb-schema-manager/README.md
+++ b/charts/kubedb-schema-manager/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-schema-manager --version=v0.17.0-rc.0
-$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.17.0-rc.0
+$ helm search repo appscode/kubedb-schema-manager --version=v0.17.0-rc.1
+$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.17.0-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB schema manager operator on a [Kubernetes](http://kub
 To install/upgrade the chart with the release name `kubedb-schema-manager`:
 
 ```bash
-$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.17.0-rc.0
+$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.17.0-rc.1
 ```
 
 The command deploys a KubeDB schema manager operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -83,12 +83,12 @@ The following table lists the configurable parameters of the `kubedb-schema-mana
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.17.0-rc.0 --set replicaCount=1
+$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.17.0-rc.1 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.17.0-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-schema-manager appscode/kubedb-schema-manager -n kubedb --create-namespace --version=v0.17.0-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-ui-server/Chart.yaml
+++ b/charts/kubedb-ui-server/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb-ui-server
 description: A Helm chart for kubedb-ui-server by AppsCode
 type: application
-version: v0.17.0-rc.0
-appVersion: v0.17.0-rc.0
+version: v0.17.0-rc.1
+appVersion: v0.17.0-rc.1
 home: https://github.com/kubedb/kubedb-ui-server
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-icon.png
 sources:

--- a/charts/kubedb-ui-server/README.md
+++ b/charts/kubedb-ui-server/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-ui-server --version=v0.17.0-rc.0
-$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.17.0-rc.0
+$ helm search repo appscode/kubedb-ui-server --version=v0.17.0-rc.1
+$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.17.0-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB UI Server on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `kubedb-ui-server`:
 
 ```bash
-$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.17.0-rc.0
+$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.17.0-rc.1
 ```
 
 The command deploys a KubeDB UI Server on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -84,12 +84,12 @@ The following table lists the configurable parameters of the `kubedb-ui-server` 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.17.0-rc.0 --set replicaCount=1
+$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.17.0-rc.1 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.17.0-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-ui-server appscode/kubedb-ui-server -n kubeops --create-namespace --version=v0.17.0-rc.1 --values values.yaml
 ```

--- a/charts/kubedb-webhook-server/Chart.yaml
+++ b/charts/kubedb-webhook-server/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: KubeDB Webhook Server by AppsCode
 name: kubedb-webhook-server
-version: v0.17.0-rc.0
-appVersion: v0.17.0-rc.0
+version: v0.17.0-rc.1
+appVersion: v0.17.0-rc.1
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-community-icon.png
 sources:

--- a/charts/kubedb-webhook-server/README.md
+++ b/charts/kubedb-webhook-server/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb-webhook-server --version=v0.17.0-rc.0
-$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.17.0-rc.0
+$ helm search repo appscode/kubedb-webhook-server --version=v0.17.0-rc.1
+$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.17.0-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB Provisioner operator on a [Kubernetes](http://kubern
 To install/upgrade the chart with the release name `kubedb-webhook-server`:
 
 ```bash
-$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.17.0-rc.0
+$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.17.0-rc.1
 ```
 
 The command deploys a KubeDB Provisioner operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -112,12 +112,12 @@ The following table lists the configurable parameters of the `kubedb-webhook-ser
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.17.0-rc.0 --set replicaCount=1
+$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.17.0-rc.1 --set replicaCount=1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.17.0-rc.0 --values values.yaml
+$ helm upgrade -i kubedb-webhook-server appscode/kubedb-webhook-server -n kubedb --create-namespace --version=v0.17.0-rc.1 --values values.yaml
 ```

--- a/charts/kubedb/Chart.lock
+++ b/charts/kubedb/Chart.lock
@@ -1,30 +1,30 @@
 dependencies:
 - name: kubedb-crd-manager
   repository: file://../kubedb-crd-manager
-  version: v0.0.2
+  version: v0.0.3
 - name: kubedb-provisioner
   repository: file://../kubedb-provisioner
-  version: v0.41.0-rc.0
+  version: v0.41.0-rc.1
 - name: kubedb-ops-manager
   repository: file://../kubedb-ops-manager
-  version: v0.28.0-rc.0
+  version: v0.28.0-rc.1
 - name: kubedb-autoscaler
   repository: file://../kubedb-autoscaler
-  version: v0.26.0-rc.0
+  version: v0.26.0-rc.1
 - name: kubedb-schema-manager
   repository: file://../kubedb-schema-manager
-  version: v0.17.0-rc.0
+  version: v0.17.0-rc.1
 - name: kubedb-webhook-server
   repository: file://../kubedb-webhook-server
-  version: v0.17.0-rc.0
+  version: v0.17.0-rc.1
 - name: kubedb-metrics
   repository: file://../kubedb-metrics
-  version: v2024.1.26-rc.0
+  version: v2024.1.28-rc.1
 - name: kubedb-catalog
   repository: file://../kubedb-catalog
-  version: v2024.1.26-rc.0
+  version: v2024.1.28-rc.1
 - name: kubedb-kubestash-catalog
   repository: file://../kubedb-kubestash-catalog
-  version: v2024.1.26-rc.0
-digest: sha256:7a7514003202bd49f2eb85d5ced0ee0a16f6c31ce7b09ad65a7559d2548fd90e
-generated: "2024-01-27T06:21:51.461894898Z"
+  version: v2024.1.28-rc.1
+digest: sha256:b9c77b21e008404e5bd26247e47e76b7d61db405714e8e8764c413022e576b70
+generated: "2024-01-29T00:32:40.893001525Z"

--- a/charts/kubedb/Chart.yaml
+++ b/charts/kubedb/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedb
 description: KubeDB by AppsCode - Production ready databases on Kubernetes
 type: application
-version: v2024.1.26-rc.0
-appVersion: v2024.1.26-rc.0
+version: v2024.1.28-rc.1
+appVersion: v2024.1.28-rc.1
 home: https://kubedb.com
 icon: https://cdn.appscode.com/images/products/kubedb/kubedb-icon.png
 sources:
@@ -15,36 +15,36 @@ dependencies:
 - name: kubedb-crd-manager
   repository: file://../kubedb-crd-manager
   condition: kubedb-crd-manager.enabled
-  version: v0.0.2
+  version: v0.0.3
 - name: kubedb-provisioner
   repository: file://../kubedb-provisioner
   condition: kubedb-provisioner.enabled
-  version: v0.41.0-rc.0
+  version: v0.41.0-rc.1
 - name: kubedb-ops-manager
   repository: file://../kubedb-ops-manager
   condition: kubedb-ops-manager.enabled
-  version: v0.28.0-rc.0
+  version: v0.28.0-rc.1
 - name: kubedb-autoscaler
   repository: file://../kubedb-autoscaler
   condition: kubedb-autoscaler.enabled
-  version: v0.26.0-rc.0
+  version: v0.26.0-rc.1
 - name: kubedb-schema-manager
   repository: file://../kubedb-schema-manager
   condition: kubedb-schema-manager.enabled
-  version: v0.17.0-rc.0
+  version: v0.17.0-rc.1
 - name: kubedb-webhook-server
   repository: file://../kubedb-webhook-server
   condition: kubedb-webhook-server.enabled
-  version: v0.17.0-rc.0
+  version: v0.17.0-rc.1
 - name: kubedb-metrics
   repository: file://../kubedb-metrics
   condition: kubedb-metrics.enabled
-  version: v2024.1.26-rc.0
+  version: v2024.1.28-rc.1
 - name: kubedb-catalog
   repository: file://../kubedb-catalog
   condition: kubedb-catalog.enabled
-  version: v2024.1.26-rc.0
+  version: v2024.1.28-rc.1
 - name: kubedb-kubestash-catalog
   repository: file://../kubedb-kubestash-catalog
   condition: kubedb-kubestash-catalog.enabled
-  version: v2024.1.26-rc.0
+  version: v2024.1.28-rc.1

--- a/charts/kubedb/README.md
+++ b/charts/kubedb/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/kubedb --version=v2024.1.26-rc.0
-$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2024.1.26-rc.0
+$ helm search repo appscode/kubedb --version=v2024.1.28-rc.1
+$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2024.1.28-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a KubeDB operator on a [Kubernetes](http://kubernetes.io) clu
 To install/upgrade the chart with the release name `kubedb`:
 
 ```bash
-$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2024.1.26-rc.0
+$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2024.1.28-rc.1
 ```
 
 The command deploys a KubeDB operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -88,12 +88,12 @@ The following table lists the configurable parameters of the `kubedb` chart and 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2024.1.26-rc.0 --set global.registry=kubedb
+$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2024.1.28-rc.1 --set global.registry=kubedb
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2024.1.26-rc.0 --values values.yaml
+$ helm upgrade -i kubedb appscode/kubedb -n kubedb --create-namespace --version=v2024.1.28-rc.1 --values values.yaml
 ```

--- a/charts/prepare-cluster/Chart.yaml
+++ b/charts/prepare-cluster/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: prepare-cluster
 description: Prepare Kubernetes Cluster by AppsCode
 type: application
-version: v2024.1.26-rc.0
-appVersion: v2024.1.26-rc.0
+version: v2024.1.28-rc.1
+appVersion: v2024.1.28-rc.1
 home: https://appscode.com
 icon: https://cdn.appscode.com/images/products/appscode/appscode-512x512.png
 sources:

--- a/charts/prepare-cluster/README.md
+++ b/charts/prepare-cluster/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add appscode https://charts.appscode.com/stable/
 $ helm repo update
-$ helm search repo appscode/prepare-cluster --version=v2024.1.26-rc.0
-$ helm upgrade -i prepare-cluster appscode/prepare-cluster -n kube-system --create-namespace --version=v2024.1.26-rc.0
+$ helm search repo appscode/prepare-cluster --version=v2024.1.28-rc.1
+$ helm upgrade -i prepare-cluster appscode/prepare-cluster -n kube-system --create-namespace --version=v2024.1.28-rc.1
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Kubernetes Job on a [Kubernetes](http://kubernetes.io) clus
 To install/upgrade the chart with the release name `prepare-cluster`:
 
 ```bash
-$ helm upgrade -i prepare-cluster appscode/prepare-cluster -n kube-system --create-namespace --version=v2024.1.26-rc.0
+$ helm upgrade -i prepare-cluster appscode/prepare-cluster -n kube-system --create-namespace --version=v2024.1.28-rc.1
 ```
 
 The command deploys a Kubernetes Job on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -75,12 +75,12 @@ The following table lists the configurable parameters of the `prepare-cluster` c
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i prepare-cluster appscode/prepare-cluster -n kube-system --create-namespace --version=v2024.1.26-rc.0 --set preparer.repository=tianon/toybox
+$ helm upgrade -i prepare-cluster appscode/prepare-cluster -n kube-system --create-namespace --version=v2024.1.28-rc.1 --set preparer.repository=tianon/toybox
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i prepare-cluster appscode/prepare-cluster -n kube-system --create-namespace --version=v2024.1.26-rc.0 --values values.yaml
+$ helm upgrade -i prepare-cluster appscode/prepare-cluster -n kube-system --create-namespace --version=v2024.1.28-rc.1 --values values.yaml
 ```


### PR DESCRIPTION
ProductLine: KubeDB
Release: v2024.1.28-rc.1
Release-tracker: https://github.com/kubedb/CHANGELOG/pull/83
Signed-off-by: 1gtm <1gtm@appscode.com>