### PR TITLE
Add raw-dhi catalog generated from Docker Hardened Images

### DIFF
--- a/catalog/kubedb/gen-raw-dhi.py
+++ b/catalog/kubedb/gen-raw-dhi.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""
+Generate catalog/kubedb/raw-dhi/ from catalog/kubedb/raw/.
+
+For each non-deprecated YAML in raw/, replace spec.db.image with the
+Docker Hardened Image (DHI) equivalent if one exists. Files/documents
+for DB types or versions without a DHI equivalent are dropped.
+"""
+
+import os
+import re
+import sys
+
+RAW_DIR = os.path.join(os.path.dirname(__file__), "raw")
+OUT_DIR = os.path.join(os.path.dirname(__file__), "raw-dhi")
+
+# DHI image name per directory (db type). None means no DHI support.
+DHI_IMAGE_MAP = {
+    "elasticsearch": None,   # handled specially by distribution
+    "mysql":         "dhi.io/mysql",
+    "mongodb":       "dhi.io/mongodb",
+    "redis":         "dhi.io/redis",
+    "postgres":      "dhi.io/postgres",
+    "memcached":     "dhi.io/memcached",
+    "kafka":         "dhi.io/kafka",
+    "rabbitmq":      "dhi.io/rabbitmq",
+    "clickhouse":    "dhi.io/clickhouse-server",
+    "zookeeper":     "dhi.io/zookeeper",
+}
+
+# Per db-type: function(version_str) -> bool, is the version supported by DHI?
+# version_str is e.g. "8.0.10", "17.9", "4.2.4"
+# We use major version comparison where appropriate.
+def parse_version(v):
+    parts = v.split(".")
+    try:
+        return tuple(int(x) for x in parts)
+    except ValueError:
+        return (0,)
+
+def supported_mysql(v):
+    t = parse_version(v)
+    # 8.0.x, 8.4.x, 9.6.x
+    if t[0] == 8 and t[1] in (0, 4):
+        return True
+    if t[0] == 9 and t[1] == 6:
+        return True
+    return False
+
+def supported_mongodb(v):
+    t = parse_version(v)
+    # 8.0.x, 8.2.x
+    return t[0] == 8 and t[1] in (0, 2)
+
+def supported_redis(v):
+    t = parse_version(v)
+    # 8.x only
+    return t[0] == 8
+
+def supported_postgres(v):
+    t = parse_version(v)
+    # 10 through 18
+    return 10 <= t[0] <= 18
+
+def supported_memcached(v):
+    t = parse_version(v)
+    # 1.6.x
+    return t[0] == 1 and t[1] == 6
+
+def supported_kafka(v):
+    t = parse_version(v)
+    # 4.1.x, 4.2.x
+    return t[0] == 4 and t[1] in (1, 2)
+
+def supported_rabbitmq(v):
+    t = parse_version(v)
+    # 4.2.x
+    return t[0] == 4 and t[1] == 2
+
+def supported_clickhouse(v):
+    t = parse_version(v)
+    # 25.3.x, 25.8.x, 26.2.x
+    if t[0] == 25 and t[1] in (3, 7, 8, 12):
+        return True
+    if t[0] == 26 and t[1] in (2,):
+        return True
+    return False
+
+def supported_zookeeper(v):
+    t = parse_version(v)
+    # 3.8.x, 3.9.x
+    return t[0] == 3 and t[1] in (8, 9)
+
+# elasticsearch is handled specially by distribution
+def supported_elasticsearch_elasticstack(v):
+    t = parse_version(v)
+    # 8.19.x, 9.1.x, 9.2.x, 9.3.x
+    if t[0] == 8 and t[1] == 19:
+        return True
+    if t[0] == 9 and t[1] in (1, 2, 3):
+        return True
+    return False
+
+def supported_opensearch(v):
+    t = parse_version(v)
+    # only 3.x
+    return t[0] == 3
+
+VERSION_SUPPORT = {
+    "mysql":      supported_mysql,
+    "mongodb":    supported_mongodb,
+    "redis":      supported_redis,
+    "postgres":   supported_postgres,
+    "memcached":  supported_memcached,
+    "kafka":      supported_kafka,
+    "rabbitmq":   supported_rabbitmq,
+    "clickhouse": supported_clickhouse,
+    "zookeeper":  supported_zookeeper,
+}
+
+
+def extract_tag(image_ref):
+    """Extract tag from image reference like 'registry/repo:tag' -> 'tag'"""
+    if ":" not in image_ref:
+        return ""
+    return image_ref.rsplit(":", 1)[1]
+
+
+def strip_os_suffix(tag):
+    """Strip OS/variant suffix from tag: '17.9-alpine' -> '17.9', '8.0.4-bookworm' -> '8.0.4'"""
+    return re.split(r"[-](?:alpine|bookworm|jammy|focal|bullseye|buster|debian|management|enterprise|official|ubi|ubi8|ubi9)", tag)[0]
+
+
+def to_major_minor(version):
+    """Convert 'major.minor.patch' to 'major.minor', e.g. '8.0.4' -> '8.0', '17.9' -> '17.9'"""
+    parts = version.split(".")
+    if len(parts) >= 3:
+        return ".".join(parts[:2])
+    return version
+
+
+def get_dhi_image(db_type, version, distribution=None):
+    """
+    Returns the DHI image string for a given db_type+version, or None if not supported.
+    distribution is used for elasticsearch (ElasticStack vs OpenSearch).
+    """
+    if db_type == "elasticsearch":
+        dist = (distribution or "").lower()
+        if "elasticstack" in dist or "xpack" in dist or "searchguard" in dist:
+            if not supported_elasticsearch_elasticstack(version):
+                return None
+            return f"dhi.io/elasticsearch:{version}"
+        elif "opensearch" in dist:
+            if not supported_opensearch(version):
+                return None
+            return f"dhi.io/opensearch:{version}"
+        else:
+            return None
+
+    dhi_name = DHI_IMAGE_MAP.get(db_type)
+    if dhi_name is None:
+        return None
+
+    support_fn = VERSION_SUPPORT.get(db_type)
+    if support_fn and not support_fn(version):
+        return None
+
+    return f"{dhi_name}:{version}"
+
+
+def process_document(doc_text, db_type):
+    """
+    Process a single YAML document (as raw text) and return modified text or None if should be dropped.
+    We use regex-based replacement to preserve comments and formatting.
+    """
+    # Skip deprecated documents
+    if re.search(r"^\s+deprecated:\s+true\s*$", doc_text, re.MULTILINE):
+        return None
+
+    # Find spec.db.image
+    db_image_match = re.search(r"(^  db:\n(?:[ \t]+\S[^\n]*\n)*?    image:\s*)(\S+)", doc_text, re.MULTILINE)
+    if not db_image_match:
+        # No db image field - skip
+        return None
+
+    current_image = db_image_match.group(2)
+    tag = extract_tag(current_image)
+    if not tag:
+        return None
+
+    version = strip_os_suffix(tag)
+
+    # Get distribution for elasticsearch
+    distribution = None
+    dist_match = re.search(r"^\s+distribution:\s+(\S+)", doc_text, re.MULTILINE)
+    if dist_match:
+        distribution = dist_match.group(1)
+
+    dhi_image = get_dhi_image(db_type, version, distribution)
+    if dhi_image is None:
+        return None
+
+    # Use major.minor as DHI tag when the full version has a patch component
+    # DHI uses major.minor tags that track the latest patch (e.g. dhi.io/redis:8.0)
+    mm_version = to_major_minor(version)
+    if mm_version != version:
+        # Rebuild the image ref with major.minor tag
+        dhi_base = dhi_image.rsplit(":", 1)[0]
+        dhi_image = f"{dhi_base}:{mm_version}"
+
+    # Replace the image
+    new_doc = doc_text[:db_image_match.start(2)] + dhi_image + doc_text[db_image_match.end(2):]
+    return new_doc
+
+
+def process_file(src_path, db_type):
+    """
+    Process a raw YAML file. Returns a list of processed document strings (may be empty).
+    """
+    with open(src_path, "r") as f:
+        content = f.read()
+
+    # Split on document separators (keep ---)
+    # Split by "^---" but preserve the separator with each doc
+    raw_docs = re.split(r"(?m)^---\n", content)
+
+    processed_docs = []
+    for i, doc in enumerate(raw_docs):
+        if not doc.strip():
+            continue
+        result = process_document(doc, db_type)
+        if result is not None:
+            processed_docs.append(result)
+
+    return processed_docs
+
+
+def main():
+    db_types = list(DHI_IMAGE_MAP.keys()) + ["elasticsearch"]
+    files_written = 0
+    files_skipped = 0
+
+    for db_type in sorted(set(db_types)):
+        src_dir = os.path.join(RAW_DIR, db_type)
+        if not os.path.isdir(src_dir):
+            continue
+
+        out_dir = os.path.join(OUT_DIR, db_type)
+
+        for filename in sorted(os.listdir(src_dir)):
+            if not filename.endswith(".yaml"):
+                continue
+            # Skip deprecated files
+            if filename.startswith("deprecated-"):
+                continue
+            # Skip psp files
+            if filename.endswith("-psp.yaml"):
+                continue
+
+            src_path = os.path.join(src_dir, filename)
+            docs = process_file(src_path, db_type)
+
+            if not docs:
+                files_skipped += 1
+                continue
+
+            os.makedirs(out_dir, exist_ok=True)
+            out_path = os.path.join(out_dir, filename)
+            with open(out_path, "w") as f:
+                for i, doc in enumerate(docs):
+                    if i > 0:
+                        f.write("---\n")
+                    f.write(doc)
+                    if not doc.endswith("\n"):
+                        f.write("\n")
+
+            files_written += 1
+
+    print(f"Done. Files written: {files_written}, skipped (no DHI support): {files_skipped}")
+
+
+if __name__ == "__main__":
+    main()

--- a/catalog/kubedb/raw-dhi/clickhouse/clickhouse-25.12.3.yaml
+++ b/catalog/kubedb/raw-dhi/clickhouse/clickhouse-25.12.3.yaml
@@ -1,0 +1,17 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: ClickHouseVersion
+metadata:
+  name: 25.12.3
+spec:
+  clickHouseKeeper:
+    image: docker.io/clickhouse/clickhouse-keeper:25.12.3
+  db:
+    image: dhi.io/clickhouse-server:25.12
+  initContainer:
+    image: ghcr.io/kubedb/clickhouse-init:24.4.1-v3
+  securityContext:
+    runAsUser: 101
+  updateConstraints:
+    allowlist:
+    - '>= 25.12.3'
+  version: 25.12.3

--- a/catalog/kubedb/raw-dhi/clickhouse/clickhouse-25.3.yaml
+++ b/catalog/kubedb/raw-dhi/clickhouse/clickhouse-25.3.yaml
@@ -1,0 +1,17 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: ClickHouseVersion
+metadata:
+  name: "25.3"
+spec:
+  clickHouseKeeper:
+    image: dhi.io/clickhouse-keeper:25.3
+  db:
+    image: dhi.io/clickhouse-server:25.3
+  initContainer:
+    image: ghcr.io/kubedb/clickhouse-init:24.4.1-v3
+  securityContext:
+    runAsUser: 101
+  updateConstraints:
+    allowlist:
+      - '>= 25.3'
+  version: "25.3"

--- a/catalog/kubedb/raw-dhi/clickhouse/clickhouse-25.7.1.yaml
+++ b/catalog/kubedb/raw-dhi/clickhouse/clickhouse-25.7.1.yaml
@@ -1,0 +1,17 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: ClickHouseVersion
+metadata:
+  name: 25.7.1
+spec:
+  clickHouseKeeper:
+    image: docker.io/clickhouse/clickhouse-keeper:25.7.1
+  db:
+    image: dhi.io/clickhouse-server:25.7
+  initContainer:
+    image: ghcr.io/kubedb/clickhouse-init:24.4.1-v3
+  securityContext:
+    runAsUser: 101
+  updateConstraints:
+    allowlist:
+    - '>= 25.7.1'
+  version: 25.7.1

--- a/catalog/kubedb/raw-dhi/clickhouse/clickhouse-26.2.6.yaml
+++ b/catalog/kubedb/raw-dhi/clickhouse/clickhouse-26.2.6.yaml
@@ -1,0 +1,17 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: ClickHouseVersion
+metadata:
+  name: 26.2.6
+spec:
+  clickHouseKeeper:
+    image: docker.io/clickhouse/clickhouse-keeper:26.2.6
+  db:
+    image: dhi.io/clickhouse-server:26.2
+  initContainer:
+    image: ghcr.io/kubedb/clickhouse-init:24.4.1-v3
+  securityContext:
+    runAsUser: 101
+  updateConstraints:
+    allowlist:
+    - '>= 26.2.6'
+  version: 26.2.6

--- a/catalog/kubedb/raw-dhi/elasticsearch/elasticsearch-3.1.0-opensearch.yaml
+++ b/catalog/kubedb/raw-dhi/elasticsearch/elasticsearch-3.1.0-opensearch.yaml
@@ -1,0 +1,39 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: ElasticsearchVersion
+metadata:
+  name: opensearch-3.1.0
+spec:
+  authPlugin: OpenSearch
+  dashboard:
+    image: ghcr.io/appscode-images/opensearch-dashboards:3.1.0
+  dashboardInitContainer:
+    yqImage: ghcr.io/kubedb/elasticsearch-dashboard-init:3.1.0-opensearch-v2025.07.07
+  db:
+    image: dhi.io/opensearch:3.1
+  distribution: OpenSearch
+  exporter:
+    image: docker.io/prometheuscommunity/elasticsearch-exporter:v1.10.0
+  initContainer:
+    image: docker.io/tianon/toybox:0.8.11
+    yqImage: ghcr.io/kubedb/elasticsearch-init:3.1-opensearch-v2026.1.15
+  podSecurityPolicies:
+    databasePolicyName: elasticsearch-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 1000
+  stash:
+    addon:
+      backupTask:
+        name: elasticsearch-backup-7.14.0
+        params:
+        - name: args
+          value: --match=^(?![.])(?!security-auditlog)(?!kubedb-system).+
+      restoreTask:
+        name: elasticsearch-restore-7.14.0
+        params:
+        - name: args
+          value: --match=^(?![.])(?!security-auditlog)(?!kubedb-system)(?!top_queries).+
+  updateConstraints:
+    allowlist:
+    - '>= 3.1.0, < 3.5.0'
+  version: 3.1.0

--- a/catalog/kubedb/raw-dhi/elasticsearch/elasticsearch-3.4.0-opensearch.yaml
+++ b/catalog/kubedb/raw-dhi/elasticsearch/elasticsearch-3.4.0-opensearch.yaml
@@ -1,0 +1,39 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: ElasticsearchVersion
+metadata:
+  name: opensearch-3.4.0
+spec:
+  authPlugin: OpenSearch
+  dashboard:
+    image: ghcr.io/appscode-images/opensearch-dashboards:3.4.0
+  dashboardInitContainer:
+    yqImage: ghcr.io/kubedb/elasticsearch-dashboard-init:3.1.0-opensearch-v2025.07.07
+  db:
+    image: dhi.io/opensearch:3.4
+  distribution: OpenSearch
+  exporter:
+    image: docker.io/prometheuscommunity/elasticsearch-exporter:v1.10.0
+  initContainer:
+    image: docker.io/tianon/toybox:0.8.11
+    yqImage: ghcr.io/kubedb/elasticsearch-init:3.1-opensearch-v2026.1.15
+  podSecurityPolicies:
+    databasePolicyName: elasticsearch-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 1000
+  stash:
+    addon:
+      backupTask:
+        name: elasticsearch-backup-7.14.0
+        params:
+        - name: args
+          value: --match=^(?![.])(?!security-auditlog)(?!kubedb-system).+
+      restoreTask:
+        name: elasticsearch-restore-7.14.0
+        params:
+        - name: args
+          value: --match=^(?![.])(?!security-auditlog)(?!kubedb-system)(?!top_queries).+
+  updateConstraints:
+    allowlist:
+    - '>= 3.4.0, < 3.5.0'
+  version: 3.4.0

--- a/catalog/kubedb/raw-dhi/elasticsearch/elasticsearch-8.19.9-elasticstack.yaml
+++ b/catalog/kubedb/raw-dhi/elasticsearch/elasticsearch-8.19.9-elasticstack.yaml
@@ -1,0 +1,39 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: ElasticsearchVersion
+metadata:
+  name: xpack-8.19.9
+spec:
+  authPlugin: X-Pack
+  dashboard:
+    image: ghcr.io/appscode-images/kibana:8.19.9
+  dashboardInitContainer:
+    yqImage: ghcr.io/kubedb/elasticsearch-dashboard-init:8.18.2-xpack-v2025.07.07
+  db:
+    image: dhi.io/elasticsearch:8.19
+  distribution: ElasticStack
+  exporter:
+    image: docker.io/prometheuscommunity/elasticsearch-exporter:v1.10.0
+  initContainer:
+    image: docker.io/tianon/toybox:0.8.11
+    yqImage: ghcr.io/kubedb/elasticsearch-init:8.18.2-xpack-v2025.12.12
+  podSecurityPolicies:
+    databasePolicyName: elasticsearch-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 1000
+  stash:
+    addon:
+      backupTask:
+        name: elasticsearch-backup-8.2.0
+        params:
+        - name: args
+          value: --match=^(?![.])(?!apm-agent-configuration)(?!kubedb-system).+
+      restoreTask:
+        name: elasticsearch-restore-8.2.0
+        params:
+        - name: args
+          value: --match=^(?![.])(?!apm-agent-configuration)(?!kubedb-system).+
+  updateConstraints:
+    allowlist:
+    - '>= 8.19.9, < 9.2.4'
+  version: 8.19.9

--- a/catalog/kubedb/raw-dhi/elasticsearch/elasticsearch-9.1.4-elasticstack.yaml
+++ b/catalog/kubedb/raw-dhi/elasticsearch/elasticsearch-9.1.4-elasticstack.yaml
@@ -1,0 +1,39 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: ElasticsearchVersion
+metadata:
+  name: xpack-9.1.4
+spec:
+  authPlugin: X-Pack
+  dashboard:
+    image: ghcr.io/appscode-images/kibana:9.1.4
+  dashboardInitContainer:
+    yqImage: ghcr.io/kubedb/elasticsearch-dashboard-init:9.1.4-xpack-v2025.09.24
+  db:
+    image: dhi.io/elasticsearch:9.1
+  distribution: ElasticStack
+  exporter:
+    image: docker.io/prometheuscommunity/elasticsearch-exporter:v1.10.0
+  initContainer:
+    image: docker.io/tianon/toybox:0.8.11
+    yqImage: ghcr.io/kubedb/elasticsearch-init:9.1.4-xpack-v2025.12.12
+  podSecurityPolicies:
+    databasePolicyName: elasticsearch-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 1000
+  stash:
+    addon:
+      backupTask:
+        name: elasticsearch-backup-8.2.0
+        params:
+        - name: args
+          value: --match=^(?![.])(?!apm-agent-configuration)(?!kubedb-system).+
+      restoreTask:
+        name: elasticsearch-restore-8.2.0
+        params:
+        - name: args
+          value: --match=^(?![.])(?!apm-agent-configuration)(?!kubedb-system).+
+  updateConstraints:
+    allowlist:
+    - '>= 9.1.4, < 9.2.4'
+  version: 9.1.4

--- a/catalog/kubedb/raw-dhi/elasticsearch/elasticsearch-9.1.9-elasticstack.yaml
+++ b/catalog/kubedb/raw-dhi/elasticsearch/elasticsearch-9.1.9-elasticstack.yaml
@@ -1,0 +1,39 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: ElasticsearchVersion
+metadata:
+  name: xpack-9.1.9
+spec:
+  authPlugin: X-Pack
+  dashboard:
+    image: ghcr.io/appscode-images/kibana:9.1.9
+  dashboardInitContainer:
+    yqImage: ghcr.io/kubedb/elasticsearch-dashboard-init:9.1.4-xpack-v2025.09.24
+  db:
+    image: dhi.io/elasticsearch:9.1
+  distribution: ElasticStack
+  exporter:
+    image: docker.io/prometheuscommunity/elasticsearch-exporter:v1.10.0
+  initContainer:
+    image: docker.io/tianon/toybox:0.8.11
+    yqImage: ghcr.io/kubedb/elasticsearch-init:9.1.4-xpack-v2025.12.12
+  podSecurityPolicies:
+    databasePolicyName: elasticsearch-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 1000
+  stash:
+    addon:
+      backupTask:
+        name: elasticsearch-backup-8.2.0
+        params:
+        - name: args
+          value: --match=^(?![.])(?!apm-agent-configuration)(?!kubedb-system).+
+      restoreTask:
+        name: elasticsearch-restore-8.2.0
+        params:
+        - name: args
+          value: --match=^(?![.])(?!apm-agent-configuration)(?!kubedb-system).+
+  updateConstraints:
+    allowlist:
+    - '>= 9.1.9, < 9.2.4'
+  version: 9.1.9

--- a/catalog/kubedb/raw-dhi/elasticsearch/elasticsearch-9.2.3-elasticstack.yaml
+++ b/catalog/kubedb/raw-dhi/elasticsearch/elasticsearch-9.2.3-elasticstack.yaml
@@ -1,0 +1,39 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: ElasticsearchVersion
+metadata:
+  name: xpack-9.2.3
+spec:
+  authPlugin: X-Pack
+  dashboard:
+    image: ghcr.io/appscode-images/kibana:9.2.3
+  dashboardInitContainer:
+    yqImage: ghcr.io/kubedb/elasticsearch-dashboard-init:9.1.4-xpack-v2025.09.24
+  db:
+    image: dhi.io/elasticsearch:9.2
+  distribution: ElasticStack
+  exporter:
+    image: docker.io/prometheuscommunity/elasticsearch-exporter:v1.10.0
+  initContainer:
+    image: docker.io/tianon/toybox:0.8.11
+    yqImage: ghcr.io/kubedb/elasticsearch-init:9.1.4-xpack-v2025.12.12
+  podSecurityPolicies:
+    databasePolicyName: elasticsearch-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 1000
+  stash:
+    addon:
+      backupTask:
+        name: elasticsearch-backup-8.2.0
+        params:
+        - name: args
+          value: --match=^(?![.])(?!apm-agent-configuration)(?!kubedb-system).+
+      restoreTask:
+        name: elasticsearch-restore-8.2.0
+        params:
+        - name: args
+          value: --match=^(?![.])(?!apm-agent-configuration)(?!kubedb-system).+
+  updateConstraints:
+    allowlist:
+    - '>= 9.2.3, < 9.3.5'
+  version: 9.2.3

--- a/catalog/kubedb/raw-dhi/kafka/kafka-4.2.0.yaml
+++ b/catalog/kubedb/raw-dhi/kafka/kafka-4.2.0.yaml
@@ -1,0 +1,27 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: KafkaVersion
+metadata:
+  name: 4.2.0
+spec:
+  connectCluster:
+    image: ghcr.io/appscode-images/kafka-connect-cluster:4.2.0
+  cruiseControl:
+    image: ghcr.io/appscode-images/kafka-cruise-control:4.2.0
+  db:
+    image: dhi.io/kafka:4.2
+  endOfLife: true
+  initContainer:
+    image: ghcr.io/kubedb/kafka-init:4.0-v2
+  podSecurityPolicies:
+    databasePolicyName: kafka-db
+  securityContext:
+    runAsUser: 1001
+  ui:
+  - name: kafka-ui
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 4.2.0'
+    denylist:
+    - < 4.2.0
+  version: 4.2.0

--- a/catalog/kubedb/raw-dhi/memcached/memcached-1.6.22.yaml
+++ b/catalog/kubedb/raw-dhi/memcached/memcached-1.6.22.yaml
@@ -1,0 +1,17 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MemcachedVersion
+metadata:
+  name: 1.6.22
+spec:
+  db:
+    image: dhi.io/memcached:1.6
+  exporter:
+    image: ghcr.io/appscode-images/memcached_exporter:v0.14.3-ac
+  podSecurityPolicies:
+    databasePolicyName: memcached-db
+  securityContext:
+    runAsUser: 999
+  updateConstraints:
+    allowlist:
+    - '>= 1.6.22, <= 1.6.40'
+  version: 1.6.22

--- a/catalog/kubedb/raw-dhi/memcached/memcached-1.6.29.yaml
+++ b/catalog/kubedb/raw-dhi/memcached/memcached-1.6.29.yaml
@@ -1,0 +1,17 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MemcachedVersion
+metadata:
+  name: 1.6.29
+spec:
+  db:
+    image: dhi.io/memcached:1.6
+  exporter:
+    image: ghcr.io/appscode-images/memcached_exporter:v0.14.3-ac
+  podSecurityPolicies:
+    databasePolicyName: memcached-db
+  securityContext:
+    runAsUser: 999
+  updateConstraints:
+    allowlist:
+    - '>= 1.6.29, <= 1.6.40'
+  version: 1.6.29

--- a/catalog/kubedb/raw-dhi/memcached/memcached-1.6.33.yaml
+++ b/catalog/kubedb/raw-dhi/memcached/memcached-1.6.33.yaml
@@ -1,0 +1,17 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MemcachedVersion
+metadata:
+  name: 1.6.33
+spec:
+  db:
+    image: dhi.io/memcached:1.6
+  exporter:
+    image: ghcr.io/appscode-images/memcached_exporter:v0.14.3-ac
+  podSecurityPolicies:
+    databasePolicyName: memcached-db
+  securityContext:
+    runAsUser: 999
+  updateConstraints:
+    allowlist:
+    - '>= 1.6.33, <= 1.6.40'
+  version: 1.6.33

--- a/catalog/kubedb/raw-dhi/memcached/memcached-1.6.40.yaml
+++ b/catalog/kubedb/raw-dhi/memcached/memcached-1.6.40.yaml
@@ -1,0 +1,17 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MemcachedVersion
+metadata:
+  name: 1.6.40
+spec:
+  db:
+    image: dhi.io/memcached:1.6
+  exporter:
+    image: ghcr.io/appscode-images/memcached_exporter:v0.14.3-ac
+  podSecurityPolicies:
+    databasePolicyName: memcached-db
+  securityContext:
+    runAsUser: 999
+  updateConstraints:
+    allowlist:
+    - '>= 1.6.40'
+  version: 1.6.40

--- a/catalog/kubedb/raw-dhi/mongodb/mongodb-8.0.10-official.yaml
+++ b/catalog/kubedb/raw-dhi/mongodb/mongodb-8.0.10-official.yaml
@@ -1,0 +1,50 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
+  name: 8.0.10
+spec:
+  archiver:
+    addon:
+      name: mongodb-addon
+      tasks:
+        fullBackup:
+          name: logical-backup
+        fullBackupRestore:
+          name: logical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/wal-g:v2026.3.30_mongo
+  db:
+    image: dhi.io/mongodb:8.0
+  distribution: Official
+  exporter:
+    image: ghcr.io/kubedb/mongodb_exporter:v0.47.2
+  gitSyncer:
+    image: registry.k8s.io/git-sync/git-sync:v4.4.2
+  initContainer:
+    image: ghcr.io/kubedb/mongodb-init:6.0-v11
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+  replicationModeDetector:
+    image: ghcr.io/kubedb/replication-mode-detector:v0.51.0-rc.0
+  securityContext:
+    runAsGroup: 999
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: mongodb-backup-6.0.5
+      restoreTask:
+        name: mongodb-restore-6.0.5
+  ui:
+  - name: mongo-ui
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 8.0.10, < 10.0.0'
+  version: 8.0.10

--- a/catalog/kubedb/raw-dhi/mongodb/mongodb-8.0.17-official.yaml
+++ b/catalog/kubedb/raw-dhi/mongodb/mongodb-8.0.17-official.yaml
@@ -1,0 +1,50 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
+  name: 8.0.17
+spec:
+  archiver:
+    addon:
+      name: mongodb-addon
+      tasks:
+        fullBackup:
+          name: logical-backup
+        fullBackupRestore:
+          name: logical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/wal-g:v2026.3.30_mongo
+  db:
+    image: dhi.io/mongodb:8.0
+  distribution: Official
+  exporter:
+    image: ghcr.io/kubedb/mongodb_exporter:v0.47.2
+  gitSyncer:
+    image: registry.k8s.io/git-sync/git-sync:v4.4.2
+  initContainer:
+    image: ghcr.io/kubedb/mongodb-init:6.0-v11
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+  replicationModeDetector:
+    image: ghcr.io/kubedb/replication-mode-detector:v0.51.0-rc.0
+  securityContext:
+    runAsGroup: 999
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: mongodb-backup-6.0.5
+      restoreTask:
+        name: mongodb-restore-6.0.5
+  ui:
+  - name: mongo-ui
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 8.0.17, < 10.0.0'
+  version: 8.0.17

--- a/catalog/kubedb/raw-dhi/mongodb/mongodb-8.0.17-percona.yaml
+++ b/catalog/kubedb/raw-dhi/mongodb/mongodb-8.0.17-percona.yaml
@@ -1,0 +1,50 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
+  name: percona-8.0.17
+spec:
+  archiver:
+    addon:
+      name: mongodb-addon
+      tasks:
+        fullBackup:
+          name: logical-backup
+        fullBackupRestore:
+          name: logical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/wal-g:v2026.3.30_mongo
+  db:
+    image: dhi.io/mongodb:8.0
+  distribution: Percona
+  exporter:
+    image: ghcr.io/kubedb/mongodb_exporter:v0.47.2
+  gitSyncer:
+    image: registry.k8s.io/git-sync/git-sync:v4.4.2
+  initContainer:
+    image: ghcr.io/kubedb/mongodb-init:6.0-v11
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+  replicationModeDetector:
+    image: ghcr.io/kubedb/replication-mode-detector:v0.51.0-rc.0
+  securityContext:
+    runAsGroup: 0
+    runAsUser: 1001
+  stash:
+    addon:
+      backupTask:
+        name: mongodb-backup-6.0.5
+      restoreTask:
+        name: mongodb-restore-6.0.5
+  ui:
+  - name: mongo-ui
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 8.0.17, < 9.0.0'
+  version: 8.0.17

--- a/catalog/kubedb/raw-dhi/mongodb/mongodb-8.0.8-percona.yaml
+++ b/catalog/kubedb/raw-dhi/mongodb/mongodb-8.0.8-percona.yaml
@@ -1,0 +1,50 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MongoDBVersion
+metadata:
+  name: percona-8.0.8
+spec:
+  archiver:
+    addon:
+      name: mongodb-addon
+      tasks:
+        fullBackup:
+          name: logical-backup
+        fullBackupRestore:
+          name: logical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/wal-g:v2026.3.30_mongo
+  db:
+    image: dhi.io/mongodb:8.0
+  distribution: Percona
+  exporter:
+    image: ghcr.io/kubedb/mongodb_exporter:v0.47.2
+  gitSyncer:
+    image: registry.k8s.io/git-sync/git-sync:v4.4.2
+  initContainer:
+    image: ghcr.io/kubedb/mongodb-init:6.0-v11
+  podSecurityPolicies:
+    databasePolicyName: mongodb-db
+  replicationModeDetector:
+    image: ghcr.io/kubedb/replication-mode-detector:v0.51.0-rc.0
+  securityContext:
+    runAsGroup: 0
+    runAsUser: 1001
+  stash:
+    addon:
+      backupTask:
+        name: mongodb-backup-6.0.5
+      restoreTask:
+        name: mongodb-restore-6.0.5
+  ui:
+  - name: mongo-ui
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 8.0.8, < 9.0.0'
+  version: 8.0.8

--- a/catalog/kubedb/raw-dhi/mysql/mysql-8.0.36-official.yaml
+++ b/catalog/kubedb/raw-dhi/mysql/mysql-8.0.36-official.yaml
@@ -1,0 +1,60 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MySQLVersion
+metadata:
+  name: 8.0.36
+spec:
+  archiver:
+    addon:
+      name: mysql-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/mysql-archiver:(v0.25.0-rc.0)_8.0.35
+  coordinator:
+    image: ghcr.io/kubedb/mysql-coordinator:v0.42.0-rc.0
+  db:
+    image: dhi.io/mysql:8.0
+  distribution: Official
+  endOfLife: true
+  exporter:
+    image: ghcr.io/kubedb/mysqld-exporter:v0.18.0
+  gitSyncer:
+    image: registry.k8s.io/git-sync/git-sync:v4.4.2
+  initContainer:
+    image: ghcr.io/kubedb/mysql-init:8.0.31-v7
+  podSecurityPolicies:
+    databasePolicyName: mysql-db
+  replicationModeDetector:
+    image: ghcr.io/kubedb/replication-mode-detector:v0.51.0-rc.0
+  securityContext:
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: mysql-backup-8.0.21
+      restoreTask:
+        name: mysql-restore-8.0.21
+  ui:
+  - name: phpmyadmin
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+      groupReplication:
+      - '>= 8.0.36, <= 9.1.0'
+      standalone:
+      - '>= 8.0.36, <= 9.1.0'
+    denylist:
+      groupReplication:
+      - < 8.0.36
+      standalone:
+      - < 8.0.36
+  version: 8.0.36

--- a/catalog/kubedb/raw-dhi/postgres/postgres-10.23-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-10.23-official.yaml
@@ -1,0 +1,84 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "10.23"
+spec:
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:10.23
+  distribution: Official
+  endOfLife: true
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-10.14
+      restoreTask:
+        name: postgres-restore-10.14
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 10.23, <= 16.8'
+  version: "10.23"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 10.23-bullseye
+spec:
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bullseye
+    image: dhi.io/postgres:10.23
+  distribution: Official
+  endOfLife: true
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-10.14
+      restoreTask:
+        name: postgres-restore-10.14
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 10.23, <= 16.8'
+  version: "10.23"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-11.22-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-11.22-official.yaml
@@ -1,0 +1,116 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "11.22"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_11.22-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:11.22
+  distribution: Official
+  endOfLife: true
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-11.9
+      restoreTask:
+        name: postgres-restore-11.9
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 11.22, <= 16.8'
+  version: "11.22"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 11.22-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_11.22-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:11.22
+  distribution: Official
+  endOfLife: true
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-11.9
+      restoreTask:
+        name: postgres-restore-11.9
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 11.22, <= 16.8'
+  version: "11.22"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-12.17-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-12.17-official.yaml
@@ -1,0 +1,115 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "12.17"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_12.17-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:12.17
+  distribution: Official
+  endOfLife: true
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-12.4
+      restoreTask:
+        name: postgres-restore-12.4
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 12.17'
+  version: "12.17"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 12.17-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_12.17-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:12.17
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-12.4
+      restoreTask:
+        name: postgres-restore-12.4
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 12.17'
+  version: "12.17"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-12.22-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-12.22-official.yaml
@@ -1,0 +1,116 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "12.22"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_12.17-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:12.22
+  distribution: Official
+  endOfLife: true
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-12.4
+      restoreTask:
+        name: postgres-restore-12.4
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 12.22'
+  version: "12.22"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 12.22-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_12.17-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:12.22
+  distribution: Official
+  endOfLife: true
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-12.4
+      restoreTask:
+        name: postgres-restore-12.4
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 12.22'
+  version: "12.22"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-13.13-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-13.13-official.yaml
@@ -1,0 +1,115 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "13.13"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_13.13-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:13.13
+  distribution: Official
+  endOfLife: true
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-13.1
+      restoreTask:
+        name: postgres-restore-13.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 13.13'
+  version: "13.13"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 13.13-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_13.13-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:13.13
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-13.1
+      restoreTask:
+        name: postgres-restore-13.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 13.13'
+  version: "13.13"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-13.18-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-13.18-official.yaml
@@ -1,0 +1,115 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "13.18"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_13.13-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:13.18
+  distribution: Official
+  endOfLife: true
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-13.1
+      restoreTask:
+        name: postgres-restore-13.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 13.18'
+  version: "13.18"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 13.18-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_13.13-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:13.18
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-13.1
+      restoreTask:
+        name: postgres-restore-13.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 13.18'
+  version: "13.18"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-13.20-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-13.20-official.yaml
@@ -1,0 +1,115 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "13.20"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_13.13-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:13.20
+  distribution: Official
+  endOfLife: true
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-13.1
+      restoreTask:
+        name: postgres-restore-13.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 13.20'
+  version: "13.20"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 13.20-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_13.13-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:13.20
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-13.1
+      restoreTask:
+        name: postgres-restore-13.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 13.20'
+  version: "13.20"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-13.21-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-13.21-official.yaml
@@ -1,0 +1,116 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "13.21"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_13.13-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:13.21
+  distribution: Official
+  endOfLife: true
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-13.1
+      restoreTask:
+        name: postgres-restore-13.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 13.21'
+  version: "13.21"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 13.21-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_13.13-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:13.21
+  distribution: Official
+  endOfLife: true
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-13.1
+      restoreTask:
+        name: postgres-restore-13.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 13.21'
+  version: "13.21"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-14.10-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-14.10-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "14.10"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_14.10-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:14.10
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-14.0
+      restoreTask:
+        name: postgres-restore-14.0
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 14.10'
+  version: "14.10"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 14.10-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_14.10-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:14.10
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-14.0
+      restoreTask:
+        name: postgres-restore-14.0
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 14.10'
+  version: "14.10"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-14.13-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-14.13-official.yaml
@@ -1,0 +1,118 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "14.13"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_14.10-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:14.13
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-14.0
+      restoreTask:
+        name: postgres-restore-14.0
+  tls:
+    disableSSLSessionResumption: true
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 14.13'
+  version: "14.13"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 14.13-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_14.10-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:14.13
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-14.0
+      restoreTask:
+        name: postgres-restore-14.0
+  tls:
+    disableSSLSessionResumption: true
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 14.13'
+  version: "14.13"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-14.15-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-14.15-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "14.15"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_14.10-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:14.15
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-14.0
+      restoreTask:
+        name: postgres-restore-14.0
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 14.15'
+  version: "14.15"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 14.15-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_14.10-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:14.15
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-14.0
+      restoreTask:
+        name: postgres-restore-14.0
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 14.15'
+  version: "14.15"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-14.17-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-14.17-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "14.17"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_14.10-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:14.17
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-14.0
+      restoreTask:
+        name: postgres-restore-14.0
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 14.17'
+  version: "14.17"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 14.17-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_14.10-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:14.17
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-14.0
+      restoreTask:
+        name: postgres-restore-14.0
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 14.17'
+  version: "14.17"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-14.18-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-14.18-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "14.18"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_14.10-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:14.18
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-14.0
+      restoreTask:
+        name: postgres-restore-14.0
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 14.18'
+  version: "14.18"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 14.18-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_14.10-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:14.18
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-14.0
+      restoreTask:
+        name: postgres-restore-14.0
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 14.18'
+  version: "14.18"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-14.21-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-14.21-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "14.21"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_14.10-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:14.21
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-14.0
+      restoreTask:
+        name: postgres-restore-14.0
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 14.21'
+  version: "14.21"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 14.21-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_14.10-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:14.21
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-14.0
+      restoreTask:
+        name: postgres-restore-14.0
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 14.21'
+  version: "14.21"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-14.22-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-14.22-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "14.22"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_14.10-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:14.22
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-14.0
+      restoreTask:
+        name: postgres-restore-14.0
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 14.22'
+  version: "14.22"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 14.22-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_14.10-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:14.22
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-14.0
+      restoreTask:
+        name: postgres-restore-14.0
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 14.22'
+  version: "14.22"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-15.10-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-15.10-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "15.10"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_15.5-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:15.10
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-15.1
+      restoreTask:
+        name: postgres-restore-15.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 15.10'
+  version: "15.10"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 15.10-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_15.5-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:15.10
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-15.1
+      restoreTask:
+        name: postgres-restore-15.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 15.10'
+  version: "15.10"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-15.12-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-15.12-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "15.12"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_15.5-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:15.12
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-15.1
+      restoreTask:
+        name: postgres-restore-15.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 15.12'
+  version: "15.12"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 15.12-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_15.5-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:15.12
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-15.1
+      restoreTask:
+        name: postgres-restore-15.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 15.12'
+  version: "15.12"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-15.13-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-15.13-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "15.13"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_15.5-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:15.13
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-15.1
+      restoreTask:
+        name: postgres-restore-15.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 15.13'
+  version: "15.13"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 15.13-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_15.5-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:15.13
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-15.1
+      restoreTask:
+        name: postgres-restore-15.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 15.13'
+  version: "15.13"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-15.16-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-15.16-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "15.16"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_15.5-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:15.16
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-15.1
+      restoreTask:
+        name: postgres-restore-15.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 15.16'
+  version: "15.16"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 15.16-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_15.5-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:15.16
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-15.1
+      restoreTask:
+        name: postgres-restore-15.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 15.16'
+  version: "15.16"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-15.17-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-15.17-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "15.17"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_15.5-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:15.17
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-15.1
+      restoreTask:
+        name: postgres-restore-15.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 15.17'
+  version: "15.17"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 15.17-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_15.5-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:15.17
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-15.1
+      restoreTask:
+        name: postgres-restore-15.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 15.17'
+  version: "15.17"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-15.5-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-15.5-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "15.5"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_15.5-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:15.5
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-15.1
+      restoreTask:
+        name: postgres-restore-15.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 15.5'
+  version: "15.5"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 15.5-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_15.5-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:15.5
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-15.1
+      restoreTask:
+        name: postgres-restore-15.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 15.5'
+  version: "15.5"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-15.8-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-15.8-official.yaml
@@ -1,0 +1,118 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "15.8"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_15.5-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:15.8
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-15.1
+      restoreTask:
+        name: postgres-restore-15.1
+  tls:
+    disableSSLSessionResumption: true
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 15.8'
+  version: "15.8"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 15.8-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_15.5-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:15.8
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-15.1
+      restoreTask:
+        name: postgres-restore-15.1
+  tls:
+    disableSSLSessionResumption: true
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 15.8'
+  version: "15.8"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-16.1-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-16.1-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "16.1"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_16.1-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:16.1
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-16.1
+      restoreTask:
+        name: postgres-restore-16.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 16.1'
+  version: "16.1"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 16.1-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_16.1-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:16.1
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-16.1
+      restoreTask:
+        name: postgres-restore-16.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 16.1'
+  version: "16.1"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-16.10-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-16.10-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "16.10"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_16.1-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:16.10
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-16.1
+      restoreTask:
+        name: postgres-restore-16.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 16.10'
+  version: "16.10"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 16.10-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_16.1-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:16.10
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-16.1
+      restoreTask:
+        name: postgres-restore-16.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 16.10'
+  version: "16.10"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-16.12-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-16.12-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "16.12"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_16.1-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:16.12
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-16.1
+      restoreTask:
+        name: postgres-restore-16.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 16.12'
+  version: "16.12"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 16.12-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_16.1-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:16.12
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-16.1
+      restoreTask:
+        name: postgres-restore-16.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 16.12'
+  version: "16.12"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-16.13-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-16.13-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "16.13"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_16.1-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:16.13
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-16.1
+      restoreTask:
+        name: postgres-restore-16.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 16.13'
+  version: "16.13"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 16.13-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_16.1-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:16.13
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-16.1
+      restoreTask:
+        name: postgres-restore-16.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 16.13'
+  version: "16.13"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-16.4-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-16.4-official.yaml
@@ -1,0 +1,118 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "16.4"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_16.1-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:16.4
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-16.1
+      restoreTask:
+        name: postgres-restore-16.1
+  tls:
+    disableSSLSessionResumption: true
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 16.4'
+  version: "16.4"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 16.4-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_16.1-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:16.4
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-16.1
+      restoreTask:
+        name: postgres-restore-16.1
+  tls:
+    disableSSLSessionResumption: true
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 16.4'
+  version: "16.4"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-16.6-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-16.6-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "16.6"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_16.1-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:16.6
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-16.1
+      restoreTask:
+        name: postgres-restore-16.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 16.6'
+  version: "16.6"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 16.6-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_16.1-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:16.6
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-16.1
+      restoreTask:
+        name: postgres-restore-16.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 16.6'
+  version: "16.6"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-16.8-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-16.8-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "16.8"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_16.1-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:16.8
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-16.1
+      restoreTask:
+        name: postgres-restore-16.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 16.8'
+  version: "16.8"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 16.8-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_16.1-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:16.8
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-16.1
+      restoreTask:
+        name: postgres-restore-16.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 16.8'
+  version: "16.8"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-16.9-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-16.9-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "16.9"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_16.1-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:16.9
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-16.1
+      restoreTask:
+        name: postgres-restore-16.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 16.9'
+  version: "16.9"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 16.9-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_16.1-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:16.9
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-16.1
+      restoreTask:
+        name: postgres-restore-16.1
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 16.9'
+  version: "16.9"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-17.2-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-17.2-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "17.2"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_17.2-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:17.2
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-17.2
+      restoreTask:
+        name: postgres-restore-17.2
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 17.2'
+  version: "17.2"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 17.2-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_17.2-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:17.2
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-17.2
+      restoreTask:
+        name: postgres-restore-17.2
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 17.2'
+  version: "17.2"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-17.4-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-17.4-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "17.4"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_17.2-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:17.4
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-17.2
+      restoreTask:
+        name: postgres-restore-17.2
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 17.4'
+  version: "17.4"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 17.4-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_17.2-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:17.4
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-17.2
+      restoreTask:
+        name: postgres-restore-17.2
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 17.4'
+  version: "17.4"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-17.5-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-17.5-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "17.5"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_17.2-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:17.5
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-17.2
+      restoreTask:
+        name: postgres-restore-17.2
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 17.5'
+  version: "17.5"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 17.5-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_17.2-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:17.5
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-17.2
+      restoreTask:
+        name: postgres-restore-17.2
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 17.5'
+  version: "17.5"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-17.8-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-17.8-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "17.8"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_17.2-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:17.8
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-17.2
+      restoreTask:
+        name: postgres-restore-17.2
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 17.8'
+  version: "17.8"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 17.8-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_17.2-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:17.8
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-17.2
+      restoreTask:
+        name: postgres-restore-17.2
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 17.8'
+  version: "17.8"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-17.9-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-17.9-official.yaml
@@ -1,0 +1,114 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "17.9"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_17.2-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:17.9
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-17.2
+      restoreTask:
+        name: postgres-restore-17.2
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 17.9'
+  version: "17.9"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 17.9-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_17.2-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:17.9
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: postgres-backup-17.2
+      restoreTask:
+        name: postgres-restore-17.2
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 17.9'
+  version: "17.9"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-18.2-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-18.2-official.yaml
@@ -1,0 +1,102 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "18.2"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_18.2-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:18.2
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 18.2'
+  version: "18.2"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 18.2-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_18.2-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:18.2
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 18.2'
+  version: "18.2"

--- a/catalog/kubedb/raw-dhi/postgres/postgres-18.3-official.yaml
+++ b/catalog/kubedb/raw-dhi/postgres/postgres-18.3-official.yaml
@@ -1,0 +1,102 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: "18.3"
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_18.2-alpine
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: alpine
+    image: dhi.io/postgres:18.3
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: false
+    runAsUser: 70
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 18.3'
+  version: "18.3"
+
+---
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: PostgresVersion
+metadata:
+  name: 18.3-bookworm
+spec:
+  archiver:
+    addon:
+      name: postgres-addon
+      tasks:
+        fullBackup:
+          name: physical-backup
+        fullBackupRestore:
+          name: physical-backup-restore
+        manifestBackup:
+          name: manifest-backup
+        manifestRestore:
+          name: manifest-restore
+        volumeSnapshot:
+          name: volume-snapshot
+    walg:
+      image: ghcr.io/kubedb/postgres-archiver:(v0.25.0-rc.0)_18.2-bookworm
+  coordinator:
+    image: ghcr.io/kubedb/pg-coordinator:v0.48.0-rc.0
+  db:
+    baseOS: bookworm
+    image: dhi.io/postgres:18.3
+  distribution: Official
+  exporter:
+    image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
+  initContainer:
+    image: ghcr.io/kubedb/postgres-init:0.19.0
+  migrator:
+    cli:
+      image: ghcr.io/kubedb/migrator-cli:v0.4.0-rc.0
+    statusReporter:
+      image: ghcr.io/kubedb/migrator-operator:v0.4.0-rc.0
+  podSecurityPolicies:
+    databasePolicyName: postgres-db
+  securityContext:
+    runAsAnyNonRoot: true
+    runAsUser: 999
+  ui:
+  - name: pgadmin
+    version: v2026.3.30
+  - name: dbgate
+    version: v2026.3.30
+  updateConstraints:
+    allowlist:
+    - '>= 18.3'
+  version: "18.3"

--- a/catalog/kubedb/raw-dhi/rabbitmq/rabbitmq-4.2.4-dhi.yaml
+++ b/catalog/kubedb/raw-dhi/rabbitmq/rabbitmq-4.2.4-dhi.yaml
@@ -1,0 +1,12 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: RabbitMQVersion
+metadata:
+  name: 4.2.4-dhi
+spec:
+  db:
+    image: dhi.io/rabbitmq:4.2
+  initContainer:
+    image: ghcr.io/kubedb/rabbitmq-init:v2026.1.19
+  securityContext:
+    runAsUser: 65532
+  version: 4.2.4

--- a/catalog/kubedb/raw-dhi/rabbitmq/rabbitmq-4.2.4.yaml
+++ b/catalog/kubedb/raw-dhi/rabbitmq/rabbitmq-4.2.4.yaml
@@ -1,0 +1,12 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: RabbitMQVersion
+metadata:
+  name: 4.2.4
+spec:
+  db:
+    image: dhi.io/rabbitmq:4.2
+  initContainer:
+    image: ghcr.io/kubedb/rabbitmq-init:v2026.1.19
+  securityContext:
+    runAsUser: 999
+  version: 4.2.4

--- a/catalog/kubedb/raw-dhi/rabbitmq/rabbitmq-4.2.6-dhi.yaml
+++ b/catalog/kubedb/raw-dhi/rabbitmq/rabbitmq-4.2.6-dhi.yaml
@@ -1,12 +1,12 @@
 apiVersion: catalog.kubedb.com/v1alpha1
 kind: RabbitMQVersion
 metadata:
-  name: 4.2.4
+  name: 4.2.6-dhi
 spec:
   db:
-    image: dhi.io/rabbitmq:4.2
+    image: dhi.io/rabbitmq:4.2.6
   initContainer:
     image: ghcr.io/kubedb/rabbitmq-init:v2026.1.19
   securityContext:
-    runAsUser: 999
-  version: 4.2.4
+    runAsUser: 65532
+  version: 4.2.6

--- a/catalog/kubedb/raw-dhi/redis/redis-8.0.3-valkey.yaml
+++ b/catalog/kubedb/raw-dhi/redis/redis-8.0.3-valkey.yaml
@@ -1,0 +1,24 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: RedisVersion
+metadata:
+  name: valkey-8.0.3
+spec:
+  coordinator:
+    image: ghcr.io/kubedb/redis-coordinator:v0.43.0-rc.0
+  db:
+    image: dhi.io/redis:8.0
+  distribution: Valkey
+  exporter:
+    image: ghcr.io/kubedb/redis_exporter:1.66.0
+  gitSyncer:
+    image: registry.k8s.io/git-sync/git-sync:v4.4.2
+  initContainer:
+    image: ghcr.io/kubedb/redis-init:0.12.1
+  podSecurityPolicies:
+    databasePolicyName: redis-db
+  securityContext:
+    runAsUser: 1000
+  updateConstraints:
+    allowlist:
+    - 8.0.3
+  version: 8.0.3

--- a/catalog/kubedb/raw-dhi/redis/redis-8.0.4-official.yaml
+++ b/catalog/kubedb/raw-dhi/redis/redis-8.0.4-official.yaml
@@ -1,0 +1,30 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: RedisVersion
+metadata:
+  name: 8.0.4
+spec:
+  coordinator:
+    image: ghcr.io/kubedb/redis-coordinator:v0.43.0-rc.0
+  db:
+    image: dhi.io/redis:8.0
+  distribution: Official
+  exporter:
+    image: ghcr.io/kubedb/redis_exporter:1.66.0
+  gitSyncer:
+    image: registry.k8s.io/git-sync/git-sync:v4.4.2
+  initContainer:
+    image: ghcr.io/kubedb/redis-init:0.12.1
+  podSecurityPolicies:
+    databasePolicyName: redis-db
+  securityContext:
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: redis-backup-7.0.5
+      restoreTask:
+        name: redis-restore-7.0.5
+  updateConstraints:
+    allowlist:
+    - '>= 8.0.4, < 8.2.2'
+  version: 8.0.4

--- a/catalog/kubedb/raw-dhi/redis/redis-8.1.1-valkey.yaml
+++ b/catalog/kubedb/raw-dhi/redis/redis-8.1.1-valkey.yaml
@@ -1,0 +1,24 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: RedisVersion
+metadata:
+  name: valkey-8.1.1
+spec:
+  coordinator:
+    image: ghcr.io/kubedb/redis-coordinator:v0.43.0-rc.0
+  db:
+    image: dhi.io/redis:8.1
+  distribution: Valkey
+  exporter:
+    image: ghcr.io/kubedb/redis_exporter:1.66.0
+  gitSyncer:
+    image: registry.k8s.io/git-sync/git-sync:v4.4.2
+  initContainer:
+    image: ghcr.io/kubedb/redis-init:0.12.1
+  podSecurityPolicies:
+    databasePolicyName: redis-db
+  securityContext:
+    runAsUser: 1000
+  updateConstraints:
+    allowlist:
+    - 8.1.1
+  version: 8.1.1

--- a/catalog/kubedb/raw-dhi/redis/redis-8.2.2-official.yaml
+++ b/catalog/kubedb/raw-dhi/redis/redis-8.2.2-official.yaml
@@ -1,0 +1,30 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: RedisVersion
+metadata:
+  name: 8.2.2
+spec:
+  coordinator:
+    image: ghcr.io/kubedb/redis-coordinator:v0.43.0-rc.0
+  db:
+    image: dhi.io/redis:8.2
+  distribution: Official
+  exporter:
+    image: ghcr.io/kubedb/redis_exporter:1.66.0
+  gitSyncer:
+    image: registry.k8s.io/git-sync/git-sync:v4.4.2
+  initContainer:
+    image: ghcr.io/kubedb/redis-init:0.12.1
+  podSecurityPolicies:
+    databasePolicyName: redis-db
+  securityContext:
+    runAsUser: 999
+  stash:
+    addon:
+      backupTask:
+        name: redis-backup-7.0.5
+      restoreTask:
+        name: redis-restore-7.0.5
+  updateConstraints:
+    allowlist:
+    - 8.2.2
+  version: 8.2.2

--- a/catalog/kubedb/raw-dhi/zookeeper/zookeeper-3.8.3.yaml
+++ b/catalog/kubedb/raw-dhi/zookeeper/zookeeper-3.8.3.yaml
@@ -1,0 +1,12 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: ZooKeeperVersion
+metadata:
+  name: 3.8.3
+spec:
+  db:
+    image: dhi.io/zookeeper:3.8
+  initContainer:
+    image: ghcr.io/kubedb/zookeeper-init:3.7-v1
+  securityContext:
+    runAsUser: 1000
+  version: 3.8.3

--- a/catalog/kubedb/raw-dhi/zookeeper/zookeeper-3.9.1.yaml
+++ b/catalog/kubedb/raw-dhi/zookeeper/zookeeper-3.9.1.yaml
@@ -1,0 +1,12 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: ZooKeeperVersion
+metadata:
+  name: 3.9.1
+spec:
+  db:
+    image: dhi.io/zookeeper:3.9
+  initContainer:
+    image: ghcr.io/kubedb/zookeeper-init:3.7-v1
+  securityContext:
+    runAsUser: 1000
+  version: 3.9.1


### PR DESCRIPTION
## What this PR does
- Adds a new catalog/kubedb/raw-dhi/ folder generated from catalog/kubedb/raw/
- Replaces spec.db.image values with DHI images under dhi.io/
- Excludes deprecated manifests and unsupported/no-DHI manifests
- Adds generator script: catalog/kubedb/gen-raw-dhi.py

## Notes
- Commit is signed off (git commit -s)
- Output currently includes 63 manifests across supported DBs
