### PR TITLE
Replace random reload annotations with serving certs chechsum

### DIFF
--- a/charts/kubedb-autoscaler/templates/statefulset.yaml
+++ b/charts/kubedb-autoscaler/templates/statefulset.yaml
@@ -45,7 +45,6 @@ spec:
       labels:
         {{- include "kubedb-autoscaler.selectorLabels" . | nindent 8 }}
       annotations:
-        reload: {{ randAlpha 8 }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kubedb-dashboard/templates/deployment.yaml
+++ b/charts/kubedb-dashboard/templates/deployment.yaml
@@ -22,7 +22,6 @@ spec:
       labels:
         {{- include "kubedb-dashboard.selectorLabels" . | nindent 8 }}
       annotations:
-        reload: {{ randAlpha 8 }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kubedb-ops-manager/templates/statefulset.yaml
+++ b/charts/kubedb-ops-manager/templates/statefulset.yaml
@@ -45,7 +45,6 @@ spec:
       labels:
         {{- include "kubedb-ops-manager.selectorLabels" . | nindent 8 }}
       annotations:
-        reload: {{ randAlpha 8 }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kubedb-provisioner/templates/statefulset.yaml
+++ b/charts/kubedb-provisioner/templates/statefulset.yaml
@@ -45,7 +45,6 @@ spec:
       labels:
         {{- include "kubedb-provisioner.selectorLabels" . | nindent 8 }}
       annotations:
-        reload: {{ randAlpha 8 }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kubedb-schema-manager/templates/statefulset.yaml
+++ b/charts/kubedb-schema-manager/templates/statefulset.yaml
@@ -45,7 +45,6 @@ spec:
       labels:
         {{- include "kubedb-schema-manager.selectorLabels" . | nindent 8 }}
       annotations:
-        reload: {{ randAlpha 8 }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kubedb-ui-server/templates/deployment.yaml
+++ b/charts/kubedb-ui-server/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       labels:
         {{- include "kubedb-ui-server.selectorLabels" . | nindent 8 }}
       annotations:
-        reload: {{ randAlpha 8 }}
+        checksum/serving-cert: {{ include (print $.Template.BasePath "/apiregistration.yaml") . | sha256sum }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/kubedb-webhook-server/templates/deployment.yaml
+++ b/charts/kubedb-webhook-server/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
       labels:
         {{- include "kubedb-webhook-server.labels" . | nindent 8 }}
       annotations:
-        reload: {{ randAlpha 8 }}
+        checksum/serving-cert: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
## What
- remove `reload: {{ randAlpha 8 }}` pod template annotations from:
  - charts/kubedb-autoscaler/templates/statefulset.yaml
  - charts/kubedb-dashboard/templates/deployment.yaml
  - charts/kubedb-ops-manager/templates/statefulset.yaml
  - charts/kubedb-provisioner/templates/statefulset.yaml
  - charts/kubedb-schema-manager/templates/statefulset.yaml
- replace `reload` with checksum annotations in:
  - charts/kubedb-ui-server/templates/deployment.yaml
    - `checksum/serving-cert: {{ include (print $.Template.BasePath "/apiregistration.yaml") . | sha256sum }}`
  - charts/kubedb-webhook-server/templates/deployment.yaml
    - `checksum/serving-cert: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}`

## Commit
- `aee12929e9b4216ce048ca053ca8ee7f33cdb3cc`
- includes sign-off: `Signed-off-by: Tamal Saha <tamal@appscode.com>`

## Validation
- `helm lint` and `helm template` passed for:
  - charts/kubedb-webhook-server
  - charts/kubedb-provisioner
  - charts/kubedb-dashboard
  - charts/kubedb-autoscaler
  - charts/kubedb-ui-server
  - charts/kubedb-schema-manager
  - charts/kubedb-ops-manager
