### PR TITLE
Add least-privilege permissions to ci.yml and release-tracker.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -9,6 +9,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
Neither `ci.yml` nor `release-tracker.yml` declared an explicit `permissions` block, so they inherited the repo default which may grant `contents: write`. Add workflow-level least-privilege blocks:

- `ci.yml` — `contents: read` (all steps are read-only)
- `release-tracker.yml` — `contents: read` + `pull-requests: write` (posts comments on the release tracker PR via `gh api`)

## Test plan
- [ ] CI workflow still passes on this PR
- [ ] Next merged PR triggers release-tracker workflow and successfully posts the comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)