### PR TITLE
Update workflow actions and standardize chart repository config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,10 +234,10 @@ jobs:
 
       - name: Create Kubernetes ${{ matrix.k8s }} cluster
         id: kind
-        uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 # v0.5.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           version: v0.31.0
-          image: kindest/node:${{ matrix.k8s }}
+          node_image: kindest/node:${{ matrix.k8s }}
 
       - name: Prepare cluster for testing
         id: local-path

--- a/.github/workflows/cve-report.yml
+++ b/.github/workflows/cve-report.yml
@@ -64,7 +64,7 @@ jobs:
         git commit -s -a -m "Update cve report $(date --rfc-3339=date)"
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
+      uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         title: Update cve report

--- a/.github/workflows/publish-oci.yml
+++ b/.github/workflows/publish-oci.yml
@@ -48,7 +48,7 @@ jobs:
         env:
           GITHUB_USER: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CHART_REPOSITORY: github.com/appscode/charts
+          CHART_REPOSITORY: ${{ secrets.CHART_REPOSITORY }}
         run: |
           url="https://${GITHUB_USER}:${GITHUB_TOKEN}@${CHART_REPOSITORY}.git"
           cd $RUNNER_WORKSPACE
@@ -61,7 +61,7 @@ jobs:
         env:
           GITHUB_USER: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CHART_REPOSITORY: github.com/appscode/charts
+          CHART_REPOSITORY: ${{ secrets.CHART_REPOSITORY }}
         run: |
           export REGISTRY_0=oci://ghcr.io/appscode-charts
           ./hack/scripts/update-chart-dependencies.sh


### PR DESCRIPTION
## Summary
- Switch `engineerd/setup-kind` (unmaintained, last release 2021) to `helm/kind-action@v1.14.0` in `ci.yml`. Renames the `image:` input to `node_image:`.
- Bump `peter-evans/create-pull-request` from v6.1.0 to v7.0.11 in `cve-report.yml`.
- Standardize on `secrets.CHART_REPOSITORY` in `publish-oci.yml` (was hardcoded as `github.com/appscode/charts`) to match `release.yml`.

## Test plan
- [ ] CI workflow runs successfully across the k8s matrix with the new kind action
- [ ] Next CVE report PR uses v7 of create-pull-request
- [ ] Next tag triggers OCI publish workflow successfully with the secret-sourced chart repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)