### PR TITLE
Add Neo4j autoscaler mutating and validating webhook configurations

### DIFF
--- a/charts/kubedb-webhook-server/templates/autoscaler/mutating-webhook.yaml
+++ b/charts/kubedb-webhook-server/templates/autoscaler/mutating-webhook.yaml
@@ -255,6 +255,24 @@ webhooks:
   failurePolicy: {{ .Values.apiserver.webhook.failurePolicy }}
   sideEffects: None
 {{- end }}
+{{- if $featureGates.Neo4j }}
+- name: neo4jautoscalerwebhook.mutators.autoscaling.kubedb.com
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace }}
+      name: {{ include "kubedb-webhook-server.fullname" . }}
+      path: /mutate-autoscaling-kubedb-com-v1alpha1-neo4jautoscaler
+      port: 443
+{{- include "kubedb-webhook-server.webhook-ca-bundle" $ | nindent 4 }}
+  rules:
+    - apiGroups: ["autoscaling.kubedb.com"]
+      apiVersions: ["*"]
+      resources: ["neo4jautoscalers"]
+      operations: ["CREATE", "UPDATE"]
+  admissionReviewVersions: ["v1beta1"]
+  failurePolicy: {{ .Values.apiserver.webhook.failurePolicy }}
+  sideEffects: None
+{{- end }}
 {{- if $featureGates.PerconaXtraDB }}
 - name: perconaxtradbautoscalerwebhook.mutators.autoscaling.kubedb.com
   clientConfig:

--- a/charts/kubedb-webhook-server/templates/autoscaler/validating-webhook.yaml
+++ b/charts/kubedb-webhook-server/templates/autoscaler/validating-webhook.yaml
@@ -256,6 +256,24 @@ webhooks:
   failurePolicy: {{ .Values.apiserver.webhook.failurePolicy }}
   sideEffects: None
 {{- end }}
+{{- if $featureGates.Neo4j }}
+- name: neo4jautoscalerwebhook.validators.autoscaling.kubedb.com
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace }}
+      name: {{ include "kubedb-webhook-server.fullname" . }}
+      path: /validate-autoscaling-kubedb-com-v1alpha1-neo4jautoscaler
+      port: 443
+{{- include "kubedb-webhook-server.webhook-ca-bundle" $ | nindent 4 }}
+  rules:
+    - apiGroups: ["autoscaling.kubedb.com"]
+      apiVersions: ["*"]
+      resources: ["neo4jautoscalers"]
+      operations: ["CREATE", "UPDATE", "DELETE"]
+  admissionReviewVersions: ["v1beta1"]
+  failurePolicy: {{ .Values.apiserver.webhook.failurePolicy }}
+  sideEffects: None
+{{- end }}
 {{- if $featureGates.PerconaXtraDB }}
 - name: perconaxtradbautoscalerwebhook.validators.autoscaling.kubedb.com
   clientConfig:


### PR DESCRIPTION
## Summary
- Add `Neo4jAutoscaler` entry to the autoscaler mutating webhook configuration
- Add `Neo4jAutoscaler` entry to the autoscaler validating webhook configuration
- Both entries are gated on `featureGates.Neo4j`

## Test plan
- [ ] `helm template` the `kubedb-webhook-server` chart and verify Neo4j webhook entries appear when `featureGates.Neo4j=true`
- [ ] Confirm no entries appear when the feature gate is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)