### PR TITLE
Use GitHub App token for release tracker comments

### DIFF
--- a/.github/workflows/publish-oci.yml
+++ b/.github/workflows/publish-oci.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           client-id: ${{ secrets.GHCRX_APP_CLIENT_ID }}
           private-key: ${{ secrets.GHCRX_APP_PRIVATE_KEY }}
+          owner: appscode-charts
 
       - name: Log in to the GitHub Container registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0

--- a/.github/workflows/publish-oci.yml
+++ b/.github/workflows/publish-oci.yml
@@ -33,12 +33,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.GHCRX_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GHCRX_APP_PRIVATE_KEY }}
+
       - name: Log in to the GitHub Container registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ steps.app-token.outputs.token }}
 
       - name: Install Helm 3
         run: |
@@ -47,7 +54,7 @@ jobs:
       - name: Clone charts repository
         env:
           GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           CHART_REPOSITORY: github.com/appscode/charts
         run: |
           url="https://${GITHUB_USER}:${GITHUB_TOKEN}@${CHART_REPOSITORY}.git"
@@ -60,7 +67,7 @@ jobs:
       - name: Publish OCI charts
         env:
           GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           CHART_REPOSITORY: github.com/appscode/charts
         run: |
           export REGISTRY_0=oci://ghcr.io/appscode-charts

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -29,12 +29,22 @@ jobs:
           curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
           sudo mv bin/hub /usr/local/bin
 
+      - name: Generate GitHub App token
+        id: app-token
+        if: |
+          github.event.action == 'closed' &&
+          github.event.pull_request.merged == true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.LGTM_APP_CLIENT_ID }}
+          private-key: ${{ secrets.LGTM_APP_PRIVATE_KEY }}
+
       - name: Update release tracker
         if: |
           github.event.action == 'closed' &&
           github.event.pull_request.merged == true
         env:
           GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           ./hack/scripts/update-release-tracker.sh

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           client-id: ${{ secrets.LGTM_APP_CLIENT_ID }}
           private-key: ${{ secrets.LGTM_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: CHANGELOG
 
       - name: Update release tracker
         if: |


### PR DESCRIPTION
## Summary
Switch the `Update release tracker` step in `release-tracker.yml` to use a short-lived GitHub App installation token via `actions/create-github-app-token@v3.2.0` instead of the workflow's `GITHUB_TOKEN`.

The release tracker URL may resolve to a different repository than this workflow runs in, so `GITHUB_TOKEN` does not have permission to post comments there. The LGTM App can be installed across the target repos.

Requires repository secrets:
- `LGTM_APP_CLIENT_ID`
- `LGTM_APP_PRIVATE_KEY`

## Test plan
- [ ] Merge a PR with a `Release-tracker:` trailer and confirm the comment is posted on the tracker issue/PR
- [ ] Verify the token generation step is skipped on non-merged PR close events

🤖 Generated with [Claude Code](https://claude.com/claude-code)