### PR TITLE
Harden CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Set up Go 1.25
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Prepare Host
         run: |
@@ -224,7 +224,7 @@ jobs:
       matrix:
         k8s: [v1.29.14, v1.31.14, v1.33.7, v1.35.0]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install yq
         run: |
@@ -234,7 +234,7 @@ jobs:
 
       - name: Create Kubernetes ${{ matrix.k8s }} cluster
         id: kind
-        uses: engineerd/setup-kind@v0.5.0
+        uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 # v0.5.0
         with:
           version: v0.31.0
           image: kindest/node:${{ matrix.k8s }}

--- a/.github/workflows/cve-report.yml
+++ b/.github/workflows/cve-report.yml
@@ -13,6 +13,9 @@ jobs:
   report:
     name: Report
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 

--- a/.github/workflows/cve-report.yml
+++ b/.github/workflows/cve-report.yml
@@ -14,10 +14,10 @@ jobs:
     name: Report
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: '1.25'
 
@@ -61,7 +61,7 @@ jobs:
         git commit -s -a -m "Update cve report $(date --rfc-3339=date)"
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
       with:
         token: ${{ secrets.LGTM_GITHUB_TOKEN }}
         title: Update cve report

--- a/.github/workflows/cve-report.yml
+++ b/.github/workflows/cve-report.yml
@@ -9,9 +9,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
   report:
     name: Report

--- a/.github/workflows/cve-report.yml
+++ b/.github/workflows/cve-report.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   report:
     name: Report

--- a/.github/workflows/publish-oci.yml
+++ b/.github/workflows/publish-oci.yml
@@ -14,6 +14,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/publish-oci.yml
+++ b/.github/workflows/publish-oci.yml
@@ -16,22 +16,22 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
           fetch-tags: true
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
           cache-image: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to the GitHub Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: 1gtm

--- a/.github/workflows/publish-oci.yml
+++ b/.github/workflows/publish-oci.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Set up QEMU
         id: qemu

--- a/.github/workflows/publish-oci.yml
+++ b/.github/workflows/publish-oci.yml
@@ -10,13 +10,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-oci
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         id: qemu
@@ -28,7 +31,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to the GitHub Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: 1gtm

--- a/.github/workflows/publish-oci.yml
+++ b/.github/workflows/publish-oci.yml
@@ -10,9 +10,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-oci
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
   build:
     name: Build

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -9,9 +9,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Prepare git
         env:

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,19 +19,19 @@ jobs:
       packages: write
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
           fetch-tags: true
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
           cache-image: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Install GitHub CLI
         run: |
@@ -43,7 +43,7 @@ jobs:
           pushd /usr/local/bin && sudo curl -fsSLO https://github.com/x-helm/helm/releases/latest/download/helm && sudo chmod +x helm && popd
 
       - name: Log in to the GitHub Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Set up QEMU
         id: qemu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,19 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-release
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
         id: qemu
@@ -37,7 +43,7 @@ jobs:
           pushd /usr/local/bin && sudo curl -fsSLO https://github.com/x-helm/helm/releases/latest/download/helm && sudo chmod +x helm && popd
 
       - name: Log in to the GitHub Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-release
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 jobs:
   build:
     name: Build


### PR DESCRIPTION
## Summary

Harden all GitHub Actions workflows in this repo:

- **Pin every action to a full-length commit SHA** with a trailing version comment, so floating tags like `@v4` can't be silently re-pointed at malicious code.
- **Grant least-privilege `GITHUB_TOKEN` permissions** at the job level, only where the action's README documents a write scope as required:
  - `cve-report.yml` → `contents: write`, `pull-requests: write` (for `peter-evans/create-pull-request`)
  - `publish-oci.yml` → `contents: read`, `packages: write` (for `docker/login-action` → ghcr.io push)
  - `release.yml` → `contents: read`, `packages: write` (for `docker/login-action` → ghcr.io push)
  - `ci.yml`, `release-tracker.yml` → no write needed; rely on the default read-only `GITHUB_TOKEN`
- **Tag-triggered workflows** (`publish-oci.yml`, `release.yml`) now check out with `fetch-depth: 1` + `fetch-tags: true` so the tag ref is resolvable without a full clone.
- **Bump outdated action versions** while in the file: `actions/checkout@v1` → `@v4.3.1`, `docker/login-action@v2` → `@v3.7.0`.

## Pinned versions

| Action | Version |
| --- | --- |
| `actions/checkout` | v4.3.1 |
| `actions/setup-go` | v5.6.0 |
| `docker/login-action` | v3.7.0 |
| `docker/setup-buildx-action` | v3.12.0 |
| `docker/setup-qemu-action` | v3.7.0 |
| `engineerd/setup-kind` | v0.5.0 |
| `peter-evans/create-pull-request` | v6.1.0 |

## Test plan
- [ ] CI workflow passes on this PR (validates `ci.yml` with new pinned actions).
- [ ] Confirm release workflow can still push to ghcr.io on next tag (requires a tagged release to fully validate `release.yml` and `publish-oci.yml`).
- [ ] Confirm `cve-report` continues to open PRs on its schedule.
- [ ] Confirm `release-tracker` still fires on PR close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)