### PR TITLE
Sync Perses dashboards from grafana-dashboards repo

### DIFF
--- a/charts/kubedb-grafana-dashboards/dashboards/hanadb/hanadb_dashboard.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/hanadb/hanadb_dashboard.json
@@ -4434,9 +4434,9 @@
   },
   "timezone": "",
   {{- if $shared }}
-  "title": "SAP HANA",
+  "title": "KubeDB / HanaDB / Database",
   {{- else }}
-  "title": {{ printf "SAP HANA / %s / %s" $.Values.app.namespace $.Values.app.name | quote }},
+  "title": {{ printf "KubeDB / HanaDB / Database / %s / %s" $.Values.app.namespace $.Values.app.name | quote }},
   {{- end }}
   "uid": "EcC4JDFWz2",
   "version": 1

--- a/charts/kubedb-perses-dashboards/dashboards/cassandra/cassandra_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/cassandra/cassandra_database_dashboard.json
@@ -47,6 +47,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -71,7 +72,7 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "max(cassandra_stats{cluster=~\"$cluster\",datacenter=~\".*\",instance=~\".*\",job=~\".*\",name=\"org:apache:cassandra:net:failuredetector:upendpointcount\"})"
                   }
                 }
               }
@@ -89,6 +90,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -117,7 +119,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "max(cassandra_stats{cluster=~\"$cluster\",datacenter=~\".*\",instance=~\".*\",job=~\".*\",name=\"org:apache:cassandra:net:failuredetector:downendpointcount\"})"
                   }
                 }
               }
@@ -164,8 +167,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -189,7 +191,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:read:latency:50thpercentile\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -209,8 +212,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -234,7 +236,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:read:latency:75thpercentile\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -254,8 +257,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -279,7 +281,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:read:latency:99thpercentile\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -299,8 +302,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -324,7 +326,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:write:latency:75thpercentile\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -344,8 +347,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -369,7 +371,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:write:latency:75thpercentile\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -389,8 +392,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -414,7 +416,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:write:latency:99thpercentile\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -461,8 +464,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -485,7 +487,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:.*:timeouts:oneminuterate\"}+0.00000001) by (instance),\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}_All"
                   }
                 }
               }
@@ -496,7 +499,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:read:timeouts:oneminuterate\"}+0.00000001) by (instance),\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}_R"
                   }
                 }
               }
@@ -507,7 +511,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:write:timeouts:oneminuterate\"}+0.00000001) by (instance),\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}_W"
                   }
                 }
               }
@@ -527,8 +532,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -551,7 +555,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",name=~\"org:apache:cassandra:metrics:clientrequest:.*:unavailables:oneminuterate\"}+0.00000001) by (instance),\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}_All"
                   }
                 }
               }
@@ -562,7 +567,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",name=~\"org:apache:cassandra:metrics:clientrequest:read:unavailables:oneminuterate\"}+0.00000001) by (instance),\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}_R"
                   }
                 }
               }
@@ -573,7 +579,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",name=~\"org:apache:cassandra:metrics:clientrequest:write:unavailables:oneminuterate\"}+0.00000001) by (instance),\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}_W"
                   }
                 }
               }
@@ -620,7 +627,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "max(cassandra_stats{cluster=~\"$cluster\",datacenter=~\".*\",instance=~\".*\",job=~\".*\",name=\"org:apache:cassandra:metrics:client:connectednativeclients:value\"})",
+                    "seriesNameFormat": ""
                   }
                 }
               }
@@ -667,8 +675,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -692,7 +699,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",name=~\"org:apache:cassandra:metrics:storage:exceptions:count\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -712,8 +720,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -737,7 +744,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".+\",name=\"org:apache:cassandra:metrics:connection:totaltimeouts:oneminuterate\"})",
+                    "seriesNameFormat": "ctt"
                   }
                 }
               }
@@ -784,8 +792,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -809,7 +816,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:antientropystage:activetasks:value\"})",
+                    "seriesNameFormat": "AntiEntropyStage"
                   }
                 }
               }
@@ -820,7 +828,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:cachecleanupexecutor:activetasks:value\"})",
+                    "seriesNameFormat": "CacheCleanupExecutor"
                   }
                 }
               }
@@ -831,7 +840,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:compactionexecutor:activetasks:value\"})",
+                    "seriesNameFormat": "CompactionExecutor"
                   }
                 }
               }
@@ -842,7 +852,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:gossipstage:activetasks:value\"})",
+                    "seriesNameFormat": "GossipStage"
                   }
                 }
               }
@@ -853,7 +864,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:hintsdispatcher:activetasks:value\"})",
+                    "seriesNameFormat": "HintsDispatcher"
                   }
                 }
               }
@@ -864,7 +876,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:internalresponsestage:activetasks:value\"})",
+                    "seriesNameFormat": "InternalResponseStage"
                   }
                 }
               }
@@ -875,7 +888,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:memtableflushwriter:activetasks:value\"})",
+                    "seriesNameFormat": "MemtableFlushWriter"
                   }
                 }
               }
@@ -886,7 +900,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:memtablepostflush:activetasks:value\"})",
+                    "seriesNameFormat": "MemtablePostFlush"
                   }
                 }
               }
@@ -897,7 +912,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:memtablereclaimmemory:activetasks:value\"})",
+                    "seriesNameFormat": "MemtableReclaimMemory"
                   }
                 }
               }
@@ -908,7 +924,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:migrationstage:activetasks:value\"})",
+                    "seriesNameFormat": "MigrationStage"
                   }
                 }
               }
@@ -919,7 +936,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:miscstage:activetasks:value\"})",
+                    "seriesNameFormat": "MiscStage"
                   }
                 }
               }
@@ -930,7 +948,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:pendingrangecalculator:activetasks:value\"})",
+                    "seriesNameFormat": "PendingRangeCalculator"
                   }
                 }
               }
@@ -941,7 +960,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:perdiskmemtableflushwriter_0:activetasks:value\"})",
+                    "seriesNameFormat": "PerDiskMemtableFlushWriter"
                   }
                 }
               }
@@ -952,7 +973,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:sampler:activetasks:value\"})",
+                    "seriesNameFormat": "Sampler"
                   }
                 }
               }
@@ -963,7 +985,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:secondaryindexmanagement:activetasks:value\"})",
+                    "seriesNameFormat": "SecondaryIndexManagement"
                   }
                 }
               }
@@ -974,7 +997,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:validationexecutor:activetasks:value\"})",
+                    "seriesNameFormat": "ValidationExecutor"
                   }
                 }
               }
@@ -985,7 +1009,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:request:countermutationstage:activetasks:value\"})",
+                    "seriesNameFormat": "CounterMutationStage"
                   }
                 }
               }
@@ -996,7 +1021,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:request:mutationstage:activetasks:value\"})",
+                    "seriesNameFormat": "MutationStage"
                   }
                 }
               }
@@ -1007,7 +1033,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:request:readrepairstage:activetasks:value\"})",
+                    "seriesNameFormat": "ReadRepairStage"
                   }
                 }
               }
@@ -1018,7 +1045,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:request:requestresponsestage:activetasks:value\"})",
+                    "seriesNameFormat": "RequestResponseStage"
                   }
                 }
               }
@@ -1029,7 +1057,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:request:viewmutationstage:activetasks:value\"})",
+                    "seriesNameFormat": "ViewMutationStage"
                   }
                 }
               }
@@ -1040,7 +1069,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:transport:native-transport-requests:activetasks:value\"})",
+                    "seriesNameFormat": "NativeTransportRequest"
                   }
                 }
               }
@@ -1060,8 +1090,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -1085,7 +1114,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:antientropystage:pendingtasks:value\"})",
+                    "seriesNameFormat": "AntiEntropyStage"
                   }
                 }
               }
@@ -1096,7 +1126,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:cachecleanupexecutor:pendingtasks:value\"})",
+                    "seriesNameFormat": "CacheCleanupExecutor"
                   }
                 }
               }
@@ -1107,7 +1138,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:compactionexecutor:pendingtasks:value\"})",
+                    "seriesNameFormat": "CompactionExecutor"
                   }
                 }
               }
@@ -1118,7 +1150,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:gossipstage:pendingtasks:value\"})",
+                    "seriesNameFormat": "GossipStage"
                   }
                 }
               }
@@ -1129,7 +1162,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:hintsdispatcher:pendingtasks:value\"})",
+                    "seriesNameFormat": "HintsDispatcher"
                   }
                 }
               }
@@ -1140,7 +1174,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:internalresponsestage:pendingtasks:value\"})",
+                    "seriesNameFormat": "InternalResponseStage"
                   }
                 }
               }
@@ -1151,7 +1186,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:memtableflushwriter:pendingtasks:value\"})",
+                    "seriesNameFormat": "MemtableFlushWriter"
                   }
                 }
               }
@@ -1162,7 +1198,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:memtablepostflush:pendingtasks:value\"})",
+                    "seriesNameFormat": "MemtablePostFlush"
                   }
                 }
               }
@@ -1173,7 +1210,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:memtablereclaimmemory:pendingtasks:value\"})",
+                    "seriesNameFormat": "MemtableReclaimMemory"
                   }
                 }
               }
@@ -1184,7 +1222,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:migrationstage:pendingtasks:value\"})",
+                    "seriesNameFormat": "MigrationStage"
                   }
                 }
               }
@@ -1195,7 +1234,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:miscstage:pendingtasks:value\"})",
+                    "seriesNameFormat": "MiscStage"
                   }
                 }
               }
@@ -1206,7 +1246,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:pendingrangecalculator:pendingtasks:value\"})",
+                    "seriesNameFormat": "PendingRangeCalculator"
                   }
                 }
               }
@@ -1217,7 +1258,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:perdiskmemtableflushwriter_0:pendingtasks:value\"})",
+                    "seriesNameFormat": "PerDiskMemtableFlushWriter"
                   }
                 }
               }
@@ -1228,7 +1271,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:sampler:pendingtasks:value\"})",
+                    "seriesNameFormat": "Sampler"
                   }
                 }
               }
@@ -1239,7 +1283,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:secondaryindexmanagement:pendingtasks:value\"})",
+                    "seriesNameFormat": "SecondaryIndexManagement"
                   }
                 }
               }
@@ -1250,7 +1295,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:validationexecutor:pendingtasks:value\"})",
+                    "seriesNameFormat": "ValidationExecutor"
                   }
                 }
               }
@@ -1261,7 +1307,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:request:countermutationstage:pendingtasks:value\"})",
+                    "seriesNameFormat": "CounterMutationStage"
                   }
                 }
               }
@@ -1272,7 +1319,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:request:mutationstage:pendingtasks:value\"})",
+                    "seriesNameFormat": "MutationStage"
                   }
                 }
               }
@@ -1283,7 +1331,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:request:readrepairstage:pendingtasks:value\"})",
+                    "seriesNameFormat": "ReadRepairStage"
                   }
                 }
               }
@@ -1294,7 +1343,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:request:requestresponsestage:pendingtasks:value\"})",
+                    "seriesNameFormat": "RequestResponseStage"
                   }
                 }
               }
@@ -1305,7 +1355,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:request:viewmutationstage:pendingtasks:value\"})",
+                    "seriesNameFormat": "ViewMutationStage"
                   }
                 }
               }
@@ -1316,7 +1367,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:transport:native-transport-requests:pendingtasks:value\"})",
+                    "seriesNameFormat": "NativeTransportRequest"
                   }
                 }
               }
@@ -1336,8 +1388,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -1361,7 +1412,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:antientropystage:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "AntiEntropyStage"
                   }
                 }
               }
@@ -1372,7 +1424,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:cachecleanupexecutor:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "CacheCleanupExecutor"
                   }
                 }
               }
@@ -1383,7 +1436,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:compactionexecutor:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "CompactionExecutor"
                   }
                 }
               }
@@ -1394,7 +1448,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:gossipstage:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "GossipStage"
                   }
                 }
               }
@@ -1405,7 +1460,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:hintsdispatcher:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "HintsDispatcher"
                   }
                 }
               }
@@ -1416,7 +1472,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:internalresponsestage:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "InternalResponseStage"
                   }
                 }
               }
@@ -1427,7 +1484,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:memtableflushwriter:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "MemtableFlushWriter"
                   }
                 }
               }
@@ -1438,7 +1496,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:memtablepostflush:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "MemtablePostFlush"
                   }
                 }
               }
@@ -1449,7 +1508,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:memtablereclaimmemory:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "MemtableReclaimMemory"
                   }
                 }
               }
@@ -1460,7 +1520,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:migrationstage:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "MigrationStage"
                   }
                 }
               }
@@ -1471,7 +1532,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:miscstage:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "MiscStage"
                   }
                 }
               }
@@ -1482,7 +1544,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:pendingrangecalculator:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "PendingRangeCalculator"
                   }
                 }
               }
@@ -1493,7 +1556,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:perdiskmemtableflushwriter_0:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "PerDiskMemtableFlushWriter"
                   }
                 }
               }
@@ -1504,7 +1569,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:sampler:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "Sampler"
                   }
                 }
               }
@@ -1515,7 +1581,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:secondaryindexmanagement:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "SecondaryIndexManagement"
                   }
                 }
               }
@@ -1526,7 +1593,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:internal:validationexecutor:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "ValidationExecutor"
                   }
                 }
               }
@@ -1537,7 +1605,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:request:countermutationstage:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "CounterMutationStage"
                   }
                 }
               }
@@ -1548,7 +1617,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:request:mutationstage:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "MutationStage"
                   }
                 }
               }
@@ -1559,7 +1629,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:request:readrepairstage:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "ReadRepairStage"
                   }
                 }
               }
@@ -1570,7 +1641,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:request:requestresponsestage:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "RequestResponseStage"
                   }
                 }
               }
@@ -1581,7 +1653,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:request:viewmutationstage:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "ViewMutationStage"
                   }
                 }
               }
@@ -1592,7 +1665,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:threadpools:transport:native-transport-requests:currentlyblockedtasks:count\"})",
+                    "seriesNameFormat": "NativeTransportRequest"
                   }
                 }
               }
@@ -1612,8 +1686,7 @@
             "spec": {
               "legend": {
                 "mode": "table",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -1637,7 +1710,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:droppedmessage:batch_remove:dropped:oneminuterate\"})",
+                    "seriesNameFormat": "BatchRemove"
                   }
                 }
               }
@@ -1648,7 +1722,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:droppedmessage:batch_store:dropped:oneminuterate\"})",
+                    "seriesNameFormat": "BatchStore"
                   }
                 }
               }
@@ -1659,7 +1734,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:droppedmessage:counter_mutation:dropped:oneminuterate\"})",
+                    "seriesNameFormat": "CounterMutation"
                   }
                 }
               }
@@ -1670,7 +1746,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:droppedmessage:hint:dropped:oneminuterate\"})",
+                    "seriesNameFormat": "Hint"
                   }
                 }
               }
@@ -1681,7 +1758,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:droppedmessage:mutation:dropped:oneminuterate\"})",
+                    "seriesNameFormat": "Mutation"
                   }
                 }
               }
@@ -1692,7 +1770,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:droppedmessage:paged_range:dropped:oneminuterate\"})",
+                    "seriesNameFormat": "PagedRange"
                   }
                 }
               }
@@ -1703,7 +1782,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:droppedmessage:range_slice:dropped:oneminuterate\"})",
+                    "seriesNameFormat": "RangeSlice"
                   }
                 }
               }
@@ -1714,7 +1794,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:droppedmessage:read:dropped:oneminuterate\"})",
+                    "seriesNameFormat": "Read"
                   }
                 }
               }
@@ -1725,7 +1806,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:droppedmessage:read_repair:dropped:oneminuterate\"})",
+                    "seriesNameFormat": "ReadRepair"
                   }
                 }
               }
@@ -1736,7 +1818,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:droppedmessage:request_response:dropped:oneminuterate\"})",
+                    "seriesNameFormat": "RequestResponse"
                   }
                 }
               }
@@ -1747,7 +1830,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".*\",name=\"org:apache:cassandra:metrics:droppedmessage:_trace:dropped:oneminuterate\"})",
+                    "seriesNameFormat": "_Trace"
                   }
                 }
               }
@@ -1794,8 +1878,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -1824,7 +1907,7 @@
                       "name": "${DS_PROMETHEUS}"
                     },
                     "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",name=~\"org:apache:cassandra:metrics:compaction:pendingtasks:value\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}_P"
                   }
                 }
               }
@@ -1835,7 +1918,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",name=~\"org:apache:cassandra:metrics:threadpools:internal:compactionexecutor:activetasks:value\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}_A"
                   }
                 }
               }
@@ -1882,8 +1966,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -1906,7 +1989,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",name=~\"org:apache:cassandra:metrics:compaction:completedtasks:value\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -1926,8 +2010,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -1950,7 +2033,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:compaction:totalcompactionscompleted:count\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -1970,8 +2054,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -1993,7 +2076,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:compaction:bytescompacted:count\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -2004,7 +2088,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\", name=~\"org:apache:cassandra:metrics:table:dfce:documents:compactionbyteswritten:count\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}_docs"
                   }
                 }
               }
@@ -2024,8 +2109,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -2049,7 +2133,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:table:livesstablecount:value\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -2069,8 +2154,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -2094,7 +2178,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "avg(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".+\",name=~\"org:apache:cassandra:metrics:table:sstablesperreadhistogram:50thpercentile\"})",
+                    "seriesNameFormat": "p55"
                   }
                 }
               }
@@ -2105,7 +2190,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "avg(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".+\",name=~\"org:apache:cassandra:metrics:table:sstablesperreadhistogram:75thpercentile\"})",
+                    "seriesNameFormat": "p75"
                   }
                 }
               }
@@ -2116,7 +2202,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "avg(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".+\",name=~\"org:apache:cassandra:metrics:table:sstablesperreadhistogram:99thpercentile\"})",
+                    "seriesNameFormat": "p99"
                   }
                 }
               }
@@ -2127,7 +2214,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "avg(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".+\",job=~\".+\",name=~\"org:apache:cassandra:metrics:table:sstablesperreadhistogram:mean\"})",
+                    "seriesNameFormat": "mean"
                   }
                 }
               }
@@ -2174,8 +2262,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -2200,7 +2287,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:cache:keycache:oneminutehitrate:value\"}*100,\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -2220,8 +2308,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -2231,7 +2318,7 @@
               },
               "yAxis": {
                 "format": {
-                  "unit": "bytes"
+                  "unit": "decbytes"
                 }
               }
             }
@@ -2243,7 +2330,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:cache:keycache:size:value\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}_sz"
                   }
                 }
               }
@@ -2254,7 +2343,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:cache:keycache:entries:value\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}_en"
                   }
                 }
               }
@@ -2274,8 +2365,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -2286,7 +2376,7 @@
               "yAxis": {
                 "format": {
                   "decimalPlaces": 0,
-                  "unit": "bytes"
+                  "unit": "decbytes"
                 },
                 "min": 0
               }
@@ -2299,7 +2389,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:cache:keycache:hits:count\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}_hits"
                   }
                 }
               }
@@ -2310,7 +2401,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:cache:keycache:requests:count\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}_reqs"
                   }
                 }
               }
@@ -2384,8 +2476,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -2396,7 +2487,7 @@
               "yAxis": {
                 "format": {
                   "decimalPlaces": 0,
-                  "unit": "bytes"
+                  "unit": "decbytes"
                 },
                 "min": 0
               }
@@ -2409,7 +2500,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:storage:load:count\"}) by (instance),\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -2429,8 +2521,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -2454,7 +2545,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:(read|write|casread|caswrite|rangeslice|viewwrite):latency:oneminuterate\"})",
+                    "seriesNameFormat": "All"
                   }
                 }
               }
@@ -2465,7 +2557,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:read:latency:oneminuterate\"})",
+                    "seriesNameFormat": "Read"
                   }
                 }
               }
@@ -2476,7 +2569,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:write:latency:oneminuterate\"})",
+                    "seriesNameFormat": "Write"
                   }
                 }
               }
@@ -2487,7 +2581,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:casread:latency:oneminuterate\"})",
+                    "seriesNameFormat": "CasRead"
                   }
                 }
               }
@@ -2498,7 +2593,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:caswrite:latency:oneminuterate\"})",
+                    "seriesNameFormat": "CasWrite"
                   }
                 }
               }
@@ -2509,7 +2605,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:rangeslice:latency:oneminuterate\"})",
+                    "seriesNameFormat": "RangeSlice"
                   }
                 }
               }
@@ -2520,7 +2617,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:viewwrite:latency:oneminuterate\"})",
+                    "seriesNameFormat": "ViewWrite"
                   }
                 }
               }
@@ -2540,8 +2638,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -2565,7 +2662,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "label_replace(sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:(read|write|casread|caswrite|rangeslice|viewwrite):latency:oneminuterate\"}) by (instance), \"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -2612,8 +2711,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -2636,7 +2734,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:read:latency:oneminuterate\"}+0.00000001) by (instance),\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -2656,8 +2755,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -2680,7 +2778,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:write:latency:oneminuterate\"}+0.00000001) by (instance),\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/cassandra/cassandra_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/cassandra/cassandra_pod_dashboard.json
@@ -1,4 +1,5 @@
 {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
 {
   "kind": "Dashboard",
   "metadata": {
@@ -110,8 +111,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -135,7 +135,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:read:latency:75thpercentile\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -155,8 +156,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -180,7 +180,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:read:latency:99thpercentile\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -200,8 +201,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -225,7 +225,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:write:latency:75thpercentile\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -245,8 +246,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -270,7 +270,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:write:latency:75thpercentile\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -290,8 +291,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -315,7 +315,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:write:latency:99thpercentile\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -362,8 +363,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -392,7 +392,7 @@
                       "name": "${DS_PROMETHEUS}"
                     },
                     "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".+\",name=~\"org:apache:cassandra:metrics:compaction:pendingtasks:value\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}_P"
                   }
                 }
               }
@@ -403,7 +403,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".+\",name=~\"org:apache:cassandra:metrics:threadpools:internal:compactionexecutor:activetasks:value\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}_A"
                   }
                 }
               }
@@ -423,8 +424,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -447,7 +447,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",name=~\"org:apache:cassandra:metrics:compaction:completedtasks:value\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -467,8 +468,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -491,7 +491,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:compaction:totalcompactionscompleted:count\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -511,8 +512,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -534,7 +534,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:compaction:bytescompacted:count\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -545,7 +546,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".*\", name=~\"org:apache:cassandra:metrics:table:dfce:documents:compactionbyteswritten:count\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}_docs"
                   }
                 }
               }
@@ -592,8 +594,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -617,7 +618,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:table:livesstablecount:value\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -637,8 +639,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -662,7 +663,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "avg(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".+\",job=~\".+\",name=~\"org:apache:cassandra:metrics:table:sstablesperreadhistogram:50thpercentile\"})",
+                    "seriesNameFormat": "p55"
                   }
                 }
               }
@@ -673,7 +675,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "avg(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".+\",job=~\".+\",name=~\"org:apache:cassandra:metrics:table:sstablesperreadhistogram:75thpercentile\"})",
+                    "seriesNameFormat": "p75"
                   }
                 }
               }
@@ -684,7 +687,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "avg(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".+\",job=~\".+\",name=~\"org:apache:cassandra:metrics:table:sstablesperreadhistogram:99thpercentile\"})",
+                    "seriesNameFormat": "p99"
                   }
                 }
               }
@@ -695,7 +699,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "avg(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".+\",job=~\".+\",name=~\"org:apache:cassandra:metrics:table:sstablesperreadhistogram:mean\"})",
+                    "seriesNameFormat": "mean"
                   }
                 }
               }
@@ -742,8 +747,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -768,7 +772,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:cache:keycache:oneminutehitrate:value\"}*100,\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -788,8 +793,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -799,7 +803,7 @@
               },
               "yAxis": {
                 "format": {
-                  "unit": "bytes"
+                  "unit": "decbytes"
                 }
               }
             }
@@ -811,7 +815,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:cache:keycache:size:value\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}_sz"
                   }
                 }
               }
@@ -822,7 +828,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:cache:keycache:entries:value\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}_en"
                   }
                 }
               }
@@ -842,8 +850,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -854,7 +861,7 @@
               "yAxis": {
                 "format": {
                   "decimalPlaces": 0,
-                  "unit": "bytes"
+                  "unit": "decbytes"
                 },
                 "min": 0
               }
@@ -867,7 +874,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:cache:keycache:hits:count\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}_hits"
                   }
                 }
               }
@@ -878,7 +886,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:cache:keycache:requests:count\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}_reqs"
                   }
                 }
               }
@@ -898,8 +907,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -923,7 +931,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",name=~\"org:apache:cassandra:metrics:clientrequest:(read|write|casread|caswrite|rangeslice|viewwrite):latency:oneminuterate\"})",
+                    "seriesNameFormat": "All"
                   }
                 }
               }
@@ -934,7 +943,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",name=~\"org:apache:cassandra:metrics:clientrequest:read:latency:oneminuterate\"})",
+                    "seriesNameFormat": "Read"
                   }
                 }
               }
@@ -945,7 +955,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",name=~\"org:apache:cassandra:metrics:clientrequest:write:latency:oneminuterate\"})",
+                    "seriesNameFormat": "Write"
                   }
                 }
               }
@@ -956,7 +967,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",name=~\"org:apache:cassandra:metrics:clientrequest:casread:latency:oneminuterate\"})",
+                    "seriesNameFormat": "CasRead"
                   }
                 }
               }
@@ -967,7 +979,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",name=~\"org:apache:cassandra:metrics:clientrequest:caswrite:latency:oneminuterate\"})",
+                    "seriesNameFormat": "CasWrite"
                   }
                 }
               }
@@ -978,7 +991,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",name=~\"org:apache:cassandra:metrics:clientrequest:rangeslice:latency:oneminuterate\"})",
+                    "seriesNameFormat": "RangeSlice"
                   }
                 }
               }
@@ -989,7 +1003,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",name=~\"org:apache:cassandra:metrics:clientrequest:viewwrite:latency:oneminuterate\"})",
+                    "seriesNameFormat": "ViewWrite"
                   }
                 }
               }
@@ -1009,8 +1024,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -1034,7 +1048,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "label_replace(sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:(read|write|casread|caswrite|rangeslice|viewwrite):latency:oneminuterate\"}) by (instance), \"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -1081,8 +1097,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -1105,7 +1120,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:read:latency:oneminuterate\"}+0.00000001) by (instance),\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -1125,8 +1141,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -1149,7 +1164,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(sum(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:write:latency:oneminuterate\"}+0.00000001) by (instance),\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }
@@ -1196,8 +1212,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "right",
-                "values": []
+                "position": "right"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -1221,7 +1236,8 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "query": "label_replace(cassandra_stats{cluster=\"$cluster\",datacenter=~\".*\",pod=~\"$pod\",instance=~\".*\",name=~\"org:apache:cassandra:metrics:clientrequest:read:latency:50thpercentile\"},\"short_instance\", \"$1\", \"instance\", \"(.*):.*\")",
+                    "seriesNameFormat": "{{ `{{short_instance}}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/cassandra/cassandra_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/cassandra/cassandra_summary_dashboard.json
@@ -92,6 +92,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
               "thresholds": {
                 "steps": [
                   {
@@ -111,7 +113,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_cassandra_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
                   }
                 }
               }
@@ -130,9 +132,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": " version ",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -158,7 +162,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_cassandra_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ version }}` }}"
                   }
                 }
               }
@@ -186,7 +190,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(sum by (namespace, pod, container) (irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-.+$\"}[5m])) * on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-.+$\"}))) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -207,29 +211,48 @@
               "columnSettings": [
                 {
                   "header": "Time",
-                  "name": "timestamp"
+                  "name": "timestamp",
+                  "width": "auto"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -331,7 +354,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(container_memory_working_set_bytes{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-.+$\",container!=\"\"} * on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\"}))) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -354,38 +377,65 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (RSS)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Cache)",
-                  "name": "Value #G"
+                  "name": "value #7"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Swap)",
-                  "name": "Value #H"
+                  "name": "value #8"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -526,7 +576,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -560,7 +610,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\" }[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
                   }
                 }
               }
@@ -573,7 +623,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\" }[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
                   }
                 }
               }
@@ -606,7 +656,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\" }[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\" }[5m])))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -639,7 +689,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\" }[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\" }[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -662,30 +712,51 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads)",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Writes)",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads + Writes)",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read)",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Write)",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read + Write)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -815,6 +886,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -839,7 +911,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_cassandra_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{requireSSL}}` }}"
                   }
                 }
               }
@@ -872,7 +944,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes{job=\"kubelet\"} + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{})) * 100",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -907,7 +979,7 @@
               },
               "yAxis": {
                 "format": {
-                  "unit": "bytes"
+                  "unit": "decbytes"
                 },
                 "max": 5000,
                 "min": 0
@@ -923,7 +995,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{  namespace=~\"$namespace\"}) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -950,7 +1022,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\" }[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -983,7 +1055,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\" }[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1002,6 +1074,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1022,7 +1095,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_cassandra_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
                   }
                 }
               }
@@ -1041,6 +1114,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "thresholds": {
                 "steps": [
                   {
@@ -1083,6 +1157,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1122,6 +1197,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1161,6 +1237,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -1203,6 +1280,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -1245,6 +1323,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },

--- a/charts/kubedb-perses-dashboards/dashboards/clickhouse/clickhouse-database.json
+++ b/charts/kubedb-perses-dashboards/dashboards/clickhouse/clickhouse-database.json
@@ -1,0 +1,1264 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "clickhouseDatabase",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / ClickHouse / Database"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Datasource",
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "ClickHouse",
+            "description": "ClickHouse stats service name",
+            "hidden": false
+          },
+          "defaultValue": "ch",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kubedb_com_clickhouse_status_phase{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Service Status"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": []
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "up{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Service Uptime"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": []
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ClickHouseAsyncMetrics_Uptime{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ClickHouse File Cache Miss Rate"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(ClickHouseProfileEvents_OpenedFileCacheMisses{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Max Parts Per Partition",
+            "description": "Maximum number of parts per partition over the specified period of time."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "max(ClickHouseAsyncMetrics_MaxPartCountForPartition{namespace=~\"$namespace\",service=~\"$app+-stats\"})\n",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Percent of Failed SELECTs",
+            "description": "Percentage of the failed SELECTs over the specified period of time."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(\n  rate(ClickHouseProfileEvents_FailedSelectQuery{namespace=~\"$namespace\", service=~\"$app+-stats\"}[$__rate_interval])\n)\n/\nsum(\n  rate(ClickHouseProfileEvents_SelectQuery{namespace=~\"$namespace\", service=~\"$app+-stats\"}[$__rate_interval])\n) * 100\n\n",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Percent of Failed INSERTs",
+            "description": "Percentage of the failed INSERTs over the specified period of time (both synchronous and asynchronous)."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "decimalPlaces": 2,
+                "unit": "percent-decimal"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(\n  sum(rate(ClickHouseProfileEvents_FailedInsertQuery{namespace=~\"$namespace\", service=~\"$app+-stats\"}[1h]))\n  +\n  sum(rate(ClickHouseProfileEvents_FailedAsyncInsertQuery{namespace=~\"$namespace\", service=~\"$app+-stats\"}[1h]))\n)\n/\n(\n  sum(rate(ClickHouseProfileEvents_InsertQuery{namespace=~\"$namespace\", service=~\"$app+-stats\"}[1h]))\n  +\n  sum(rate(ClickHouseProfileEvents_AsyncInsertQuery{namespace=~\"$namespace\", service=~\"$app+-stats\"}[1h]))\n) * 100\n\n\n\n\n\n\n\n\n",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "logged errors",
+            "description": "Number of log message with ERROR (and higher) severity over the specified period of time.asynchronous)."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "decimalPlaces": 2,
+                "unit": "percent-decimal"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(\n  increase(ClickHouseProfileEvents_LogError{namespace=~\"$namespace\", service=~\"$app+-stats\"}[1h])\n)\n\n\n\n\n\n\n",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ClickHouse Cluster Query Rate",
+            "description": "Shows the total queries per second executed by all ClickHouse pods"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(\n  rate(ClickHouseProfileEvents_Query{namespace=~\"$namespace\", service=~\"$app+-stats\"}[1h])\n)\n",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Queries with MEMORY_LIMIT_EXCEEDED",
+            "description": "Number of times when memory limit exceeded for query."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(\n  irate(ClickHouseProfileEvents_QueryMemoryLimitExceeded{namespace=~\"$namespace\", service=~\"$app+-stats\"}[1h])\n)\n\n",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Failed Queries",
+            "description": "Number of failed queries."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(\n  rate(ClickHouseProfileEvents_FailedQuery{namespace=~\"$namespace\", service=~\"$app+-stats\"}[1h])\n)\n\n",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "SELECT Queries",
+            "description": "Same as Queries, but only for SELECT queries."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(\n  rate(ClickHouseProfileEvents_SelectQuery{namespace=~\"$namespace\", service=~\"$app+-stats\"}[1h])\n)\n\n",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Failed SELECT Queries",
+            "description": "Same as Failed Queries, but only for SELECT queries."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(\n  rate(ClickHouseProfileEvents_FailedSelectQuery{namespace=~\"$namespace\", service=~\"$app+-stats\"}[1h])\n)\n\n\n",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Healthy Pods Count"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#f2495c",
+                    "value": 0
+                  },
+                  {
+                    "color": "#fade2a",
+                    "value": 2
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 3
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "count(ClickHouseAsyncMetrics_Uptime{namespace=~\"$namespace\",service=~\"$app+-stats\"} > 0)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Synchronous INSERT Queries",
+            "description": "Same as Queries, but only for INSERT queries. Only accounts for synchronous inserts."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(\n  rate(ClickHouseProfileEvents_InsertQuery{namespace=~\"$namespace\", service=~\"$app+-stats\"}[1h])\n)\n\n\n",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Asynchronous INSERT Queries",
+            "description": "Same as Queries, but only for INSERT queries. Only accounts for asynchronous inserts."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(\n  rate(ClickHouseProfileEvents_AsyncInsertQuery{namespace=~\"$namespace\", service=~\"$app+-stats\"}[1h])\n)\n\n\n",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Failed Asynchronous INSERT Queries",
+            "description": "Same as Failed Queries, but only for INSERT queries. Only accounts for asynchronous inserts."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(\n  rate(ClickHouseProfileEvents_FailedAsyncInsertQuery{namespace=~\"$namespace\", service=~\"$app+-stats\"}[1h])\n)\n\n\n\n",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cluster Status"
+          },
+          "plugin": {
+            "kind": "GaugeChart",
+            "spec": {
+              "calculation": "last-number",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#fade2a",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 0
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "up{namespace=~\"$namespace\",job=~\"$app+-stats\"} == 1",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Current QPS"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(\n  rate(ClickHouseMetrics_Query{namespace=~\"$namespace\", service=~\"$app+-stats\"}[5m])\n)\n",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Active ClickHouse Connections"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(ClickHouseMetrics_TCPConnection{namespace=~\"$namespace\",service=~\"$app+-stats\"})\n",
+                    "seriesNameFormat": "TCP Connection - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ClickHouse Metrics reads vs writes"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(ClickHouseMetrics_Read{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
+                    "seriesNameFormat": "reads - {{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(ClickHouseMetrics_Write{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
+                    "seriesNameFormat": "write - {{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ClickHouse network received vs sent"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(ClickHouseMetrics_NetworkReceive{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
+                    "seriesNameFormat": "received - {{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(ClickHouseMetrics_NetworkSend{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
+                    "seriesNameFormat": "sent - {{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Top 5 Pods by Query Count"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "1h",
+                    "query": "topk(5, avg by (pod, query_type) (\n  increase(ClickHouseProfileEvents_Query{namespace=~\"$namespace\",service=~\"$app+-stats\"}[1h]) > 0\n))",
+                    "seriesNameFormat": "{{ `{{ pod }}` }} "
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ClickHouse Opened File Cache Hits"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(ClickHouseProfileEvents_OpenedFileCacheHits{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 12,
+              "y": 1,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 12,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 12,
+              "y": 8,
+              "width": 12,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 0,
+              "y": 13,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 12,
+              "y": 13,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 0,
+              "y": 20,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 12,
+              "y": 20,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 0,
+              "y": 27,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 0,
+              "y": 35,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 12,
+              "y": 35,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 0,
+              "y": 2,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 6,
+              "y": 2,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 12,
+              "y": 2,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 18,
+              "y": 2,
+              "width": 6,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 0,
+              "y": 3,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 6,
+              "y": 3,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 12,
+              "y": 3,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            },
+            {
+              "x": 18,
+              "y": 3,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/18"
+              }
+            },
+            {
+              "x": 0,
+              "y": 7,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/19"
+              }
+            },
+            {
+              "x": 6,
+              "y": 7,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/20"
+              }
+            },
+            {
+              "x": 12,
+              "y": 7,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/21"
+              }
+            },
+            {
+              "x": 18,
+              "y": 7,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/22"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/clickhouse/clickhouse-pod.json
+++ b/charts/kubedb-perses-dashboards/dashboards/clickhouse/clickhouse-pod.json
@@ -1,0 +1,1088 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "clickhousePodSummary",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / ClickHouse / Pod"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Datasource",
+            "hidden": false
+          },
+          "defaultValue": "default",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "ClickHouse",
+            "hidden": false
+          },
+          "defaultValue": "ch",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kubedb_com_clickhouse_status_phase{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Pod",
+            "hidden": false
+          },
+          "defaultValue": "$__all",
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "pod",
+              "matchers": [
+                "up{namespace=~\"$namespace\", service=~\"$app+-stats\"}"
+              ]
+            }
+          },
+          "name": "pod"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Pod Name"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": "pod}} ",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#3274d9",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "up{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} "
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ClickHouse Uptime"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "format": {
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#e02f44",
+                    "value": 0
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 90
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ClickHouseAsyncMetrics_Uptime{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Usage"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "format": {
+                "unit": "percent"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(\n  ClickHouseMetrics_MemoryTracking{\n    namespace=~\"$namespace\",\n    service=~\"$app+-stats\",\n    pod=~\"$pod\"\n  }\n  /\n  ignoring(table)\n  ClickHouseAsyncMetrics_CGroupMemoryTotal{\n    namespace=~\"$namespace\",\n    service=~\"$app+-stats\",\n    pod=~\"$pod\"\n  }\n) * 100\n",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ClickHouse Connections"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ClickHouseMetrics_TCPConnection{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "TCP Connection - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ClickHouseMetrics_HTTPConnection{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "HTTP Connection - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ClickHouse Aborted Connections"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(ClickHouseProfileEvents_HTTPConnectionsErrors{namespace=~\"$namespace\", service=~\"$app-stats\", pod=~\"$pod\"}[5m]))",
+                    "seriesNameFormat": "Aborted Connects - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ClickHouse Client Thread Activity"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ClickHouseMetrics_GlobalThreadActive{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Threads Connected - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ClickHouse Query Thread"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ClickHouseMetrics_QueryThread{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Thread Cache Size - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ClickHouse Network Traffic",
+            "description": "\n\nHere we can see how much network traffic is generated by ClickHouse. Outbound is network traffic sent from ClickHouse and Inbound is network traffic ClickHouse has received."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(ClickHouseMetrics_NetworkReceive{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Inbound - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(ClickHouseMetrics_NetworkSend{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Outbound - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ClickHouse Network Usage Hourly",
+            "description": "\n\nHere we can see how much network traffic is generated by ClickHouse. Outbound is network traffic sent from ClickHouse and Inbound is network traffic ClickHouse has received."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "1h",
+                    "query": "increase(ClickHouseMetrics_NetworkReceive{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[1h])",
+                    "seriesNameFormat": "Received - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "1h",
+                    "query": "increase(ClickHouseMetrics_NetworkSend{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[1h])",
+                    "seriesNameFormat": "Sent - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Top 5 Pods by Query Count",
+            "description": "\n\nHere we can see how much network traffic is generated by ClickHouse. Outbound is network traffic sent from ClickHouse and Inbound is network traffic ClickHouse has received."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "1h",
+                    "query": "topk(5, avg by (pod, query_type) (\n  increase(ClickHouseProfileEvents_Query{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[1h]) > 0\n))\n",
+                    "seriesNameFormat": " {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ClickHouse Opened File Cache Hits"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(ClickHouseProfileEvents_OpenedFileCacheHits{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": " {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ClickHouse File Cache Miss Rate"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(ClickHouseProfileEvents_OpenedFileCacheMisses{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Current QPS"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "format": {
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#8ab8ff",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(ClickHouseMetrics_Query{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Storage Buffer Size"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "format": {
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#e02f44",
+                    "value": 0
+                  },
+                  {
+                    "color": "#8ab8ff",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ClickHouseMetrics_StorageBufferBytes{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Databases"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ClickHouseAsyncMetrics_NumberOfDatabases{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tables",
+            "description": "\n"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ClickHouseAsyncMetrics_NumberOfTables{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total data in MergeTree tables"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg by () (ClickHouseAsyncMetrics_TotalBytesOfMergeTreeTables{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"})",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Data selected per second",
+            "description": "Uncompressed, as stored in memory."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(\n  rate(\n    ClickHouseProfileEvents_SelectedBytes{namespace=~\"$namespace\", service=~\"$app+-stats\", pod=~\"$pod\"}[1h]\n  )\n)\n",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Data inserted per second",
+            "description": "Uncompressed, as stored in memory."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(\n  rate(\n    ClickHouseProfileEvents_MergeTreeDataWriterUncompressedBytes{namespace=~\"$namespace\", service=~\"$app+-stats\", pod=~\"$pod\"}[1h]\n  )\n)\n",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "format": {
+                "decimalPlaces": 1,
+                "unit": "percent"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(\n  ClickHouseAsyncMetrics_OSUserTimeNormalized{namespace=~\"$namespace\", service=~\"$app+-stats\", pod=~\"$pod\"}\n  +\n  ClickHouseAsyncMetrics_OSSystemTimeNormalized{namespace=~\"$namespace\", service=~\"$app+-stats\", pod=~\"$pod\"}\n) * 100\n",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 8,
+              "y": 1,
+              "width": 5,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 13,
+              "y": 1,
+              "width": 5,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 18,
+              "y": 1,
+              "width": 5,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 12,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 12,
+              "y": 4,
+              "width": 11,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 0,
+              "y": 7,
+              "width": 7,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 7,
+              "y": 7,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 13,
+              "y": 7,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 0,
+              "y": 12,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 12,
+              "y": 12,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 0,
+              "y": 20,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 12,
+              "y": 20,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 0,
+              "y": 28,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 12,
+              "y": 28,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 0,
+              "y": 36,
+              "width": 24,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 0,
+              "y": 46,
+              "width": 24,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 0,
+              "y": 57,
+              "width": 24,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            },
+            {
+              "x": 0,
+              "y": 68,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/18"
+              }
+            },
+            {
+              "x": 12,
+              "y": 68,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/19"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/clickhouse/clickhouse-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/clickhouse/clickhouse-summary.json
@@ -1,0 +1,1589 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "clickhouseSummary",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / ClickHouse / Summary"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Datasource",
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "ClickHouse",
+            "hidden": false
+          },
+          "defaultValue": "ch",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kubedb_com_clickhouse_status_phase{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Database Status",
+            "description": "Represent database status"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_clickhouse_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1",
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Version",
+            "description": "ClickHouse CR Name"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "mean",
+              "colorMode": "none",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": " version ",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              },
+              "valueFontSize": 50
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_clickhouse_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{ version }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage",
+            "description": "CPU Usage by ClickHouse pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(sum by (namespace, pod, container) (irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-.+$\"}[5m])) * on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-.+$\"}))) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Quota",
+            "description": "CPU Quote information in details"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp",
+                  "width": "auto"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(sum by (namespace, pod, container) (irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-.+$\"}[5m])) * on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-.+$\"}))) by (pod) / sum(kube_pod_container_resource_requests{job=\"kube-state-metrics\",resource=\"cpu\",namespace=\"$namespace\", pod=~\"$app-.+$\"} * on (namespace,pod) group_left () max by (namespace,pod) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(kube_pod_container_resource_requests{job=\"kube-state-metrics\",resource=\"cpu\",namespace=\"$namespace\", pod=~\"$app-.+$\"} * on (namespace,pod) group_left () max by (namespace,pod) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(sum by (namespace, pod, container) (irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-.+$\"}[5m])) * on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-.+$\"}))) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\",resource=\"cpu\",namespace=\"$namespace\", pod=~\"$app-.+$\"} * on (namespace,pod) group_left() max by (namespace, pod) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(sum by (namespace, pod, container) (irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-.+$\"}[5m])) * on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-.+$\"}))) by (pod) / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\",resource=\"cpu\",namespace=\"$namespace\", pod=~\"$app-.+$\"} * on (namespace,pod) group_left() max by (namespace, pod) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Usage",
+            "description": "Memory Usage by ClickHouse pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-.+$\",container!=\"\"} * on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\"}))) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Quota"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (RSS)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Cache)",
+                  "name": "value #7"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Swap)",
+                  "name": "value #8"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",container!=\"\", image!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum (kube_pod_container_resource_requests{job=\"kube-state-metrics\",resource=\"memory\",namespace=\"$namespace\",pod=~\"$app-.+$\"} * on (namespace, pod, cluster) group_left () max by (namespace, pod, cluster) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-.+$\",container!=\"\", image!=\"\"}) by (pod) / sum(kube_pod_container_resource_requests{job=\"kube-state-metrics\",resource=\"memory\",namespace=\"$namespace\",pod=~\"$app-.+$\"} * on (namespace, pod, cluster) group_left () max by (namespace, pod, cluster) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\",resource=\"memory\",namespace=\"$namespace\",pod=~\"$app-.+$\"} * on (namespace, pod, cluster) group_left () max by (namespace, pod, cluster) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-.+$\",container!=\"\", image!=\"\"}) by (pod) / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\",resource=\"memory\",namespace=\"$namespace\",pod=~\"$app-.+$\"} * on (namespace, pod, cluster) group_left () max by (namespace, pod, cluster) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_rss{namespace=\"$namespace\",pod=~\"$app-.+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_cache{namespace=\"$namespace\",pod=~\"$app-.+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_swap{namespace=\"$namespace\",pod=~\"$app-.+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk Usage",
+            "description": "Disk usage by ClickHouse pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk R/W Info",
+            "description": "System Disk Usage Information"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\" }[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\" }[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "IOPS (Reads+Writes)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\" }[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\" }[5m])))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ThroughPut (Read+Write)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\" }[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\" }[5m]))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Current Storage IO"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads)",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Writes)",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads + Writes)",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read)",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Write)",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read + Write)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\" ,namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\" ,namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_total{container!=\"\",pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\" ,namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\" ,namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\",pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Allocated Storage",
+            "description": "This panel describes allocated persistent storage in a table format\n"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": []
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace=~\"$namespace\"}\n+ on(persistentvolumeclaim,namespace) group_left(pod)\nkube_pod_spec_volumes_persistentvolumeclaims_info{namespace=~\"$namespace\"}\n\n\n",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Require Secure Transport",
+            "description": "When this option is enabled, connections attempted using insecure transport will be rejected."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_clickhouse_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{requireSSL}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage",
+            "description": "This panel shows the persistent volume usage in percentage. "
+          },
+          "plugin": {
+            "kind": "BarChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "percent"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes{job=\"kubelet\"} + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{})) * 100\n\n",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage History",
+            "description": "This panel describes the persistent volume usage in a time series. "
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "right",
+                "values": [
+                  "max",
+                  "last-number"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineStyle": "solid",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decbytes"
+                },
+                "max": 5000,
+                "min": 0
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(kubelet_volume_stats_used_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{  namespace=~\"$namespace\"}) \n",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Receive Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\" }[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Transmit Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\" }[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Deletion Policy",
+            "description": "KubeDB Database Resource deletionPolicy"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_clickhouse_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Nodes",
+            "description": "Total node count of ClickHouse cluster"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_clickhouse_replicas{namespace=\"$namespace\",app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Request (Core)",
+            "description": "Initial Requested CPU amount by ClickHouse Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_clickhouse_resource_request_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Limit (Core)",
+            "description": "CPU Limit in core by ClickHouse instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_clickhouse_resource_limit_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Request",
+            "description": "Initial Requested Memory amount by ClickHouse Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_clickhouse_resource_request_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Limit",
+            "description": "KubeDB ClickHouse Total Memory Limit"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_clickhouse_resource_limit_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Storage Request",
+            "description": "Total storage request by ClickHouse nodes"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_clickhouse_resource_request_storage{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 8,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 16,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 20,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 4,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 8,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 12,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 16,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 20,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 0,
+              "y": 22,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 0,
+              "y": 28,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 0,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 12,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 0,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 12,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            },
+            {
+              "x": 0,
+              "y": 51,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/18"
+              }
+            },
+            {
+              "x": 0,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/19"
+              }
+            },
+            {
+              "x": 12,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/20"
+              }
+            },
+            {
+              "x": 0,
+              "y": 65,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/21"
+              }
+            },
+            {
+              "x": 0,
+              "y": 60,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/22"
+              }
+            },
+            {
+              "x": 12,
+              "y": 60,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/23"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/connectcluster/connectcluster-connect.json
+++ b/charts/kubedb-perses-dashboards/dashboards/connectcluster/connectcluster-connect.json
@@ -1,0 +1,1543 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "7Uvb_MbSk",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / Kafka / ConnectCluster / Connect"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "default",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "ConnectCluster",
+            "hidden": false
+          },
+          "defaultValue": "connect-cluster",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kafka_kubedb_com_connectcluster_status_phase{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Status",
+            "description": "Status of Connect Cluster"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "metricLabel": "phase",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kafka_kubedb_com_connectcluster_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Uptime",
+            "description": "Cluster Uptime"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "format": {
+                "unit": "seconds"
+              },
+              "metricLabel": "",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "time() - process_start_time_seconds{namespace=~\"$namespace\",pod=~\"$app-.+$\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Outgoing Byte Total",
+            "description": "Average number of outgoing bytes sent to all servers"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineStyle": "solid",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decbytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "${datasource}"
+                    },
+                    "query": "kafka_connect_outgoing_byte_total{namespace=~\"$namespace\",pod=~\"$app-.+$\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Current number of active connections",
+            "description": "Current number of active connections"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineStyle": "solid",
+                "lineWidth": 1
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "${datasource}"
+                    },
+                    "query": "kafka_connect_connection_count{namespace=~\"$namespace\",pod=~\"$app-.+$\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Responses received and sent"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineStyle": "solid",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "${datasource}"
+                    },
+                    "query": "kafka_connect_response_total{namespace=~\"$namespace\",pod=~\"$app-.+$\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Success authentication connections",
+            "description": "Connections that were successfully authenticated using SASL or SSL"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineStyle": "solid",
+                "lineWidth": 1
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "${datasource}"
+                    },
+                    "query": "kafka_connect_successful_authentication_total{namespace=~\"$namespace\",pod=~\"$app-.+$\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Failed authentication connections",
+            "description": "Connections that failed authentication"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "${datasource}"
+                    },
+                    "query": "kafka_connect_failed_authentication_total{namespace=~\"$namespace\",pod=~\"$app-.+$\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Network IO Total",
+            "description": "Total number of network operations (reads or writes) on all connections"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineStyle": "solid",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "${datasource}"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_network_io_total{namespace=~\"$namespace\",pod=~\"$app-.+$\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Rebalances average time",
+            "description": "Rebalances average time"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "milliseconds"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_worker_rebalance_rebalance_avg_time_ms{namespace=~\"$namespace\",pod=~\"$app-.+$\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Time since last rebalance ",
+            "description": "Time since last rebalance"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_worker_rebalance_time_since_last_rebalance_ms{namespace=~\"$namespace\",pod=~\"$app-.+$\"} >= 0",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Connector count",
+            "description": "Total connector in this cluster"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "metricLabel": "",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(kafka_connect_connector_status{namespace=~\"$namespace\", pod=~\"$app-.+$\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Task count",
+            "description": "Total tasks in pods"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "metricLabel": "",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(kafka_connect_worker_connector_total_task_count{namespace=~\"$namespace\", pod=~\"$app-.+$\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "JVM Version",
+            "description": "JVM version of the cluster"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "metricLabel": "jdk",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "label_join(jvm_info{namespace=\"$namespace\", pod=~\"$app-.+$\"}, \"jdk\", \", \", \"vendor\", \"runtime\", \"version\")",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Connect Worker"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "name": "client_id"
+                },
+                {
+                  "header": "Startup time",
+                  "name": "start_time_ms"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Connector Count",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Connector Startup Success Total",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Connector Startup Failure Total",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Number of rebalances",
+                  "name": "Value #F"
+                },
+                {
+                  "format": {
+                    "unit": "milliseconds"
+                  },
+                  "header": "Average time of Rebalances",
+                  "name": "Value #G"
+                },
+                {
+                  "format": {
+                    "unit": "milliseconds"
+                  },
+                  "header": "Time since last rebalance",
+                  "name": "Value #H"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Worker instance",
+                  "name": "instance"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Number of tasks",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Task Startup Success ",
+                  "name": "value #7"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Task Startup Failure",
+                  "name": "value #8"
+                },
+                {
+                  "name": "Connector Startup Success Total",
+                  "width": 248
+                },
+                {
+                  "name": "clientId",
+                  "width": 228
+                },
+                {
+                  "header": "Worker",
+                  "name": "pod"
+                },
+                {
+                  "name": "Number of tasks",
+                  "width": 248
+                },
+                {
+                  "name": "Task Startup Failure",
+                  "width": 272
+                },
+                {
+                  "name": "Task Startup Success ",
+                  "width": 275
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kafka_connect_app_info{instance=~\"$instance\",start_time_ms!=\"\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kafka_connect_app_info{instance=~\"$instance\",version!=\"\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (pod) (kafka_connect_worker_connector_count{namespace=~\"$namespace\",pod=~\"$app-.+$\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (pod) (kafka_connect_worker_connector_startup_success_total{namespace=~\"$namespace\",pod=~\"$app-.+$\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (pod) (kafka_connect_worker__connector_startup_failure_total{namespace=~\"$namespace\",pod=~\"$app-.+$\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (pod) (kafka_connect_worker_task_count{namespace=~\"$namespace\",pod=~\"$app-.+$\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (pod) (kafka_connect_worker_task_startup_success_total{namespace=~\"$namespace\",pod=~\"$app-.+$\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (pod) (kafka_connect_worker_task_startup_failure_total{namespace=~\"$namespace\",pod=~\"$app-.+$\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Connectors"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Class",
+                  "name": "connector_class"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "name": "env"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "name": "instance"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "name": "job"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Worker",
+                  "name": "pod"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "No. of Tasks destroyed",
+                  "name": "value #9"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "name": "status"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Name",
+                  "name": "connector"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Type",
+                  "name": "connector_type"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Version",
+                  "name": "connector_version"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "No. of tasks",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "No. of Tasks running",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "No. of Tasks failed",
+                  "name": "value #7"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "No. of Tasks paused",
+                  "name": "value #8"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "No. of Tasks unassigned",
+                  "name": "value #10"
+                },
+                {
+                  "name": "name",
+                  "width": 195
+                },
+                {
+                  "header": "Namespace",
+                  "name": "namespace",
+                  "width": 106
+                },
+                {
+                  "name": "type",
+                  "width": 96
+                },
+                {
+                  "name": "version",
+                  "width": 116
+                },
+                {
+                  "name": "class",
+                  "width": 252
+                },
+                {
+                  "name": "Worker",
+                  "width": 160
+                },
+                {
+                  "name": "No. of Tasks destroyed",
+                  "width": 162
+                },
+                {
+                  "name": "No. of Tasks unassigned",
+                  "width": 168
+                },
+                {
+                  "name": "Name",
+                  "width": 183
+                }
+              ],
+              "density": "compact"
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "label_replace(label_replace(label_replace(kafka_connect_connector_info{namespace=\"$namespace\",pod=~\"$app-.+$\",status!=\"\"}, \"status\", \"1\", \"status\", \"running\"), \"status\", \"2\", \"status\", \"paused\"), \"status\", \"3\", \"status\", \"stopped\")",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_connector_info{namespace=\"$namespace\",pod=~\"$app-.+$\",connector_type!=\"\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_connector_info{namespace=\"$namespace\",pod=~\"$app-.+$\",connector_version!=\"\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_connector_info{namespace=\"$namespace\",pod=~\"$app-.+$\",connector_class!=\"\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "sum by (connector) (kafka_connect_worker_connector_total_task_count{namespace=\"$namespace\",pod=~\"$app-.+$\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "sum by (connector) (kafka_connect_worker_connector_running_task_count{namespace=\"$namespace\",pod=~\"$app-.+$\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "sum by (connector) (kafka_connect_worker_connector_failed_task_count{namespace=\"$namespace\",pod=~\"$app-.+$\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "sum by (connector) (kafka_connect_worker_connector_paused_task_count{namespace=\"$namespace\",pod=~\"$app-.+$\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "sum by (connector) (kafka_connect_worker_connector_destroyed_task_count{namespace=\"$namespace\",pod=~\"$app-.+$\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "sum by (pod) (kafka_connect_worker_connector_unassigned_task_count{namespace=\"$namespace\",pod=~\"$app-.+$\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Average number of requests",
+            "description": "Average number of requests sent per second"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineStyle": "solid",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "requests/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "${datasource}"
+                    },
+                    "query": "kafka_connect_request_size_avg{namespace=~\"$namespace\",pod=~\"$app-.+$\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "IO Ratio",
+            "description": "Fraction of time the I/O thread spent doing I/O"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "percent"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "${datasource}"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_io_ratio{namespace=~\"$namespace\",pod=~\"$app-.+$\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Incoming Byte Total",
+            "description": "Bytes read off all sockets"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineStyle": "solid",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decbytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "${datasource}"
+                    },
+                    "query": "kafka_connect_incoming_byte_total{namespace=~\"$namespace\",pod=~\"$app-.+$\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 4,
+              "y": 1,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 8,
+              "y": 1,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 12,
+              "y": 1,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 16,
+              "y": 1,
+              "width": 8,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 0,
+              "y": 6,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 24,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 0,
+              "y": 25,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 12,
+              "y": 25,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 0,
+              "y": 34,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 12,
+              "y": 34,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 0,
+              "y": 43,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 12,
+              "y": 43,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 0,
+              "y": 52,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 12,
+              "y": 52,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 0,
+              "y": 61,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 0,
+              "y": 71,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 12,
+              "y": 71,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/connectcluster/connectcluster-pod.json
+++ b/charts/kubedb-perses-dashboards/dashboards/connectcluster/connectcluster-pod.json
@@ -1,0 +1,2424 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "DcPflMxIz",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / Kafka / ConnectCluster / Pod"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "default",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "ConnectCluster",
+            "hidden": false
+          },
+          "defaultValue": "connect-cluster",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kafka_kubedb_com_connectcluster_status_phase{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": [
+            "$__all"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "pod",
+              "matchers": [
+                "kafka_connect_app_info{namespace=~\"$namespace\",pod=~\"$app.+$\"}"
+              ]
+            }
+          },
+          "name": "pod"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": [
+            "$__all"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "connector",
+              "matchers": [
+                "kafka_connect_connector_status{namespace=~\"$namespace\",pod=~\"$pod\"}"
+              ]
+            }
+          },
+          "name": "connector"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Status"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "metricLabel": "phase",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kube_pod_status_phase{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Uptime",
+            "description": "Pod uptime"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "format": {
+                "unit": "seconds"
+              },
+              "metricLabel": "",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "time() - process_start_time_seconds{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tasks Unassigned"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              },
+              "valueFontSize": 75
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "query": "sum(kafka_connect_worker_connector_unassigned_task_count{namespace=~\"$namespace\",pod=~\"$pod\"})"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tasks Destroyed"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              },
+              "valueFontSize": 75
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "query": "sum(kafka_connect_worker_connector_destroyed_task_count{namespace=~\"$namespace\",pod=~\"$pod\"})"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Batch Size Average",
+            "description": "Average size of the batches processed by the connector"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decbytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_connector_task_batch_size_avg{namespace=~\"$namespace\",pod=~\"$pod\",connector=~\"$connector\",task!=\"\"}",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Running ratio",
+            "description": "The fraction of time this task has spent in the running state."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "percent-decimal"
+                },
+                "max": 1,
+                "min": 0
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_connector_task_running_ratio{namespace=~\"$namespace\",pod=~\"$pod\",connector=~\"$connector\",task!=\"\"}",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Offset commit Average Time",
+            "description": "The average time in milliseconds taken by this task to commit offsets"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "milliseconds"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_connector_task_offset_commit_avg_time_ms{namespace=~\"$namespace\",pod=~\"$pod\",connector=~\"$connector\",task!=\"\"}",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Batch Size Avg",
+            "description": "Average size of the batches processed by the connector"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "mean",
+                  "last-number",
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decbytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_connector_task_batch_size_avg{namespace=~\"$namespace\",pod=~\"$pod\",connector=~\"$connector\",task!=\"\"}",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "JVM Threads used",
+            "description": "JVM threads info"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "jvm_threads_current{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{ pod }}` }}-current"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": " jvm_threads_daemon{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{ pod }}` }}-daemon"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": " jvm_threads_peak{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{ pod }}` }}-peak"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": " jvm_threads_deadlocked{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{ pod }}` }}-deadlocked"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "JVM memory used [non-heap]",
+            "description": "used non-heap memory in Mi"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "jvm_memory_bytes_used{namespace=~\"$namespace\",pod=~\"$pod\",area=\"nonheap\"} / 1024 / 1024",
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "JVM memory used [heap]",
+            "description": "used heap memory in Mi"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "jvm_memory_bytes_used{namespace=~\"$namespace\",pod=~\"$pod\",area=\"heap\"} / 1024 / 1024",
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "JVM pool bytes used",
+            "description": "JVM pool usage info"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "mean",
+                  "last-number",
+                  "max",
+                  "min",
+                  "sum"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 1
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "jvm_memory_pool_bytes_used{namespace=~\"$namespace\",pod=~\"$pod\"} / 1024 / 1024",
+                    "seriesNameFormat": "{{ `{{ pool }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Connector count",
+            "description": "Total connector in this cluster"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "metricLabel": "",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(kafka_connect_connector_status{namespace=~\"$namespace\", pod=~\"$pod\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "GC count increase",
+            "description": "GC count increase"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(jvm_gc_collection_seconds_count{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{ pod }}` }}-{{ `{{ gc }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "GC time increase",
+            "description": "GC time increase"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(jvm_gc_collection_seconds_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{ pod }}` }}-{{ `{{ gc }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Poll Batch Average time",
+            "description": "The average time in milliseconds taken by this task to poll for a batch of source records"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "mean",
+                  "last-number",
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "milliseconds"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_source_task_poll_batch_avg_time_ms{namespace=~\"$namespace\",pod=~\"$pod\",connector=~\"$connector\",task!=\"\"}",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Source Record Poll Total",
+            "description": "The total records produced/polled (before transformation) by this task belonging to the named source connector in this worker."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "mean",
+                  "last-number",
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "${datasource}"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_source_task_source_record_poll_total{namespace=~\"$namespace\",pod=~\"$pod\",connector=~\"$connector\",task!=\"\"}",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "24": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Source Record Write Total",
+            "description": "Total records output from the transformations and written to Kafka for this task belonging to the named source connector in this worker. This is after transformations are applied and excludes any records filtered out by the transformations."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "mean",
+                  "last-number",
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_source_task_source_record_write_total{namespace=~\"$namespace\",pod=~\"$pod\",connector=~\"$connector\",task!=\"\"}",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "25": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Source Record Active Count average",
+            "description": "The average number of records that have been produced by this task but not yet completely written to Kafka."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "mean",
+                  "last-number",
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "avg by(connector, task) (kafka_connect_source_task_source_record_active_count{namespace=~\"$namespace\",pod=~\"$pod\", connector=~\"$connector\", task!=\"\"})",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "26": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Poll Batch Max time",
+            "description": "The maximum time in milliseconds taken by this task to poll for a batch of source records"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "mean",
+                  "last-number",
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "milliseconds"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_source_task_poll_batch_max_time_ms{namespace=~\"$namespace\",pod=~\"$pod\",connector=~\"$connector\",task!=\"\"}",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "27": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Source Record Active Count max",
+            "description": "The maximum number of records that have been produced by this task but not yet completely written to Kafka."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "mean",
+                  "last-number",
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineStyle": "solid",
+                "lineWidth": 2
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "max by(connector, task) (kafka_connect_source_task_source_record_active_count{namespace=~\"$namespace\",pod=~\"$pod\", connector=~\"$connector\", task!=\"\"})",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Put Batch Average time",
+            "description": "The average time in milliseconds taken by this task to put a batch of sinks records"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "min",
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "milliseconds"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_sink_task_put_batch_avg_time_ms{namespace=~\"$namespace\",pod=~\"$pod\",connector=~\"$connector\",task!=\"\"}",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "29": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Put Batch Max time",
+            "description": "The maximum time in milliseconds taken by this task to put a batch of sinks records"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "min",
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "milliseconds"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_sink_task_put_batch_max_time_ms{namespace=~\"$namespace\",pod=~\"$pod\",connector=~\"$connector\",task!=\"\"}",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Task count",
+            "description": "Total tasks in pods"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "metricLabel": "",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(kafka_connect_worker_connector_total_task_count{namespace=~\"$namespace\", pod=~\"$pod\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "30": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Partition Count",
+            "description": "The number of topic partitions assigned to this task belonging to the named sink connector in this worker."
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Sink Task Name",
+                  "name": "Field"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_sink_task_partition_count{namespace=~\"$namespace\",pod=~\"$pod\",connector=~\"$connector\",task!=\"\"}",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "31": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Record Send Total",
+            "description": "The total record send from kafka"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Sink Task Name",
+                  "name": "Field"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_sink_task_sink_record_send_total{namespace=~\"$namespace\",pod=~\"$pod\",connector=~\"$connector\",task!=\"\"}",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "32": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Record Read Total",
+            "description": "The total record read from kafka"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Sink Task Name",
+                  "name": "Field"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_sink_task_sink_record_read_total{namespace=~\"$namespace\",pod=~\"$pod\", connector=~\"$connector\",task!=\"\"}",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "33": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total record failures",
+            "description": "Total number of failures seen by task"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_task_error_total_record_failures{namespace=~\"$namespace\",pod=~\"$pod\",connector=~\"$connector\",task!=\"\"}",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "34": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Dead letter queue Produce requests",
+            "description": "Number of produce requests to the dead letter queue"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "mean",
+                  "last-number",
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "decimalPlaces": 0,
+                  "unit": "decimal"
+                },
+                "min": 0
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_task_error_deadletterqueue_produce_requests{namespace=~\"$namespace\",pod=~\"$pod\",connector=~\"$connector\",task!=\"\"}",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "35": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Dead letter queue Produce failures",
+            "description": "Number of produce failures to the dead letter queue"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "mean",
+                  "last-number",
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "decimalPlaces": 0,
+                  "unit": "decimal"
+                },
+                "min": 0
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_task_error_deadletterqueue_produce_failures{namespace=~\"$namespace\",pod=~\"$pod\", connector=~\"$connector\",task!=\"\"}",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "36": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total record skipped",
+            "description": "Total number of records skipped by task"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "mean",
+                  "last-number",
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "decimalPlaces": 0,
+                  "unit": "decimal"
+                },
+                "min": 0
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_task_error_total_records_skipped{namespace=~\"$namespace\",pod=~\"$pod\",connector=~\"$connector\",task!=\"\"}",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "37": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total record errors",
+            "description": "Total number of errors seen by task"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "decimalPlaces": 0,
+                  "unit": "decimal"
+                },
+                "min": 0
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_task_error_total_record_errors{namespace=~\"$namespace\",pod=~\"$pod\",connector=~\"$connector\",task!=\"\"}",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "38": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total errors logged",
+            "description": "The number of messages that was logged into either the dead letter queue or with Log4j"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_task_error_total_errors_logged{namespace=~\"$namespace\",pod=~\"$pod\",connector=~\"$connector\",task!=\"\"}",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "39": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total retries",
+            "description": "Total number of retries made by task"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "mean",
+                  "last-number",
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "decimalPlaces": 0,
+                  "unit": "decimal"
+                },
+                "min": 0
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "kafka_connect_task_error_total_retries{namespace=~\"$namespace\",pod=~\"$pod\",connector=~\"$connector\",task!=\"\"}",
+                    "seriesNameFormat": "{{ `{{connector}}` }}-{{ `{{task}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Network-I/O Total"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kafka_connect_network_io_total{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Network-I/O-rate",
+            "description": "The average number of network operations (reads or writes) on all connections per second."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kafka_connect_connect_metrics_network_io_rate{namespace=\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Task Total"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              },
+              "valueFontSize": 75
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "${datasource}"
+                    },
+                    "minStep": "",
+                    "query": "sum(kafka_connect_worker_connector_total_task_count{namespace=~\"$namespace\",pod=~\"$pod\",connector=~\"$connector\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tasks Running"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              },
+              "valueFontSize": 75
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "sum(kafka_connect_worker_connector_running_task_count{namespace=~\"$namespace\",pod=~\"$pod\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tasks Paused"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              },
+              "valueFontSize": 75
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "minStep": "",
+                    "query": "sum(kafka_connect_worker_connector_paused_task_count{namespace=~\"$namespace\",pod=~\"$pod\"})"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Tasks Tasks Failed"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              },
+              "valueFontSize": 75
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus"
+                    },
+                    "query": "sum(kafka_connect_worker_connector_failed_task_count{pod=~\"$pod\"})"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 6,
+              "y": 1,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 12,
+              "y": 1,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 18,
+              "y": 1,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 0,
+              "y": 6,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 12,
+              "y": 6,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 4,
+              "y": 15,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 8,
+              "y": 15,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 12,
+              "y": 15,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 16,
+              "y": 15,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 20,
+              "y": 15,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 0,
+              "y": 19,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 12,
+              "y": 19,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 0,
+              "y": 28,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 12,
+              "y": 28,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 0,
+              "y": 38,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 12,
+              "y": 38,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            },
+            {
+              "x": 0,
+              "y": 46,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/18"
+              }
+            },
+            {
+              "x": 12,
+              "y": 46,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/19"
+              }
+            },
+            {
+              "x": 0,
+              "y": 54,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/20"
+              }
+            },
+            {
+              "x": 12,
+              "y": 54,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/21"
+              }
+            },
+            {
+              "x": 0,
+              "y": 63,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/22"
+              }
+            },
+            {
+              "x": 12,
+              "y": 63,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/23"
+              }
+            },
+            {
+              "x": 0,
+              "y": 72,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/24"
+              }
+            },
+            {
+              "x": 12,
+              "y": 72,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/25"
+              }
+            },
+            {
+              "x": 0,
+              "y": 81,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/26"
+              }
+            },
+            {
+              "x": 12,
+              "y": 81,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/27"
+              }
+            },
+            {
+              "x": 0,
+              "y": 91,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/28"
+              }
+            },
+            {
+              "x": 12,
+              "y": 91,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/29"
+              }
+            },
+            {
+              "x": 0,
+              "y": 100,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/30"
+              }
+            },
+            {
+              "x": 12,
+              "y": 100,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/31"
+              }
+            },
+            {
+              "x": 0,
+              "y": 109,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/32"
+              }
+            },
+            {
+              "x": 0,
+              "y": 119,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/33"
+              }
+            },
+            {
+              "x": 12,
+              "y": 119,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/34"
+              }
+            },
+            {
+              "x": 0,
+              "y": 127,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/35"
+              }
+            },
+            {
+              "x": 12,
+              "y": 127,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/36"
+              }
+            },
+            {
+              "x": 0,
+              "y": 135,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/37"
+              }
+            },
+            {
+              "x": 12,
+              "y": 135,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/38"
+              }
+            },
+            {
+              "x": 0,
+              "y": 143,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/39"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/connectcluster/connectcluster-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/connectcluster/connectcluster-summary.json
@@ -1,0 +1,1446 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "lLHclMbIz",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / Kafka / ConnectCluster / Summary"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Datasource",
+            "hidden": false
+          },
+          "defaultValue": "default",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "ConnectCluster",
+            "hidden": false
+          },
+          "defaultValue": "connect-cluster",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kafka_kubedb_com_connectcluster_info{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Connect Cluster Status",
+            "description": "Represent connect cluster status"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kafka_kubedb_com_connectcluster_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1",
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Version",
+            "description": "ConnectCluster Version"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "mean",
+              "colorMode": "none",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": " version ",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              },
+              "valueFontSize": 50
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kafka_kubedb_com_connectcluster_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{ version }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage",
+            "description": "CPU Usage by ConnectCluster pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(sum by (namespace, pod, container) (irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-.+$\"}[5m])) * on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-.+$\"}))) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Quota",
+            "description": "CPU Quote information in details"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp",
+                  "width": "auto"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(sum by (namespace, pod, container) (irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-.+$\"}[5m])) * on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-.+$\"}))) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(kube_pod_container_resource_requests{job=\"kube-state-metrics\",resource=\"cpu\",namespace=\"$namespace\", pod=~\"$app-.+$\"} * on (namespace,pod) group_left () max by (namespace,pod) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(sum by (namespace, pod, container) (irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-.+$\"}[5m])) * on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-.+$\"}))) by (pod) / sum(kube_pod_container_resource_requests{job=\"kube-state-metrics\",resource=\"cpu\",namespace=\"$namespace\", pod=~\"$app-.+$\"} * on (namespace,pod) group_left () max by (namespace,pod) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\",resource=\"cpu\",namespace=\"$namespace\", pod=~\"$app-.+$\"} * on (namespace,pod) group_left() max by (namespace, pod) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(sum by (namespace, pod, container) (irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-.+$\"}[5m])) * on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-.+$\"}))) by (pod) / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\",resource=\"cpu\",namespace=\"$namespace\", pod=~\"$app-.+$\"} * on (namespace,pod) group_left() max by (namespace, pod) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Usage",
+            "description": "Memory Usage by ConnectCluster pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-.+$\",container!=\"\"} * on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\"}))) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Quota",
+            "description": "Memory Quota for ConnectCluster pods"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (RSS)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Cache)",
+                  "name": "value #7"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Swap)",
+                  "name": "value #8"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-.+$\",container!=\"\", image!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum (kube_pod_container_resource_requests{job=\"kube-state-metrics\",resource=\"memory\",namespace=\"$namespace\",pod=~\"$app-.+$\"} * on (namespace, pod, cluster) group_left () max by (namespace, pod, cluster) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-.+$\",container!=\"\", image!=\"\"}) by (pod) / sum(kube_pod_container_resource_requests{job=\"kube-state-metrics\",resource=\"memory\",namespace=\"$namespace\",pod=~\"$app-.+$\"} * on (namespace, pod, cluster) group_left () max by (namespace, pod, cluster) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\",resource=\"memory\",namespace=\"$namespace\",pod=~\"$app-.+$\"} * on (namespace, pod, cluster) group_left () max by (namespace, pod, cluster) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-.+$\",container!=\"\", image!=\"\"}) by (pod) / sum(kube_pod_container_resource_limits{job=\"kube-state-metrics\",resource=\"memory\",namespace=\"$namespace\",pod=~\"$app-.+$\"} * on (namespace, pod, cluster) group_left () max by (namespace, pod, cluster) ((kube_pod_status_phase{phase=~\"Pending|Running\"} == 1))) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_rss{namespace=\"$namespace\",pod=~\"$app-.+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_cache{namespace=\"$namespace\",pod=~\"$app-.+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_swap{namespace=\"$namespace\",pod=~\"$app-.+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk Usage",
+            "description": "Disk usage by ConnectCluster pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-.+$\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk R/W Info",
+            "description": "System Disk Usage Information"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-.+$\"}[5m])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-.+$\"}[5m])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "IOPS (Reads+Writes)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-.+$\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-.+$\"}[5m])))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ThroughPut (Read+Write)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-.+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-.+$\"}[5m]))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Current Storage IO"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads)",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Writes)",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads + Writes)",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read)",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Write)",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read + Write)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app-.+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_total{container!=\"\", pod=~\"$app-.+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app-.+$\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_total{container!=\"\",pod=~\"$app-.+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", pod=~\"$app-.+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_bytes_total{container!=\"\", pod=~\"$app-.+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", pod=~\"$app-.+$\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\",pod=~\"$app-.+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Receive Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-.+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Require Secure Transport",
+            "description": "When this option is enabled, connections attempted using insecure transport will be rejected."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kafka_kubedb_com_connectcluster_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{requireSSL}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Transmit Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-.+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Deletion Policy",
+            "description": "KubeDB Database Resource deletionPolicy"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kafka_kubedb_com_connectcluster_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Nodes",
+            "description": "Total node count of connect cluster"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kafka_kubedb_com_connectcluster_replicas{namespace=\"$namespace\",app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Request (Core)",
+            "description": "Initial Requested CPU amount by ConnectCluster Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kafka_kubedb_com_connectcluster_resource_request_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Limit (Core)",
+            "description": "CPU Limit in core by ConnectCluster instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kafka_kubedb_com_connectcluster_resource_limit_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Request",
+            "description": "Initial Requested Memory amount by ConnectCluster Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kafka_kubedb_com_connectcluster_resource_request_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Limit",
+            "description": "KubeDB ConnectCluster Total Memory Limit"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kafka_kubedb_com_connectcluster_resource_limit_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Kafka Reference",
+            "description": "KubeDB Kafka that connect cluster is using"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kafka_kubedb_com_connectcluster_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{kafkaRef}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 8,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 16,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 20,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 4,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 8,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 12,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 16,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 20,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 0,
+              "y": 22,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 0,
+              "y": 30,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 0,
+              "y": 38,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 12,
+              "y": 38,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 0,
+              "y": 47,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 12,
+              "y": 47,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            },
+            {
+              "x": 0,
+              "y": 54,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/18"
+              }
+            },
+            {
+              "x": 0,
+              "y": 62,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/19"
+              }
+            },
+            {
+              "x": 12,
+              "y": 62,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/20"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/druid/druid_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/druid/druid_database_dashboard.json
@@ -67,6 +67,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -94,7 +95,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "min(druid_service_heartbeat{service=\"$app-stats\", namespace=\"$namespace\"})",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -113,6 +114,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -140,7 +142,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "min(druid_zk_connected{service=\"$app-stats\", namespace=\"$namespace\"})",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -186,7 +188,7 @@
                     },
                     "minStep": "",
                     "query": "druid_jvm_gc_cpu_total{service=\"$app-stats\", namespace=\"$namespace\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -205,6 +207,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "value",
               "format": {
                 "unit": "bytes"
               },
@@ -254,7 +257,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(increase(druid_segment_size{service=\"$app-stats\", namespace=\"$namespace\"}[$__range])) by (dataSource)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{dataSource}}` }}"
                   }
                 }
               }
@@ -289,7 +292,7 @@
                       "name": "prometheusdata"
                     },
                     "query": "count by(le) (druid_query_time_bucket)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{le}}` }}"
                   }
                 }
               }
@@ -324,7 +327,7 @@
                       "name": "prometheusdata"
                     },
                     "query": "count by(le) (druid_query_wait_time_bucket)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{le}}` }}"
                   }
                 }
               }
@@ -343,6 +346,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -385,6 +389,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -427,6 +432,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -446,7 +452,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "count_over_time(druid_task_success_count_created{service=\"$app-stats\", namespace=\"$namespace\"}[$__range])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{task_status}}` }}"
                   }
                 }
               }
@@ -465,6 +471,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -507,6 +514,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -558,7 +566,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg(increase(druid_jvm_mem_used{service=\"$app-stats\", namespace=\"$namespace\"}[$__range])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -586,7 +594,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg(increase(druid_jvm_pool_used{service=\"$app-stats\", namespace=\"$namespace\"}[$__range])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -606,8 +614,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -630,7 +637,7 @@
                     },
                     "minStep": "",
                     "query": "druid_jvm_bufferpool_count{bufferpoolName=\"direct\", service=\"$app-stats\", namespace=\"$namespace\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/druid/druid_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/druid/druid_pod_dashboard.json
@@ -1,4 +1,5 @@
 {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
 {
   "kind": "Dashboard",
   "metadata": {
@@ -111,6 +112,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -138,7 +140,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "druid_service_heartbeat{job=\"$app-stats\", namespace=\"$namespace\", pod=\"$pod\", namespace=\"$namespace\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -157,6 +159,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -184,7 +187,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "druid_zk_connected{job=\"$app-stats\", pod=\"$pod\", namespace=\"$namespace\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -212,7 +215,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg(increase(druid_jvm_mem_used{job=\"$app-stats\", pod=\"$pod\", namespace=\"$namespace\"}[$__range])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -240,7 +243,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg(increase(druid_jvm_pool_used{job=\"$app-stats\", pod=\"$pod\", namespace=\"$namespace\"}[$__range])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -260,8 +263,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -284,7 +286,7 @@
                     },
                     "minStep": "",
                     "query": "druid_jvm_bufferpool_count{bufferpoolName=\"direct\", job=\"$app-stats\", pod=\"$pod\", namespace=\"$namespace\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -330,7 +332,7 @@
                     },
                     "minStep": "",
                     "query": "druid_jvm_gc_cpu_total{job=\"$app-stats\", pod=\"$pod\", namespace=\"$namespace\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -349,6 +351,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -391,6 +394,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -433,6 +437,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {

--- a/charts/kubedb-perses-dashboards/dashboards/druid/druid_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/druid/druid_summary_dashboard.json
@@ -92,6 +92,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
               "thresholds": {
                 "steps": [
                   {
@@ -111,7 +113,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_druid_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
                   }
                 }
               }
@@ -130,9 +132,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": " version ",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -158,7 +162,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_druid_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ version }}` }}"
                   }
                 }
               }
@@ -186,7 +190,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(sum by (namespace, pod, container) (irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-.+$\"}[5m])) * on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-.+$\"}))) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -207,29 +211,48 @@
               "columnSettings": [
                 {
                   "header": "Time",
-                  "name": "timestamp"
+                  "name": "timestamp",
+                  "width": "auto"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -331,7 +354,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(container_memory_working_set_bytes{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-.+$\",container!=\"\"} * on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\"}))) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -354,38 +377,65 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (RSS)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Cache)",
-                  "name": "Value #G"
+                  "name": "value #7"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Swap)",
-                  "name": "Value #H"
+                  "name": "value #8"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -526,7 +576,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-brokers-\\\\d+$|$app-coordinators-\\\\d+$|$app-historicals-\\\\d+$|$app-middlemanagers-\\\\d+$|$app-routers-\\\\d+$|$app-overlords-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -560,7 +610,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\",  pod=~\"$app-brokers-\\\\d+$|$app-coordinators-\\\\d+$|$app-historicals-\\\\d+$|$app-middlemanagers-\\\\d+$|$app-routers-\\\\d+$|$app-overlords-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
                   }
                 }
               }
@@ -573,7 +623,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\",  pod=~\"$app-brokers-\\\\d+$|$app-coordinators-\\\\d+$|$app-historicals-\\\\d+$|$app-middlemanagers-\\\\d+$|$app-routers-\\\\d+$|$app-overlords-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
                   }
                 }
               }
@@ -606,7 +656,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\",  pod=~\"$app-brokers-\\\\d+$|$app-coordinators-\\\\d+$|$app-historicals-\\\\d+$|$app-middlemanagers-\\\\d+$|$app-routers-\\\\d+$|$app-overlords-\\\\d+$\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\",  pod=~\"$app-brokers-\\\\d+$|$app-coordinators-\\\\d+$|$app-historicals-\\\\d+$|$app-middlemanagers-\\\\d+$|$app-routers-\\\\d+$|$app-overlords-\\\\d+$\"}[5m])))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -639,7 +689,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\",  pod=~\"$app-brokers-\\\\d+$|$app-coordinators-\\\\d+$|$app-historicals-\\\\d+$|$app-middlemanagers-\\\\d+$|$app-routers-\\\\d+$|$app-overlords-\\\\d+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\",  pod=~\"$app-brokers-\\\\d+$|$app-coordinators-\\\\d+$|$app-historicals-\\\\d+$|$app-middlemanagers-\\\\d+$|$app-routers-\\\\d+$|$app-overlords-\\\\d+$\"}[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -662,30 +712,51 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads)",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Writes)",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads + Writes)",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read)",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Write)",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read + Write)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -815,6 +886,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -839,7 +911,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_druid_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{requireSSL}}` }}"
                   }
                 }
               }
@@ -872,7 +944,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-brokers-\\\\d+$|$app-coordinators-\\\\d+$|$app-historicals-\\\\d+$|$app-middlemanagers-\\\\d+$|$app-routers-\\\\d+$|$app-overlords-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -907,7 +979,7 @@
               },
               "yAxis": {
                 "format": {
-                  "unit": "bytes"
+                  "unit": "decbytes"
                 },
                 "max": 5000,
                 "min": 0
@@ -923,7 +995,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-brokers-\\\\d+$|$app-coordinators-\\\\d+$|$app-historicals-\\\\d+$|$app-middlemanagers-\\\\d+$|$app-routers-\\\\d+$|$app-overlords-\\\\d+$\",namespace=~\"$namespace\"}) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -950,7 +1022,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-brokers-\\\\d+$|$app-coordinators-\\\\d+$|$app-historicals-\\\\d+$|$app-middlemanagers-\\\\d+$|$app-routers-\\\\d+$|$app-overlords-\\\\d+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -983,7 +1055,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-brokers-\\\\d+$|$app-coordinators-\\\\d+$|$app-historicals-\\\\d+$|$app-middlemanagers-\\\\d+$|$app-routers-\\\\d+$|$app-overlords-\\\\d+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1002,6 +1074,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1022,7 +1095,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_druid_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
                   }
                 }
               }
@@ -1041,6 +1114,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "thresholds": {
                 "steps": [
                   {
@@ -1083,6 +1157,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1122,6 +1197,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1161,6 +1237,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -1203,6 +1280,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -1245,6 +1323,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },

--- a/charts/kubedb-perses-dashboards/dashboards/elasticsearch/elasticsearch_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/elasticsearch/elasticsearch_database_dashboard.json
@@ -90,6 +90,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "background_solid",
               "format": {
                 "unit": "decimal"
               },
@@ -138,6 +139,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
@@ -192,7 +194,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "max by (cluster,name) (elasticsearch_indices_docs{namespace=~\"$namespace\",cluster=~\"$app\"})",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{name}}` }}"
                   }
                 }
               }
@@ -219,7 +221,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "elasticsearch_indices_store_size_bytes{namespace=~\"$namespace\",cluster=~\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{name}}` }}"
                   }
                 }
               }
@@ -246,7 +248,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(elasticsearch_indices_indexing_index_total{namespace=~\"$namespace\",cluster=~\"$app\"}[1h])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{name}}` }}"
                   }
                 }
               }
@@ -273,7 +275,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(elasticsearch_indices_search_fetch_total{namespace=\"$namespace\",cluster=~\"$app\"}[1h])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{name}}` }}"
                   }
                 }
               }
@@ -306,7 +308,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "elasticsearch_os_mem_used_bytes{namespace=~\"$namespace\",cluster=~\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{name}}` }}"
                   }
                 }
               }
@@ -339,7 +341,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "elasticsearch_os_mem_free_bytes{namespace=~\"$namespace\",cluster=~\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{name}}` }}"
                   }
                 }
               }
@@ -366,7 +368,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "elasticsearch_os_cpu_percent{namespace=~\"$namespace\",cluster=~\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ name }}` }}"
                   }
                 }
               }
@@ -393,7 +395,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg_over_time(elasticsearch_jvm_memory_used_bytes{area=\"heap\",namespace=~\"$namespace\",cluster=~\"$app\"}[15m]) / elasticsearch_jvm_memory_max_bytes{area=\"heap\",namespace=~\"$namespace\",cluster=~\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ name }}` }}"
                   }
                 }
               }
@@ -420,7 +422,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(elasticsearch_transport_rx_packets_total{namespace=~\"$namespace\",cluster=~\"$app\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{name}}` }}-RX"
                   }
                 }
               }
@@ -433,7 +435,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(elasticsearch_transport_tx_packets_total{namespace=~\"$namespace\",cluster=~\"$app\"}[5m]) * -1",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{name}}` }}-TX"
                   }
                 }
               }
@@ -460,7 +462,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "irate(elasticsearch_jvm_gc_collection_seconds_sum{namespace=~\"$namespace\",cluster=~\"$app\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ name }}` }} {{ `{{ gc }}` }}"
                   }
                 }
               }
@@ -478,6 +480,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
@@ -523,6 +526,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
@@ -572,6 +576,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
@@ -617,6 +622,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
@@ -662,6 +668,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
@@ -711,6 +718,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
@@ -760,6 +768,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
@@ -809,6 +818,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },

--- a/charts/kubedb-perses-dashboards/dashboards/elasticsearch/elasticsearch_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/elasticsearch/elasticsearch_pod_dashboard.json
@@ -1,4 +1,5 @@
 {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
 {
   "kind": "Dashboard",
   "metadata": {
@@ -111,6 +112,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "background_solid",
               "format": {
                 "unit": "decimal"
               },
@@ -174,7 +176,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "elasticsearch_process_open_files_count{namespace=~\"$namespace\",cluster=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -192,6 +194,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
@@ -256,7 +259,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "elasticsearch_os_mem_used_bytes{namespace=~\"$namespace\",cluster=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{name}}` }}"
                   }
                 }
               }
@@ -289,7 +292,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "elasticsearch_os_mem_free_bytes{namespace=~\"$namespace\",cluster=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{name}}` }}"
                   }
                 }
               }
@@ -316,7 +319,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "elasticsearch_os_cpu_percent{namespace=~\"$namespace\",cluster=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ name }}` }}"
                   }
                 }
               }
@@ -343,7 +346,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg_over_time(elasticsearch_jvm_memory_used_bytes{area=\"heap\",namespace=~\"$namespace\",cluster=~\"$app\",pod=~\"$pod\"}[15m]) / elasticsearch_jvm_memory_max_bytes{area=\"heap\",namespace=~\"$namespace\",cluster=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ name }}` }}"
                   }
                 }
               }
@@ -370,7 +373,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(elasticsearch_transport_rx_packets_total{namespace=~\"$namespace\",cluster=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{name}}` }}-RX"
                   }
                 }
               }
@@ -383,7 +386,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(elasticsearch_transport_tx_packets_total{namespace=~\"$namespace\",cluster=~\"$app\",pod=~\"$pod\"}[5m]) * -1",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{name}}` }}-TX"
                   }
                 }
               }
@@ -410,7 +413,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "irate(elasticsearch_jvm_gc_collection_seconds_sum{namespace=~\"$namespace\",cluster=~\"$app\",pod=~\"$pod\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ name }}` }} {{ `{{ gc }}` }}"
                   }
                 }
               }
@@ -437,7 +440,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "elasticsearch_indices_docs{namespace=~\"$namespace\",cluster=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{name}}` }}"
                   }
                 }
               }
@@ -464,7 +467,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "elasticsearch_indices_store_size_bytes{namespace=~\"$namespace\",cluster=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{name}}` }}"
                   }
                 }
               }
@@ -491,7 +494,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(elasticsearch_indices_indexing_index_total{namespace=~\"$namespace\",cluster=~\"$app\",pod=~\"$pod\"}[1h])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{name}}` }}"
                   }
                 }
               }
@@ -524,7 +527,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "elasticsearch_cluster_health_number_of_pending_tasks{namespace=~\"$namespace\",cluster=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -551,7 +554,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(elasticsearch_indices_search_fetch_total{namespace=\"$namespace\",cluster=~\"$app\",pod=~\"$pod\"}[1h])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{name}}` }}"
                   }
                 }
               }
@@ -578,7 +581,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "elasticsearch_cluster_health_number_of_nodes{namespace=~\"$namespace\",cluster=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -611,7 +614,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "elasticsearch_cluster_health_number_of_data_nodes{namespace=~\"$namespace\",cluster=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -629,6 +632,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
@@ -674,6 +678,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
@@ -719,6 +724,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
@@ -768,6 +774,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
@@ -817,6 +824,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },

--- a/charts/kubedb-perses-dashboards/dashboards/elasticsearch/elasticsearch_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/elasticsearch/elasticsearch_summary_dashboard.json
@@ -91,6 +91,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
               "thresholds": {
                 "steps": [
                   {
@@ -110,7 +112,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_elasticsearch_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
                   }
                 }
               }
@@ -129,6 +131,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "seconds"
               },
@@ -171,6 +174,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -228,7 +232,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-.+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -249,29 +253,48 @@
               "columnSettings": [
                 {
                   "header": "Time",
-                  "name": "timestamp"
+                  "name": "timestamp",
+                  "width": "auto"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -373,7 +396,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app-.+$\",container!=\"\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -396,38 +419,65 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (RSS)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Cache)",
-                  "name": "Value #G"
+                  "name": "value #7"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Swap)",
-                  "name": "Value #H"
+                  "name": "value #8"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -573,7 +623,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-.+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -612,7 +662,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-.+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
                   }
                 }
               }
@@ -625,7 +675,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-.+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
                   }
                 }
               }
@@ -663,7 +713,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-.+$\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-.+$\"}[5m])))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -701,7 +751,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-.+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-.+$\"}[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -724,30 +774,51 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads)",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Writes)",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads + Writes)",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read)",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Write)",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read + Write)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -847,9 +918,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": "version",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -874,7 +947,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_elasticsearch_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{version}}` }}"
                   }
                 }
               }
@@ -937,7 +1010,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-.+$\",namespace=~\"$namespace\"}) )* 100",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -972,7 +1045,7 @@
               },
               "yAxis": {
                 "format": {
-                  "unit": "bytes"
+                  "unit": "decbytes"
                 },
                 "max": 5000,
                 "min": 0
@@ -988,7 +1061,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-.+$\",namespace=~\"$namespace\"}) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1026,7 +1099,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-.+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1064,7 +1137,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-.+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1083,6 +1156,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1122,6 +1196,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1142,7 +1217,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_elasticsearch_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
                   }
                 }
               }
@@ -1161,6 +1236,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "thresholds": {
                 "steps": [
                   {
@@ -1203,6 +1279,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1242,6 +1319,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1281,6 +1359,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -1323,6 +1402,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },

--- a/charts/kubedb-perses-dashboards/dashboards/hanadb/hanadb_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/hanadb/hanadb_dashboard.json
@@ -1,0 +1,2206 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "EcC4JDFWz2",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / HanaDB / Database"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Datasource",
+            "hidden": true
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Node",
+            "hidden": false
+          },
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "host",
+              "matchers": [
+                "hanadb_host_memory_used_total_mb"
+              ]
+            }
+          },
+          "name": "node_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": true
+          },
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "instance",
+              "matchers": [
+                "node_uname_info{nodename=\"$node_name\"}"
+              ]
+            }
+          },
+          "name": "node_ip"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "SID",
+            "hidden": false
+          },
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "sid",
+              "matchers": [
+                "hanadb_host_memory_used_total_mb{host=\"$node_name\"}"
+              ]
+            }
+          },
+          "name": "sid"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Instance number",
+            "hidden": false
+          },
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "insnr",
+              "matchers": [
+                "hanadb_host_memory_used_total_mb{host=\"$node_name\", sid=\"$sid\"}"
+              ]
+            }
+          },
+          "name": "instance_number"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Database",
+            "hidden": false
+          },
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "database_name",
+              "matchers": [
+                "hanadb_host_memory_used_total_mb{host=\"$node_name\", sid=\"$sid\", insnr=\"$instance_number\"}"
+              ]
+            }
+          },
+          "name": "database_name"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory usage"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_host_memory_physical_total_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} / 1024",
+                    "seriesNameFormat": "Total Physical Memory"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_host_memory_physical_free_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} / 1024",
+                    "seriesNameFormat": "Free Physical Memory"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_host_memory_resident_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} / 1024",
+                    "seriesNameFormat": "Resident Memory "
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_host_memory_alloc_limit_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} / 1024",
+                    "seriesNameFormat": "Allocation Limit"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_host_memory_pool_size_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} / 1024",
+                    "seriesNameFormat": "Pool Size"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "hanadb_host_memory_used_total_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} / 1024",
+                    "seriesNameFormat": "Used"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_host_memory_shared_alloc_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} / 1024",
+                    "seriesNameFormat": "Shared Memory"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "hanadb_host_memory_swap_used_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} / 1024",
+                    "seriesNameFormat": "Swap"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "hanadb_host_memory_code_size_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} / 1024",
+                    "seriesNameFormat": "Code size"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "hanadb_host_memory_shared_alloc_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} / 1024",
+                    "seriesNameFormat": "Shared"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "hanadb_column_tables_used_memory_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} / 1024",
+                    "seriesNameFormat": "Column Store Tables"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "RAM Usage",
+            "description": "Percentage of Total Used RAM over the HANA Allocation Limit."
+          },
+          "plugin": {
+            "kind": "GaugeChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "decimalPlaces": 1,
+                "unit": "percent"
+              },
+              "max": 100,
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#299c46",
+                    "value": 0
+                  },
+                  {
+                    "color": "rgba(237, 129, 40, 0.89)",
+                    "value": 85
+                  },
+                  {
+                    "color": "#d44a3a",
+                    "value": 95
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(hanadb_host_memory_used_total_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"}) / sum(hanadb_host_memory_alloc_limit_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"}) * 100",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory usage by service"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_memory_service_total_used_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"}",
+                    "seriesNameFormat": "{{ `{{service}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "SQL Executions Statistics"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "SERVICE",
+                  "name": "service"
+                },
+                {
+                  "header": "SQL TYPE",
+                  "name": "sql_type"
+                },
+                {
+                  "header": "TOTAL EXECUTIONS",
+                  "name": "value #1"
+                },
+                {
+                  "header": "TOTAL EXEC TIME",
+                  "name": "value #2"
+                },
+                {
+                  "header": "AVG EXEC TIME",
+                  "name": "value #3"
+                },
+                {
+                  "header": "AVG LOCK WAIT",
+                  "name": "value #4"
+                },
+                {
+                  "header": "MAX EXEC TIME",
+                  "name": "value #5"
+                },
+                {
+                  "header": "",
+                  "hide": true,
+                  "name": "/.*/"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "sort(hanadb_sql_service_executions_count{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_sql_service_elapsed_time_ms{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_sql_service_elap_per_exec_avg_ms{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_sql_service_lock_per_exec_ms{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_sql_service_max_ela_time_ms{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Top SQL Time Consumers"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "SQL HASH",
+                  "name": "sql_hash"
+                },
+                {
+                  "header": "SQL STRING SNIPPET",
+                  "name": "sql_string"
+                },
+                {
+                  "header": "ELA. TIME",
+                  "name": "value #1"
+                },
+                {
+                  "header": "EXEC COUNT",
+                  "name": "value #2"
+                },
+                {
+                  "header": "",
+                  "hide": true,
+                  "name": "/.*/"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sort(hanadb_sql_top_time_consumers_mu{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_sql_top_time_consumers_count{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Used Memory by Schema"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "SCHEMA",
+                  "name": "Metric"
+                },
+                {
+                  "header": "Size",
+                  "name": "value"
+                },
+                {
+                  "header": "",
+                  "hide": true,
+                  "name": "/.*/"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sort(sum(hanadb_schema_used_memory_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"}) by (schema_name))",
+                    "seriesNameFormat": "{{ `{{schema_name}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Top SQL Memory Consumers"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "SQL HASH",
+                  "name": "sql_hash"
+                },
+                {
+                  "header": "SQL STRING SNIPPET",
+                  "name": "sql_string"
+                },
+                {
+                  "header": "USED MEM.",
+                  "name": "value #1"
+                },
+                {
+                  "header": "EXEC COUNT",
+                  "name": "value #2"
+                },
+                {
+                  "header": "",
+                  "hide": true,
+                  "name": "/.*/"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "sort(hanadb_sql_top_mem_consumers_byte{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "sort(hanadb_sql_top_mem_consumers_count{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "TOP CS Tables Memory Consumers"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "SCHEMA NAME",
+                  "name": "schema_name"
+                },
+                {
+                  "header": "TABLE NAME",
+                  "name": "table_name"
+                },
+                {
+                  "header": "TOTAL MEM",
+                  "name": "value #1"
+                },
+                {
+                  "header": "EST LOAD MEM",
+                  "name": "value #2"
+                },
+                {
+                  "header": "TOTAL DISK",
+                  "name": "value #3"
+                },
+                {
+                  "header": "RECORDS",
+                  "name": "value #4"
+                },
+                {
+                  "header": "",
+                  "hide": true,
+                  "name": "/.*/"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "sort(hanadb_table_cs_top_mem_total_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"}) + 0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_table_cs_top_mem_estimated_max_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_table_cs_top_mem_disk_size_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_table_cs_top_mem_record_count{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "DATA Files Usage"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "FILE NAME",
+                  "name": "file_name"
+                },
+                {
+                  "header": "Used Size",
+                  "name": "value #1"
+                },
+                {
+                  "header": "Total Size",
+                  "name": "value #2"
+                },
+                {
+                  "header": "% Used",
+                  "name": "value #3"
+                },
+                {
+                  "header": "",
+                  "hide": true,
+                  "name": "/.*/"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_disk_data_files_used_size_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_disk_data_files_total_size_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "(hanadb_disk_data_files_used_size_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} / hanadb_disk_data_files_total_size_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"}) * 100"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "HANA System Replication Status"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "HOST",
+                  "name": "host"
+                },
+                {
+                  "header": "PORT",
+                  "name": "port"
+                },
+                {
+                  "header": "REPLICATION MODE",
+                  "name": "replication_mode"
+                },
+                {
+                  "header": "SECONDARY HOST",
+                  "name": "secondary_host"
+                },
+                {
+                  "header": "SECONDARY PORT",
+                  "name": "secondary_port"
+                },
+                {
+                  "header": "SECONDARY SITE NAME",
+                  "name": "secondary_site_name"
+                },
+                {
+                  "header": "PRIMARY SITE NAME",
+                  "name": "site_name"
+                },
+                {
+                  "header": "REPLICATION STATUS",
+                  "name": "value #1"
+                },
+                {
+                  "header": "SECONDARY ACTIVE?",
+                  "name": "value #2"
+                },
+                {
+                  "header": "SEC. RECONNECT COUNT",
+                  "name": "value #3"
+                },
+                {
+                  "header": "SEC. FAILOVER COUNT",
+                  "name": "value #4"
+                },
+                {
+                  "header": "",
+                  "hide": true,
+                  "name": "/.*/"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_sr_replication_status{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_sr_secondary_active_status{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_sr_secondary_reconnect_count{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_sr_secondary_failover_count{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "System Replication Log Shipping Delay"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "hanadb_sr_ship_delay_seconds{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"}",
+                    "seriesNameFormat": "{{ `{{host}}` }}:{{ `{{port}}` }} -> {{ `{{secondary_host}}` }}:{{ `{{secondary_port}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "System Replication Used Async Log Shipping Buffer"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "hanadb_sr_async_used_shipping_buffer_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"}",
+                    "seriesNameFormat": "{{ `{{host}}` }}:{{ `{{port}}` }} -> {{ `{{secondary_host}}` }}:{{ `{{secondary_port}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage",
+            "description": "Average percent of CPU usage based on usage type."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (pod) (rate(container_cpu_usage_seconds_total{pod=~\"$node_name\",container!=\"\",container!=\"POD\",image!=\"\"}[5m])) * 100",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "System Replication Takeover History",
+            "description": "System Replication Takeover history. When the values of end time cannot be collected, the duration time is presented as -1 and the end time as \"N/A\""
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "SOURCE HOST",
+                  "name": "src_host"
+                },
+                {
+                  "header": "END TIME",
+                  "name": "end_time"
+                },
+                {
+                  "header": "LOG POSITION TIME",
+                  "name": "log_pos_time"
+                },
+                {
+                  "header": "OPERATION MODE",
+                  "name": "operation_mode"
+                },
+                {
+                  "header": "SHIPPED LOG POS TIME",
+                  "name": "shipped_log_pos_time"
+                },
+                {
+                  "header": "SOURCE SITE",
+                  "name": "src_site_name"
+                },
+                {
+                  "header": "START TIME",
+                  "name": "start_time"
+                },
+                {
+                  "header": "TARGET HOST",
+                  "name": "tgt_host"
+                },
+                {
+                  "header": "TARGET SITE",
+                  "name": "tgt_site_name"
+                },
+                {
+                  "header": "SR STATUS",
+                  "name": "value #1"
+                },
+                {
+                  "header": "DURATION TIME",
+                  "name": "value #2"
+                },
+                {
+                  "header": "MASTER LOG POS",
+                  "name": "value #3"
+                },
+                {
+                  "header": "MASTER LOG SHIPPED",
+                  "name": "value #4"
+                },
+                {
+                  "header": "",
+                  "hide": true,
+                  "name": "/.*/"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_sr_takeover_replication_status{src_host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_sr_takeover_duration_time_seconds{src_host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "hanadb_sr_takeover_log_position_bigint{src_host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "hanadb_sr_takeover_shipped_log_position_bigint{src_host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} + 0"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Receive Rate (KB/s)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (pod) (rate(container_network_receive_bytes_total{pod=~\"$node_name\"}[5m])) / 1024",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Transmission Rate (KB/s)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "sum by (pod) (rate(container_network_transmit_bytes_total{pod=~\"$node_name\"}[5m])) / 1024",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Receive/Transmission Errors per Second"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "sum by (pod) (rate(container_network_receive_errors_total{pod=~\"$node_name\"}[5m]))",
+                    "seriesNameFormat": "{{ `{{pod}}` }} - Rx errors"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "sum by (pod) (rate(container_network_transmit_errors_total{pod=~\"$node_name\"}[5m]))",
+                    "seriesNameFormat": "{{ `{{pod}}` }} - Tx errors"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "24": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Received Requests per Second"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (pod) (rate(container_network_receive_packets_total{pod=~\"$node_name\"}[5m]))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "25": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Transmitted Requests per Second"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (pod) (rate(container_network_transmit_packets_total{pod=~\"$node_name\"}[5m]))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "26": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Collisions per Second"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "hanadb_network_collisions_per_seconds{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"}",
+                    "seriesNameFormat": "{{ `{{interface}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "27": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "I/O Throughput",
+            "description": "I/O Throughput  per Disk in KB/Sec"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "sum by (pod) (rate(container_fs_reads_bytes_total{pod=~\"$node_name\",container!=\"\",container!=\"POD\"}[5m])) / 1024",
+                    "seriesNameFormat": "{{ `{{pod}}` }} read"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "sum by (pod) (rate(container_fs_writes_bytes_total{pod=~\"$node_name\",container!=\"\",container!=\"POD\"}[5m])) / 1024",
+                    "seriesNameFormat": "{{ `{{pod}}` }} write"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Latency",
+            "description": "I/O Latency in milliseconds."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "(((sum by (host_ip) (label_replace(rate(node_disk_read_time_seconds_total{device!~\"loop.*|ram.*|fd.*\"}[5m]), \"host_ip\", \"$1\", \"instance\", \"([^:]+):.*\")) + sum by (host_ip) (label_replace(rate(node_disk_write_time_seconds_total{device!~\"loop.*|ram.*|fd.*\"}[5m]), \"host_ip\", \"$1\", \"instance\", \"([^:]+):.*\"))) / clamp_min((sum by (host_ip) (label_replace(rate(node_disk_reads_completed_total{device!~\"loop.*|ram.*|fd.*\"}[5m]), \"host_ip\", \"$1\", \"instance\", \"([^:]+):.*\")) + sum by (host_ip) (label_replace(rate(node_disk_writes_completed_total{device!~\"loop.*|ram.*|fd.*\"}[5m]), \"host_ip\", \"$1\", \"instance\", \"([^:]+):.*\"))), 0.001)) * 1000) * on (host_ip) group_left(pod) max by (host_ip, pod) (kube_pod_info{pod=~\"$node_name\"})",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "29": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "I/O Service Time"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "((sum by (host_ip) (label_replace(rate(node_disk_io_time_seconds_total{device!~\"loop.*|ram.*|fd.*\"}[5m]), \"host_ip\", \"$1\", \"instance\", \"([^:]+):.*\")) / clamp_min((sum by (host_ip) (label_replace(rate(node_disk_reads_completed_total{device!~\"loop.*|ram.*|fd.*\"}[5m]), \"host_ip\", \"$1\", \"instance\", \"([^:]+):.*\")) + sum by (host_ip) (label_replace(rate(node_disk_writes_completed_total{device!~\"loop.*|ram.*|fd.*\"}[5m]), \"host_ip\", \"$1\", \"instance\", \"([^:]+):.*\"))), 0.001)) * 1000) * on (host_ip) group_left(pod) max by (host_ip, pod) (kube_pod_info{pod=~\"$node_name\"})",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage",
+            "description": "Average CPU busy time of all cores."
+          },
+          "plugin": {
+            "kind": "GaugeChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "percent"
+              },
+              "max": 100,
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#299c46",
+                    "value": 0
+                  },
+                  {
+                    "color": "rgba(237, 129, 40, 0.89)",
+                    "value": 85
+                  },
+                  {
+                    "color": "#d44a3a",
+                    "value": 95
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(sum by (pod) (rate(container_cpu_usage_seconds_total{pod=~\"$node_name\",container!=\"\",container!=\"POD\",image!=\"\"}[5m]))) * 100",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "30": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Requests per Sec"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "sum by (pod) (rate(container_fs_reads_total{pod=~\"$node_name\",container!=\"\",container!=\"POD\"}[5m]))",
+                    "seriesNameFormat": "{{ `{{pod}}` }} read"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "sum by (pod) (rate(container_fs_writes_total{pod=~\"$node_name\",container!=\"\",container!=\"POD\"}[5m]))",
+                    "seriesNameFormat": "{{ `{{pod}}` }} write"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "31": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Queue Length (Number of Requests)",
+            "description": "average queue length of the requests that were issued to the Disk Device"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "(sum by (host_ip) (label_replace(node_disk_io_now{device!~\"loop.*|ram.*|fd.*\"}, \"host_ip\", \"$1\", \"instance\", \"([^:]+):.*\"))) * on (host_ip) group_left(pod) max by (host_ip, pod) (kube_pod_info{pod=~\"$node_name\"})",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "32": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "I/O Wait Time"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "((sum by (host_ip) (label_replace(rate(node_disk_io_time_weighted_seconds_total{device!~\"loop.*|ram.*|fd.*\"}[5m]), \"host_ip\", \"$1\", \"instance\", \"([^:]+):.*\")) / clamp_min((sum by (host_ip) (label_replace(rate(node_disk_reads_completed_total{device!~\"loop.*|ram.*|fd.*\"}[5m]), \"host_ip\", \"$1\", \"instance\", \"([^:]+):.*\")) + sum by (host_ip) (label_replace(rate(node_disk_writes_completed_total{device!~\"loop.*|ram.*|fd.*\"}[5m]), \"host_ip\", \"$1\", \"instance\", \"([^:]+):.*\"))), 0.001)) * 1000) * on (host_ip) group_left(pod) max by (host_ip, pod) (kube_pod_info{pod=~\"$node_name\"})",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Alerts"
+          },
+          "plugin": {
+            "kind": "GaugeChart",
+            "spec": {
+              "calculation": "last",
+              "format": {
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#299c46",
+                    "value": 0
+                  },
+                  {
+                    "color": "#d44a3a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "count(hanadb_alerts_current_rating{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"}) or vector(0)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Connections"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "hanadb_connections_total_count{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"}",
+                    "seriesNameFormat": "{{ `{{connection_type}}` }} : {{ `{{connection_status}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Filesystem usage",
+            "description": "Details HANA on how HANA uses the filesystem in its various directories"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(hanadb_disk_used_size_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} / hanadb_disk_total_device_size_mb)",
+                    "seriesNameFormat": "{{ `{{usage_type}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "File system details",
+            "description": "Details HANA on how HANA uses the filesystem in its various directories"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Path",
+                  "name": "path"
+                },
+                {
+                  "header": "Usage type",
+                  "name": "usage_type"
+                },
+                {
+                  "header": "Usage",
+                  "name": "value #1"
+                },
+                {
+                  "header": "Device Usage %",
+                  "name": "value #5"
+                },
+                {
+                  "header": "Device Usage",
+                  "name": "value #4"
+                },
+                {
+                  "header": "Usage %",
+                  "name": "value #3"
+                },
+                {
+                  "header": "",
+                  "hide": true,
+                  "name": "/.*/"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "hanadb_disk_used_size_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\",usage_type!=\"ROOTKEY_BACKUP\"} + 0",
+                    "seriesNameFormat": "Usage by type"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "hanadb_disk_total_size_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\",usage_type!=\"ROOTKEY_BACKUP\"} + 0",
+                    "seriesNameFormat": "Disk Total Size"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(hanadb_disk_used_size_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\",usage_type!=\"ROOTKEY_BACKUP\"} / hanadb_disk_total_size_mb) * 100",
+                    "seriesNameFormat": "Percent Used by type"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "hanadb_disk_total_used_size_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\",usage_type!=\"ROOTKEY_BACKUP\"} + 0",
+                    "seriesNameFormat": "Total Device Usage"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(hanadb_disk_total_used_size_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\",usage_type!=\"ROOTKEY_BACKUP\"} / hanadb_disk_total_size_mb) * 100",
+                    "seriesNameFormat": "Device Percent Used"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "hanadb_disk_total_device_size_mb{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\",usage_type!=\"ROOTKEY_BACKUP\"}",
+                    "seriesNameFormat": "Total Device Size"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Alert counts by rating"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "count(hanadb_alerts_current_rating{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} == 1) or vector(0)",
+                    "seriesNameFormat": "Info"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "count(hanadb_alerts_current_rating{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} == 2) or vector(0)",
+                    "seriesNameFormat": "Low"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "count(hanadb_alerts_current_rating{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} == 3) or vector(0)",
+                    "seriesNameFormat": "Medium"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "count(hanadb_alerts_current_rating{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} == 4) or vector(0)",
+                    "seriesNameFormat": "High"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "count(hanadb_alerts_current_rating{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"} == 5) or vector(0)",
+                    "seriesNameFormat": "Critical"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Alert details",
+            "description": "Alerts raised from the HANA database internal alerting system"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Timestamp",
+                  "name": "alert_timestamp"
+                },
+                {
+                  "header": "Details",
+                  "name": "alert_details"
+                },
+                {
+                  "header": "User Action",
+                  "name": "alert_useraction"
+                },
+                {
+                  "header": "Rating",
+                  "name": "value"
+                },
+                {
+                  "hide": true,
+                  "name": "/.*/"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sort_desc(hanadb_alerts_current_rating{host=~\"$node_name\",sid=~\"$sid\",insnr=~\"$instance_number\",database_name=~\"$database_name\"}) ",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 10,
+              "height": 15,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 10,
+              "y": 0,
+              "width": 4,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 14,
+              "y": 0,
+              "width": 10,
+              "height": 15,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 10,
+              "y": 5,
+              "width": 4,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 10,
+              "y": 10,
+              "width": 4,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 12,
+              "height": 11,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 12,
+              "y": 15,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 12,
+              "y": 21,
+              "width": 12,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 0,
+              "y": 27,
+              "width": 7,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 7,
+              "y": 27,
+              "width": 17,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 0,
+              "y": 35,
+              "width": 12,
+              "height": 14,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 12,
+              "y": 35,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 12,
+              "y": 43,
+              "width": 12,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 0,
+              "y": 49,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 12,
+              "y": 53,
+              "width": 12,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 0,
+              "y": 56,
+              "width": 12,
+              "height": 14,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 12,
+              "y": 63,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 0,
+              "y": 71,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            },
+            {
+              "x": 0,
+              "y": 77,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/18"
+              }
+            },
+            {
+              "x": 12,
+              "y": 77,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/19"
+              }
+            },
+            {
+              "x": 0,
+              "y": 85,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/20"
+              }
+            },
+            {
+              "x": 0,
+              "y": 92,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/21"
+              }
+            },
+            {
+              "x": 8,
+              "y": 92,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/22"
+              }
+            },
+            {
+              "x": 16,
+              "y": 92,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/23"
+              }
+            },
+            {
+              "x": 0,
+              "y": 100,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/24"
+              }
+            },
+            {
+              "x": 8,
+              "y": 100,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/25"
+              }
+            },
+            {
+              "x": 16,
+              "y": 100,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/26"
+              }
+            },
+            {
+              "x": 0,
+              "y": 109,
+              "width": 8,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/27"
+              }
+            },
+            {
+              "x": 8,
+              "y": 109,
+              "width": 8,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/28"
+              }
+            },
+            {
+              "x": 16,
+              "y": 109,
+              "width": 8,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/29"
+              }
+            },
+            {
+              "x": 0,
+              "y": 118,
+              "width": 8,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/30"
+              }
+            },
+            {
+              "x": 8,
+              "y": 118,
+              "width": 8,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/31"
+              }
+            },
+            {
+              "x": 16,
+              "y": 118,
+              "width": 8,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/32"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/hanadb/hanadb_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/hanadb/hanadb_summary_dashboard.json
@@ -1,0 +1,1589 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "hanadb-summary",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / HanaDB / Summary"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Datasource",
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_created"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "hanadb",
+            "hidden": false
+          },
+          "defaultValue": "hana-cluster",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kubedb_com_hanadb_status_phase{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Database Status",
+            "description": "Represent database status"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_hanadb_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Version",
+            "description": "HanaDB CR Name"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "mean",
+              "colorMode": "none",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": " version ",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              },
+              "valueFontSize": 50
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_hanadb_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{ version }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage",
+            "description": "CPU Usage by HanaDB pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Quota",
+            "description": "CPU Quote information in details"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp",
+                  "width": "auto"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Usage",
+            "description": "Memory Usage by HanaDB pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Quota"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (RSS)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Cache)",
+                  "name": "value #7"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Swap)",
+                  "name": "value #8"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_rss{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_cache{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_swap{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk Usage",
+            "description": "Disk usage by HanaDB pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk R/W Info",
+            "description": "System Disk Usage Information"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "IOPS (Reads+Writes)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m])))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ThroughPut (Read+Write)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Current Storage IO"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads)",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Writes)",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads + Writes)",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read)",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Write)",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read + Write)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_total{container!=\"\",pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_bytes_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\",pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Allocated Storage",
+            "description": "This panel describes allocated persistent storage in a table format\n"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": []
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubelet_volume_stats_capacity_bytes{job=\"kubelet\",namespace=~\"$namespace\"} * on(namespace,persistentvolumeclaim) group_left(pod) max by(namespace,persistentvolumeclaim,pod) (kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Topology Mode",
+            "description": "Deployment mode configured for the HanaDB resource."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_hanadb_mode{namespace=\"$namespace\", app=\"$app\"} == 1",
+                    "seriesNameFormat": "{{ `{{mode}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage",
+            "description": "This panel shows the persistent volume usage in percentage. "
+          },
+          "plugin": {
+            "kind": "BarChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "percent"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "100 * ((kubelet_volume_stats_used_bytes{job=\"kubelet\",namespace=~\"$namespace\"} / on(namespace,persistentvolumeclaim) kubelet_volume_stats_capacity_bytes{job=\"kubelet\",namespace=~\"$namespace\"}) * on(namespace,persistentvolumeclaim) group_left(pod) max by(namespace,persistentvolumeclaim,pod) (kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage History",
+            "description": "This panel describes the persistent volume usage in a time series. "
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "right",
+                "values": [
+                  "max",
+                  "last-number"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineStyle": "solid",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decbytes"
+                },
+                "max": 5000,
+                "min": 0
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubelet_volume_stats_used_bytes{job=\"kubelet\",namespace=~\"$namespace\"} * on(namespace,persistentvolumeclaim) group_left(pod) max by(namespace,persistentvolumeclaim,pod) (kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"})",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Receive Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Transmit Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Deletion Policy",
+            "description": "KubeDB Database Resource deletionPolicy"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_hanadb_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Nodes",
+            "description": "Total node count of HanaDB cluster"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_hanadb_replicas{namespace=\"$namespace\",app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Request (Core)",
+            "description": "Initial Requested CPU amount by HanaDB Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_hanadb_resource_request_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Limit (Core)",
+            "description": "CPU Limit in core by HanaDB instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_hanadb_resource_limit_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Request",
+            "description": "Initial Requested Memory amount by HanaDB Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_hanadb_resource_request_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Limit",
+            "description": "KubeDB HanaDB Total Memory Limit"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_hanadb_resource_limit_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Storage Request",
+            "description": "Total storage request by HanaDB nodes"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_hanadb_resource_request_storage{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 8,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 16,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 20,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 4,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 8,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 12,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 16,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 20,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 0,
+              "y": 22,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 0,
+              "y": 28,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 0,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 12,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 0,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 12,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            },
+            {
+              "x": 0,
+              "y": 51,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/18"
+              }
+            },
+            {
+              "x": 0,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/19"
+              }
+            },
+            {
+              "x": 12,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/20"
+              }
+            },
+            {
+              "x": 0,
+              "y": 65,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/21"
+              }
+            },
+            {
+              "x": 0,
+              "y": 74,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/22"
+              }
+            },
+            {
+              "x": 12,
+              "y": 74,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/23"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/hazelcast/hazelcast_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/hazelcast/hazelcast_database_dashboard.json
@@ -11,7 +11,7 @@
   },
   "spec": {
     "display": {
-      "name": "KubeDb / Hazelcast / Database"
+      "name": "KubeDB / Hazelcast / Database"
     },
     "variables": [
       {
@@ -90,6 +90,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -136,6 +137,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -188,7 +190,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_totalPutLatency{namespace=~\"$namespace\",service=~\"$app-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Put Latency {{ `{{pod}}` }} {{ `{{tag0}}` }}"
                   }
                 }
               }
@@ -201,7 +203,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_putCount{namespace=~\"$namespace\",service=~\"$app-stats\"}\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Put Count {{ `{{pod}}` }} {{ `{{tag0}}` }}"
                   }
                 }
               }
@@ -228,7 +230,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_totalSetLatency{namespace=~\"$namespace\",service=~\"$app-stats\"}\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "setLatency {{ `{{pod}}` }} {{ `{{tag0}}` }}"
                   }
                 }
               }
@@ -241,7 +243,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_setCount{namespace=~\"$namespace\",service=~\"$app-stats\"}\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "setCount {{ `{{pod}}` }} {{ `{{tag0}}` }}"
                   }
                 }
               }
@@ -269,7 +271,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_totalRemoveLatency{namespace=~\"$namespace\",service=~\"$app-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "RemoveLatency {{ `{{pod}}` }} {{ `{{tag0}}` }}"
                   }
                 }
               }
@@ -282,7 +284,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_removeCount{namespace=~\"$namespace\",service=~\"$app-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "RemoveCount {{ `{{pod}}` }} {{ `{{tag0}}` }}"
                   }
                 }
               }
@@ -310,7 +312,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_entryCount{namespace=~\"$namespace\",service=~\"$app-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} {{ `{{tag0}}` }}"
                   }
                 }
               }
@@ -338,7 +340,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_backupEntryCount{namespace=~\"$namespace\",service=~\"$app-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} {{ `{{tag0}}` }}"
                   }
                 }
               }
@@ -366,7 +368,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_lockedEntryCount{namespace=~\"$namespace\",service=~\"$app-stats\"}\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} {{ `{{tag0}}` }}"
                   }
                 }
               }
@@ -394,7 +396,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_dirtyEntryCount{namespace=~\"$namespace\",service=~\"$app-stats\"}\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} {{ `{{tag0}}` }}"
                   }
                 }
               }
@@ -413,6 +415,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -467,7 +470,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_activePartitionCount{namespace=~\"$namespace\",service=~\"$app-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -495,7 +498,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_systemLoadAverage{namespace=~\"$namespace\",service=~\"$app-stats\"}\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -537,7 +540,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_usedHeap{namespace=~\"$namespace\",service=~\"$app-stats\"}/(com_hazelcast_Metrics_usedHeap{namespace=~\"$namespace\",service=~\"$app-stats\"}+com_hazelcast_Metrics_freeHeap{namespace=~\"$namespace\",service=~\"$app-stats\"})*100",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -564,7 +567,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_ownedEntryMemoryCost{namespace=~\"$namespace\",service=~\"$app-stats\"}/1000\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} {{ `{{tag0}}` }}"
                   }
                 }
               }
@@ -592,7 +595,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_backupEntryMemoryCost{namespace=~\"$namespace\",service=~\"$app-stats\"}/1000\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} {{ `{{tag0}}` }}"
                   }
                 }
               }
@@ -620,7 +623,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_heapCost{namespace=~\"$namespace\",service=~\"$app-stats\"}/1000",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} {{ `{{tag0}}` }}"
                   }
                 }
               }
@@ -653,7 +656,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_totalGetLatency{namespace=~\"$namespace\",service=~\"$app-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "GetLatency {{ `{{pod}}` }} {{ `{{tag0}}` }}"
                   }
                 }
               }
@@ -666,7 +669,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_getCount{namespace=~\"$namespace\",service=~\"$app-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "GetCount {{ `{{pod}}` }} {{ `{{tag0}}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/hazelcast/hazelcast_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/hazelcast/hazelcast_pod_dashboard.json
@@ -1,4 +1,5 @@
 {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
 {
   "kind": "Dashboard",
   "metadata": {
@@ -132,6 +133,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -179,7 +181,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_systemLoadAverage{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\"}\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -206,7 +208,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "increase(com_hazelcast_Metrics_putCount{namespace=\"$namespace\", pod=~\"$pod\", service=~\"$app-stats\", tag0=~'$map'}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{tag0}}` }} - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -225,8 +227,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0.1,
@@ -250,7 +251,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "increase(com_hazelcast_Metrics_getCount{namespace=\"$namespace\", pod=~\"$pod\", service=~\"$app-stats\", tag0=~'$map'}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{tag0}}` }} - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -269,8 +270,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0.1,
@@ -294,7 +294,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_totalGetLatency{namespace=\"$namespace\", pod=~\"$pod\", service=~\"$app-stats\", tag0=~'$map'} / ignoring(unit) com_hazelcast_Metrics_getCount{namespace=\"$namespace\", pod=~\"$pod\", service=~\"$app-stats\", tag0=~'$map'}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} - {{ `{{tag0}}` }}"
                   }
                 }
               }
@@ -313,8 +313,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0.1,
@@ -357,8 +356,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0.1,
@@ -382,7 +380,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_totalPutLatency{namespace=\"$namespace\", pod=~\"$pod\", service=~\"$app-stats\", tag0=~'$map'} / ignoring(unit) com_hazelcast_Metrics_putCount{namespace=\"$namespace\", pod=~\"$pod\", service=~\"$app-stats\", tag0=~'$map'}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} - {{ `{{tag0}}` }}"
                   }
                 }
               }
@@ -409,7 +407,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_totalRemoveLatency{namespace=\"$namespace\", pod=~\"$pod\", service=~\"$app-stats\", tag0=~'$map'} / ignoring(unit) com_hazelcast_Metrics_removeCount{namespace=\"$namespace\", pod=~\"$pod\", service=~\"$app-stats\", tag0=~'$map'}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} - {{ `{{tag0}}` }}"
                   }
                 }
               }
@@ -428,7 +426,7 @@
             "spec": {
               "calculation": "last-number",
               "format": {
-                "unit": "bytes"
+                "unit": "decbytes"
               },
               "thresholds": {
                 "steps": [
@@ -449,7 +447,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_usedHeap{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -481,7 +479,7 @@
             "spec": {
               "calculation": "last-number",
               "format": {
-                "unit": "bytes"
+                "unit": "decbytes"
               },
               "thresholds": {
                 "steps": [
@@ -502,7 +500,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(com_hazelcast_Metrics_totalPhysicalMemorySize{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\"}-com_hazelcast_Metrics_freePhysicalMemorySize{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\"})",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -534,7 +532,7 @@
             "spec": {
               "calculation": "last-number",
               "format": {
-                "unit": "bytes"
+                "unit": "decbytes"
               },
               "thresholds": {
                 "steps": [
@@ -555,7 +553,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(com_hazelcast_Metrics_totalPhysicalMemorySize{namespace=\"$namespace\", service=~\"$app-stats\", pod=~\"$pod\"}) by (pod) - sum(com_hazelcast_Metrics_freePhysicalMemorySize{namespace=\"$namespace\", service=~\"$app-stats\", pod=~\"$pod\"}) by (pod) - sum(com_hazelcast_Metrics_committedHeap{namespace=\"$namespace\", service=~\"$app-stats\", pod=~\"$pod\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -587,8 +585,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0.1,
@@ -612,7 +609,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_freePhysicalMemorySize{namespace=\"$namespace\", service=~\"$app-stats\", pod=~\"$pod\"} / 1024",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -631,7 +628,7 @@
             "spec": {
               "calculation": "last-number",
               "format": {
-                "unit": "bytes"
+                "unit": "decbytes"
               },
               "thresholds": {
                 "steps": [
@@ -652,7 +649,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "( sum(com_hazelcast_Metrics_totalPhysicalMemorySize{namespace=\"$namespace\", service=~\"$app-stats\", pod=~\"$pod\"}) by (pod) - sum(com_hazelcast_Metrics_freePhysicalMemorySize{namespace=\"$namespace\", service=~\"$app-stats\", pod=~\"$pod\"}) by (pod) - sum(com_hazelcast_Metrics_committedHeap{namespace=\"$namespace\", service=~\"$app-stats\", pod=~\"$pod\"}) by (pod) )",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -684,8 +681,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0.1,
@@ -709,7 +705,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_ownedEntryMemoryCost{namespace=\"$namespace\", pod=~\"$pod\", service=~\"$app-stats\",tag0=~'$map'}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "owned-entry-{{ `{{pod}}` }}-{{ `{{tag0}}` }}"
                   }
                 }
               }
@@ -722,7 +718,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_backupEntryMemoryCost{namespace=\"$namespace\", pod=~\"$pod\", service=~\"$app-stats\",tag0=~'$map'}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "backup-entry-{{ `{{pod}}` }}-{{ `{{tag0}}` }}"
                   }
                 }
               }
@@ -735,7 +731,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_heapCost{namespace=\"$namespace\", pod=~\"$pod\", service=~\"$app-stats\",tag0=~'$map'}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "heap-cost-{{ `{{pod}}` }}-{{ `{{tag0}}` }}"
                   }
                 }
               }
@@ -754,8 +750,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0.1,
@@ -779,7 +774,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_evictionCount{namespace=\"$namespace\", pod=~\"$pod\", service=~\"$app-stats\", tag0=~'$map'}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Owned entries: {{ `{{tag0}}` }} - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -798,8 +793,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0.1,
@@ -823,7 +817,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_ownedEntryCount{namespace=\"$namespace\", pod=~\"$pod\", service=~\"$app-stats\", tag0=~'$map'}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Owned entries: {{ `{{tag0}}` }} - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -836,7 +830,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_backupEntryCount{namespace=\"$namespace\", pod=~\"$pod\", service=~\"$app-stats\", tag0=~'$map'}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Backup entries: {{ `{{tag0}}` }} - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -849,7 +843,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_lockedEntryCount{namespace=\"$namespace\", pod=~\"$pod\", service=~\"$app-stats\", tag0=~'$map'}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Locked entries: {{ `{{tag0}}` }} - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -862,7 +856,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "com_hazelcast_Metrics_dirtyEntryCount{namespace=\"$namespace\", pod=~\"$pod\", service=~\"$app-stats\", tag0=~'$map'}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Dirty entries: {{ `{{tag0}}` }} - {{ `{{pod}}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/hazelcast/hazelcast_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/hazelcast/hazelcast_summary_dashboard.json
@@ -92,6 +92,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
               "thresholds": {
                 "steps": [
                   {
@@ -111,7 +113,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_hazelcast_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
                   }
                 }
               }
@@ -130,6 +132,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "seconds"
               },
@@ -187,7 +190,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -208,29 +211,48 @@
               "columnSettings": [
                 {
                   "header": "Time",
-                  "name": "timestamp"
+                  "name": "timestamp",
+                  "width": "auto"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -332,7 +354,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\",container!=\"\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -356,38 +378,65 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (RSS)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Cache)",
-                  "name": "Value #G"
+                  "name": "value #7"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Swap)",
-                  "name": "Value #H"
+                  "name": "value #8"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -533,7 +582,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -572,7 +621,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
                   }
                 }
               }
@@ -585,7 +634,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
                   }
                 }
               }
@@ -624,7 +673,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\"}[5m])))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -663,7 +712,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\"}[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -687,30 +736,51 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads)",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Writes)",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads + Writes)",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read)",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Write)",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read + Write)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -840,6 +910,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -893,7 +964,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes{service=\"prometheus-kube-prometheus-kubelet\"} / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes{service=\"prometheus-kube-prometheus-kubelet\"} + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -928,7 +999,7 @@
               },
               "yAxis": {
                 "format": {
-                  "unit": "bytes"
+                  "unit": "decbytes"
                 },
                 "max": 5000,
                 "min": 0
@@ -944,7 +1015,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -983,7 +1054,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1022,7 +1093,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1041,6 +1112,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -1083,6 +1155,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -1125,9 +1198,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": "version",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1152,7 +1227,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_hazelcast_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{version}}` }}"
                   }
                 }
               }
@@ -1171,6 +1246,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "thresholds": {
                 "steps": [
                   {
@@ -1213,6 +1289,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1252,6 +1329,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -1294,6 +1372,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1314,7 +1393,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_hazelcast_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/ignite/ignite_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/ignite/ignite_database_dashboard.json
@@ -106,7 +106,7 @@
       }
     ],
     "panels": {
-      "0_0": {
+      "0": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -116,26 +116,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "result": {
-                      "value": "Down"
-                    },
-                    "value": "0"
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "result": {
-                      "value": "Up"
-                    },
-                    "value": "1"
-                  }
-                }
-              ],
+              "colorMode": "background_solid",
               "thresholds": {
                 "steps": [
                   {
@@ -167,7 +148,7 @@
           ]
         }
       },
-      "0_1": {
+      "1": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -177,6 +158,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "background_solid",
               "format": {
                 "unit": "hours"
               },
@@ -203,7 +185,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "hour ((ignite_uptime{namespace=\"demo\",pod=~\"$app-.+$\"}))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -211,7 +193,473 @@
           ]
         }
       },
-      "0_2": {
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Data Region memory usage  history (GiB)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "io_dataregion_default_OffheapUsedSize{namespace=\"demo\", pod=~\"$app-.+$\"} / 1024 / 1024 / 1024 ",
+                    "seriesNameFormat": "{{ `{{pod}}` }} allocated size"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "io_dataregion_default_OffHeapSize{namespace=\"demo\", pod=~\"$app-.+$\"} / 1024 / 1024 / 1024",
+                    "seriesNameFormat": "{{ `{{pod}}` }} Max size"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Data region size (GB)"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "io_dataregion_default_OffHeapSize / 1024 / 1024 / 1024",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Data region off Heap Size"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "io_dataregion_default_OffHeapSize / 1024 / 1024 / 1024",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Data region offheap used (GB)"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "io_dataregion_default_OffheapUsedSize / 1024 / 1024 / 1024",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Data Region- Max Size",
+            "description": "< 70% is good"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 70
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "io_dataregion_default_MaxSize / 1024 / 1024 / 1024\n",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Data Region- No of PagesRead",
+            "description": "< 70% is good"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "io_dataregion_default_PagesRead\n",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Data Region- No of PagesWritten",
+            "description": "< 70% is good"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "io_dataregion_default_PagesWritten\n",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cache Hits",
+            "description": "> 0 means that rebalance is in progress"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.2,
+                "connectNulls": true,
+                "display": "bar",
+                "lineWidth": 2
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "cache_${cacheName}_CacheHits",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cache Hits",
+            "description": "> 0 means that rebalance is in progress"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.2,
+                "connectNulls": true,
+                "display": "bar",
+                "lineWidth": 2
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "cache_${cacheName}_CacheHits",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cache Puts",
+            "description": "> 0 means that rebalance is in progress"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.2,
+                "connectNulls": true,
+                "display": "bar",
+                "lineWidth": 2
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "cache_${cacheName}_CachePuts",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -221,26 +669,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "result": {
-                      "value": "Down"
-                    },
-                    "value": "0"
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "result": {
-                      "value": "Up"
-                    },
-                    "value": "1"
-                  }
-                }
-              ],
+              "colorMode": "background_solid",
               "thresholds": {
                 "steps": [
                   {
@@ -272,20 +701,60 @@
           ]
         }
       },
-      "0_3": {
+      "20": {
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "Topology",
-            "description": "Topology snapshot"
+            "name": "Cache Misses",
+            "description": "> 0 means that rebalance is in progress"
           },
           "plugin": {
-            "kind": "StatChart",
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.2,
+                "connectNulls": true,
+                "display": "bar",
+                "lineWidth": 2
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "cache_${cacheName}_CacheMisses",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cache Size",
+            "description": "> 0 means that rebalance is in progress"
+          },
+          "plugin": {
+            "kind": "GaugeChart",
             "spec": {
               "calculation": "last-number",
-              "format": {
-                "unit": "decimal"
-              },
               "thresholds": {
                 "steps": [
                   {
@@ -311,9 +780,9 @@
                       "kind": "PrometheusDatasource",
                       "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
                     },
-                    "minStep": "2",
-                    "query": "up{job=\"${job}\"}",
-                    "seriesNameFormat": ""
+                    "minStep": "",
+                    "query": "cache_${cacheName}_CacheSize",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -321,7 +790,199 @@
           ]
         }
       },
-      "0_4": {
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Hit Ratio",
+            "description": "> 0 means that rebalance is in progress"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineStyle": "solid",
+                "lineWidth": 1
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "(cache_${cacheName}_CacheHits) / clamp_min((cache_${cacheName}_CacheHits) + (cache_${cacheName}_CacheMisses), 1)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Moving partitions",
+            "description": "> 0 means that rebalance is in progress"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "cacheGroups_ignite_sys_cache_LocalNodeMovingPartitionsCount ",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "24": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Owning partitions"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "decimalPlaces": 0,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "cacheGroups_ignite_sys_cache_LocalNodeOwningPartitionsCount",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Topology",
+            "description": "Topology snapshot"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": "pod",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "2s",
+                    "query": "up{job=\"${job}\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -333,8 +994,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0.1,
@@ -362,7 +1022,7 @@
                     },
                     "minStep": "",
                     "query": " avg (up{namespace=\"demo\", pod=~\"$app-.+$\"})",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -370,7 +1030,7 @@
           ]
         }
       },
-      "0_5": {
+      "5": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -411,7 +1071,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "100 - ((sys_memory_heap_max - sys_memory_heap_used)*100 / sys_memory_heap_max)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -419,7 +1079,7 @@
           ]
         }
       },
-      "0_6": {
+      "6": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -464,7 +1124,7 @@
                     },
                     "minStep": "",
                     "query": "sys_CpuLoad * 100",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -472,7 +1132,7 @@
           ]
         }
       },
-      "0_7": {
+      "7": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -482,6 +1142,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "background_solid",
               "format": {
                 "unit": "decimal"
               },
@@ -512,7 +1173,7 @@
                     },
                     "minStep": "",
                     "query": "threadPools_GridRebalanceExecutor_ActiveCount",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -520,7 +1181,7 @@
           ]
         }
       },
-      "1_0": {
+      "8": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -566,7 +1227,7 @@
                     },
                     "minStep": "",
                     "query": "avg (sys_CpuLoad{namespace=\"demo\", pod=~\"$app-.+$\"}) * 100",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -574,7 +1235,7 @@
           ]
         }
       },
-      "1_1": {
+      "9": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -621,701 +1282,7 @@
                     },
                     "minStep": "",
                     "query": "sys_memory_heap_used{namespace=\"demo\", pod=~\"$app-.+$\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "1_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Data Region memory usage  history (GiB)"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "legend": {
-                "mode": "list",
-                "position": "bottom",
-                "values": []
-              },
-              "visual": {
-                "areaOpacity": 0.1,
-                "connectNulls": true,
-                "display": "line",
-                "lineWidth": 1
-              },
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "io_dataregion_default_OffheapUsedSize{namespace=\"demo\", pod=~\"$app-.+$\"} / 1024 / 1024 / 1024 ",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "io_dataregion_default_OffHeapSize{namespace=\"demo\", pod=~\"$app-.+$\"} / 1024 / 1024 / 1024",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Data region size (GB)"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "io_dataregion_default_OffHeapSize / 1024 / 1024 / 1024",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Data region off Heap Size"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "io_dataregion_default_OffHeapSize / 1024 / 1024 / 1024",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Data region offheap used (GB)"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "io_dataregion_default_OffheapUsedSize / 1024 / 1024 / 1024",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Data Region- Max Size",
-            "description": "< 70% is good"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#73bf69",
-                    "value": 70
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "io_dataregion_default_MaxSize / 1024 / 1024 / 1024\n",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_4": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Data Region- No of PagesRead",
-            "description": "< 70% is good"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "decimal"
-              },
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#73bf69",
-                    "value": 80
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "io_dataregion_default_PagesRead\n",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_5": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Data Region- No of PagesWritten",
-            "description": "< 70% is good"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "decimal"
-              },
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#73bf69",
-                    "value": 80
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "io_dataregion_default_PagesWritten\n",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Cache Hits",
-            "description": "> 0 means that rebalance is in progress"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "legend": {
-                "mode": "table",
-                "position": "bottom",
-                "values": []
-              },
-              "visual": {
-                "areaOpacity": 0.2,
-                "connectNulls": true,
-                "display": "bar",
-                "lineWidth": 2
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "cache_${cacheName}_CacheHits",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Cache Hits",
-            "description": "> 0 means that rebalance is in progress"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "legend": {
-                "mode": "table",
-                "position": "bottom",
-                "values": []
-              },
-              "visual": {
-                "areaOpacity": 0.2,
-                "connectNulls": true,
-                "display": "bar",
-                "lineWidth": 2
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "cache_${cacheName}_CacheHits",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Cache Puts",
-            "description": "> 0 means that rebalance is in progress"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "legend": {
-                "mode": "table",
-                "position": "bottom",
-                "values": []
-              },
-              "visual": {
-                "areaOpacity": 0.2,
-                "connectNulls": true,
-                "display": "bar",
-                "lineWidth": 2
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "cache_${cacheName}_CachePuts",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Cache Misses",
-            "description": "> 0 means that rebalance is in progress"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "legend": {
-                "mode": "table",
-                "position": "bottom",
-                "values": []
-              },
-              "visual": {
-                "areaOpacity": 0.2,
-                "connectNulls": true,
-                "display": "bar",
-                "lineWidth": 2
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "cache_${cacheName}_CacheMisses",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_4": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Cache Size",
-            "description": "> 0 means that rebalance is in progress"
-          },
-          "plugin": {
-            "kind": "GaugeChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#f2495c",
-                    "value": 80
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "cache_${cacheName}_CacheSize",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_5": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Hit Ratio",
-            "description": "> 0 means that rebalance is in progress"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "legend": {
-                "mode": "list",
-                "position": "bottom",
-                "values": []
-              },
-              "visual": {
-                "areaOpacity": 0.1,
-                "connectNulls": true,
-                "display": "line",
-                "lineStyle": "solid",
-                "lineWidth": 1
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "(cache_${cacheName}_CacheHits) / clamp_min((cache_${cacheName}_CacheHits) + (cache_${cacheName}_CacheMisses), 1)",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_6": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Moving partitions",
-            "description": "> 0 means that rebalance is in progress"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#f2495c",
-                    "value": 80
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "cacheGroups_ignite_sys_cache_LocalNodeMovingPartitionsCount ",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_7": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Owning partitions"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "decimalPlaces": 0,
-                "unit": "decimal"
-              },
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#73bf69",
-                    "value": 1
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "cacheGroups_ignite_sys_cache_LocalNodeOwningPartitionsCount",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1329,10 +1296,7 @@
         "kind": "Grid",
         "spec": {
           "display": {
-            "title": "General",
-            "collapse": {
-              "open": true
-            }
+            "title": "Panel Group 1"
           },
           "items": [
             {
@@ -1341,7 +1305,7 @@
               "width": 4,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/0_0"
+                "$ref": "#/spec/panels/0"
               }
             },
             {
@@ -1350,7 +1314,7 @@
               "width": 4,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/0_1"
+                "$ref": "#/spec/panels/1"
               }
             },
             {
@@ -1359,7 +1323,7 @@
               "width": 4,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/0_2"
+                "$ref": "#/spec/panels/2"
               }
             },
             {
@@ -1368,7 +1332,7 @@
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/0_3"
+                "$ref": "#/spec/panels/3"
               }
             },
             {
@@ -1377,7 +1341,7 @@
               "width": 9,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_4"
+                "$ref": "#/spec/panels/4"
               }
             },
             {
@@ -1386,7 +1350,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_5"
+                "$ref": "#/spec/panels/5"
               }
             },
             {
@@ -1395,7 +1359,7 @@
               "width": 7,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_6"
+                "$ref": "#/spec/panels/6"
               }
             },
             {
@@ -1404,29 +1368,16 @@
               "width": 24,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_7"
+                "$ref": "#/spec/panels/7"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Memory and CPU",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 23,
               "width": 24,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1_0"
+                "$ref": "#/spec/panels/8"
               }
             },
             {
@@ -1435,7 +1386,7 @@
               "width": 12,
               "height": 10,
               "content": {
-                "$ref": "#/spec/panels/1_1"
+                "$ref": "#/spec/panels/9"
               }
             },
             {
@@ -1444,29 +1395,16 @@
               "width": 12,
               "height": 10,
               "content": {
-                "$ref": "#/spec/panels/1_2"
+                "$ref": "#/spec/panels/10"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Data Region",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 42,
               "width": 8,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2_0"
+                "$ref": "#/spec/panels/11"
               }
             },
             {
@@ -1475,7 +1413,7 @@
               "width": 8,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2_1"
+                "$ref": "#/spec/panels/12"
               }
             },
             {
@@ -1484,7 +1422,7 @@
               "width": 8,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2_2"
+                "$ref": "#/spec/panels/13"
               }
             },
             {
@@ -1493,7 +1431,7 @@
               "width": 8,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2_3"
+                "$ref": "#/spec/panels/14"
               }
             },
             {
@@ -1502,7 +1440,7 @@
               "width": 8,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2_4"
+                "$ref": "#/spec/panels/15"
               }
             },
             {
@@ -1511,29 +1449,16 @@
               "width": 8,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2_5"
+                "$ref": "#/spec/panels/16"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Caches",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 57,
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_0"
+                "$ref": "#/spec/panels/17"
               }
             },
             {
@@ -1542,7 +1467,7 @@
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_1"
+                "$ref": "#/spec/panels/18"
               }
             },
             {
@@ -1551,7 +1476,7 @@
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_2"
+                "$ref": "#/spec/panels/19"
               }
             },
             {
@@ -1560,7 +1485,7 @@
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_3"
+                "$ref": "#/spec/panels/20"
               }
             },
             {
@@ -1569,7 +1494,7 @@
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_4"
+                "$ref": "#/spec/panels/21"
               }
             },
             {
@@ -1578,7 +1503,7 @@
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_5"
+                "$ref": "#/spec/panels/22"
               }
             },
             {
@@ -1587,7 +1512,7 @@
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_6"
+                "$ref": "#/spec/panels/23"
               }
             },
             {
@@ -1596,7 +1521,7 @@
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_7"
+                "$ref": "#/spec/panels/24"
               }
             }
           ]

--- a/charts/kubedb-perses-dashboards/dashboards/ignite/ignite_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/ignite/ignite_pod_dashboard.json
@@ -1,4 +1,5 @@
 {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
 {
   "kind": "Dashboard",
   "metadata": {
@@ -105,7 +106,7 @@
       }
     ],
     "panels": {
-      "0_0": {
+      "0": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -115,26 +116,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "result": {
-                      "value": "Down"
-                    },
-                    "value": "0"
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "result": {
-                      "value": "Up"
-                    },
-                    "value": "1"
-                  }
-                }
-              ],
+              "colorMode": "background_solid",
               "thresholds": {
                 "steps": [
                   {
@@ -166,7 +148,7 @@
           ]
         }
       },
-      "0_1": {
+      "1": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -176,6 +158,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "background_solid",
               "format": {
                 "unit": "hours"
               },
@@ -202,6 +185,48 @@
                   "spec": {
                     "minStep": "",
                     "query": "hour ((ignite_uptime{namespace=\"demo\", pod= \"$node\"}))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Data region size (GB)"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "io_dataregion_default_OffHeapSize{pod= \"$node\"} / 1024 / 1024 / 1024",
                     "seriesNameFormat": ""
                   }
                 }
@@ -210,7 +235,404 @@
           ]
         }
       },
-      "0_2": {
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Data region off Heap Size"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "io_dataregion_default_OffHeapSize{pod= \"$node\"} / 1024 / 1024 / 1024",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Data region offheap used (GB)"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "io_dataregion_default_OffheapUsedSize{pod= \"$node\"} / 1024 / 1024 / 1024",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Data Region- Max Size",
+            "description": "< 70% is good"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 70
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "io_dataregion_default_MaxSize{pod= \"$node\"} / 1024 / 1024 / 1024\n",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Data Region- No of PagesRead",
+            "description": "< 70% is good"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "io_dataregion_default_PagesRead{pod= \"$node\"}\n",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Data Region- No of PagesWritten",
+            "description": "< 70% is good"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 70
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "io_dataregion_default_PagesWritten{pod= \"$node\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cache Hits",
+            "description": "> 0 means that rebalance is in progress"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.2,
+                "connectNulls": true,
+                "display": "bar",
+                "lineWidth": 2
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "cache_${cacheName}_CacheHits {pod= \"$node\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cache Hits",
+            "description": "> 0 means that rebalance is in progress"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.2,
+                "connectNulls": true,
+                "display": "bar",
+                "lineWidth": 2
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "cache_${cacheName}_CacheHits{pod= \"$node\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cache Puts",
+            "description": "> 0 means that rebalance is in progress"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.2,
+                "connectNulls": true,
+                "display": "bar",
+                "lineWidth": 2
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "cache_${cacheName}_CachePuts{pod= \"$node\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cache Misses",
+            "description": "> 0 means that rebalance is in progress"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.2,
+                "connectNulls": true,
+                "display": "bar",
+                "lineWidth": 2
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "cache_${cacheName}_CacheMisses{pod= \"$node\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -220,26 +642,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "result": {
-                      "value": "Down"
-                    },
-                    "value": "0"
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "result": {
-                      "value": "Up"
-                    },
-                    "value": "1"
-                  }
-                }
-              ],
+              "colorMode": "background_solid",
               "thresholds": {
                 "steps": [
                   {
@@ -271,7 +674,194 @@
           ]
         }
       },
-      "0_3": {
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cache Size",
+            "description": "> 0 means that rebalance is in progress"
+          },
+          "plugin": {
+            "kind": "GaugeChart",
+            "spec": {
+              "calculation": "last-number",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "cache_${cacheName}_CacheSize{pod= \"$node\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Hit Ratio",
+            "description": "> 0 means that rebalance is in progress"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineStyle": "solid",
+                "lineWidth": 1
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "(cache_${cacheName}_CacheHits{pod= \"$node\"}) / clamp_min((cache_${cacheName}_CacheHits{pod= \"$node\"}) + (cache_${cacheName}_CacheMisses{pod= \"$node\"}), 1)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Moving partitions",
+            "description": "> 0 means that rebalance is in progress"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "cacheGroups_ignite_sys_cache_LocalNodeMovingPartitionsCount{pod= \"$node\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Owning partitions"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "decimalPlaces": 0,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
+                    },
+                    "minStep": "",
+                    "query": "cacheGroups_ignite_sys_cache_LocalNodeOwningPartitionsCount{pod= \"$node\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -281,6 +871,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "background_solid",
               "format": {
                 "unit": "decimal"
               },
@@ -311,7 +902,7 @@
                     },
                     "minStep": "",
                     "query": "threadPools_GridRebalanceExecutor_ActiveCount{pod= \"$node\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -319,7 +910,7 @@
           ]
         }
       },
-      "0_4": {
+      "4": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -331,8 +922,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0.1,
@@ -360,7 +950,7 @@
                     },
                     "minStep": "",
                     "query": " avg (up{namespace=\"demo\", pod= \"$node\"})",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -368,7 +958,7 @@
           ]
         }
       },
-      "0_5": {
+      "5": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -409,7 +999,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "100 - ((sys_memory_heap_max {pod= \"$node\"} - sys_memory_heap_used{pod= \"$node\"})*100 / sys_memory_heap_max{pod= \"$node\"})",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -417,7 +1007,7 @@
           ]
         }
       },
-      "0_6": {
+      "6": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -462,7 +1052,7 @@
                     },
                     "minStep": "",
                     "query": "sys_CpuLoad{pod= \"$node\"} * 100",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -470,7 +1060,7 @@
           ]
         }
       },
-      "1_0": {
+      "7": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -516,7 +1106,7 @@
                     },
                     "minStep": "",
                     "query": "avg (sys_CpuLoad{namespace=\"demo\", pod= \"$node\"}) * 100",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -524,7 +1114,7 @@
           ]
         }
       },
-      "1_1": {
+      "8": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -571,7 +1161,7 @@
                     },
                     "minStep": "",
                     "query": "sys_memory_heap_used{namespace=\"demo\", pod= \"$node\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -579,7 +1169,7 @@
           ]
         }
       },
-      "1_2": {
+      "9": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -590,8 +1180,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0.1,
@@ -619,7 +1208,7 @@
                     },
                     "minStep": "",
                     "query": "io_dataregion_default_OffheapUsedSize{namespace=\"demo\", pod= \"$node\"} / 1024 / 1024 / 1024 ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} allocated size"
                   }
                 }
               }
@@ -636,630 +1225,7 @@
                     },
                     "minStep": "",
                     "query": "io_dataregion_default_OffHeapSize{namespace=\"demo\", pod= \"$node\"} / 1024 / 1024 / 1024",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Data region size (GB)"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "io_dataregion_default_OffHeapSize{pod= \"$node\"} / 1024 / 1024 / 1024",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Data region off Heap Size"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "io_dataregion_default_OffHeapSize{pod= \"$node\"} / 1024 / 1024 / 1024",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Data region offheap used (GB)"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "io_dataregion_default_OffheapUsedSize{pod= \"$node\"} / 1024 / 1024 / 1024",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Data Region- Max Size",
-            "description": "< 70% is good"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#73bf69",
-                    "value": 70
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "io_dataregion_default_MaxSize{pod= \"$node\"} / 1024 / 1024 / 1024\n",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_4": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Data Region- No of PagesRead",
-            "description": "< 70% is good"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#73bf69",
-                    "value": 80
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "io_dataregion_default_PagesRead{pod= \"$node\"}\n",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_5": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Data Region- No of PagesWritten",
-            "description": "< 70% is good"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#73bf69",
-                    "value": 70
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "io_dataregion_default_PagesWritten{pod= \"$node\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Cache Hits",
-            "description": "> 0 means that rebalance is in progress"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "legend": {
-                "mode": "table",
-                "position": "bottom",
-                "values": []
-              },
-              "visual": {
-                "areaOpacity": 0.2,
-                "connectNulls": true,
-                "display": "bar",
-                "lineWidth": 2
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "cache_${cacheName}_CacheHits {pod= \"$node\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Cache Hits",
-            "description": "> 0 means that rebalance is in progress"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "legend": {
-                "mode": "table",
-                "position": "bottom",
-                "values": []
-              },
-              "visual": {
-                "areaOpacity": 0.2,
-                "connectNulls": true,
-                "display": "bar",
-                "lineWidth": 2
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "cache_${cacheName}_CacheHits{pod= \"$node\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Cache Puts",
-            "description": "> 0 means that rebalance is in progress"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "legend": {
-                "mode": "table",
-                "position": "bottom",
-                "values": []
-              },
-              "visual": {
-                "areaOpacity": 0.2,
-                "connectNulls": true,
-                "display": "bar",
-                "lineWidth": 2
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "cache_${cacheName}_CachePuts{pod= \"$node\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Cache Misses",
-            "description": "> 0 means that rebalance is in progress"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "legend": {
-                "mode": "table",
-                "position": "bottom",
-                "values": []
-              },
-              "visual": {
-                "areaOpacity": 0.2,
-                "connectNulls": true,
-                "display": "bar",
-                "lineWidth": 2
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "cache_${cacheName}_CacheMisses{pod= \"$node\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_4": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Cache Size",
-            "description": "> 0 means that rebalance is in progress"
-          },
-          "plugin": {
-            "kind": "GaugeChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#f2495c",
-                    "value": 80
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "cache_${cacheName}_CacheSize{pod= \"$node\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_5": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Hit Ratio",
-            "description": "> 0 means that rebalance is in progress"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "legend": {
-                "mode": "list",
-                "position": "bottom",
-                "values": []
-              },
-              "visual": {
-                "areaOpacity": 0.1,
-                "connectNulls": true,
-                "display": "line",
-                "lineStyle": "solid",
-                "lineWidth": 1
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "(cache_${cacheName}_CacheHits{pod= \"$node\"}) / clamp_min((cache_${cacheName}_CacheHits{pod= \"$node\"}) + (cache_${cacheName}_CacheMisses{pod= \"$node\"}), 1)",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_6": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Moving partitions",
-            "description": "> 0 means that rebalance is in progress"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#f2495c",
-                    "value": 80
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "cacheGroups_ignite_sys_cache_LocalNodeMovingPartitionsCount{pod= \"$node\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_7": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Owning partitions"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "decimalPlaces": 0,
-                "unit": "decimal"
-              },
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#73bf69",
-                    "value": 1
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "datasource": {
-                      "kind": "PrometheusDatasource",
-                      "name": "e105d3fd-a91b-462e-b2e9-891dc66b8d78"
-                    },
-                    "minStep": "",
-                    "query": "cacheGroups_ignite_sys_cache_LocalNodeOwningPartitionsCount{pod= \"$node\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} Max size"
                   }
                 }
               }
@@ -1273,10 +1239,7 @@
         "kind": "Grid",
         "spec": {
           "display": {
-            "title": "General",
-            "collapse": {
-              "open": true
-            }
+            "title": "Panel Group 1"
           },
           "items": [
             {
@@ -1285,7 +1248,7 @@
               "width": 6,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/0_0"
+                "$ref": "#/spec/panels/0"
               }
             },
             {
@@ -1294,7 +1257,7 @@
               "width": 6,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/0_1"
+                "$ref": "#/spec/panels/1"
               }
             },
             {
@@ -1303,7 +1266,7 @@
               "width": 6,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/0_2"
+                "$ref": "#/spec/panels/2"
               }
             },
             {
@@ -1312,7 +1275,7 @@
               "width": 6,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/0_3"
+                "$ref": "#/spec/panels/3"
               }
             },
             {
@@ -1321,7 +1284,7 @@
               "width": 9,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_4"
+                "$ref": "#/spec/panels/4"
               }
             },
             {
@@ -1330,7 +1293,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_5"
+                "$ref": "#/spec/panels/5"
               }
             },
             {
@@ -1339,29 +1302,16 @@
               "width": 7,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_6"
+                "$ref": "#/spec/panels/6"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Memory and CPU",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 15,
               "width": 24,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1_0"
+                "$ref": "#/spec/panels/7"
               }
             },
             {
@@ -1370,7 +1320,7 @@
               "width": 12,
               "height": 10,
               "content": {
-                "$ref": "#/spec/panels/1_1"
+                "$ref": "#/spec/panels/8"
               }
             },
             {
@@ -1379,29 +1329,16 @@
               "width": 12,
               "height": 10,
               "content": {
-                "$ref": "#/spec/panels/1_2"
+                "$ref": "#/spec/panels/9"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Data Region",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 34,
               "width": 8,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/2_0"
+                "$ref": "#/spec/panels/10"
               }
             },
             {
@@ -1410,7 +1347,7 @@
               "width": 8,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/2_1"
+                "$ref": "#/spec/panels/11"
               }
             },
             {
@@ -1419,7 +1356,7 @@
               "width": 8,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/2_2"
+                "$ref": "#/spec/panels/12"
               }
             },
             {
@@ -1428,7 +1365,7 @@
               "width": 8,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/2_3"
+                "$ref": "#/spec/panels/13"
               }
             },
             {
@@ -1437,7 +1374,7 @@
               "width": 8,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/2_4"
+                "$ref": "#/spec/panels/14"
               }
             },
             {
@@ -1446,29 +1383,16 @@
               "width": 8,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/2_5"
+                "$ref": "#/spec/panels/15"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Caches",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 45,
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_0"
+                "$ref": "#/spec/panels/16"
               }
             },
             {
@@ -1477,7 +1401,7 @@
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_1"
+                "$ref": "#/spec/panels/17"
               }
             },
             {
@@ -1486,7 +1410,7 @@
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_2"
+                "$ref": "#/spec/panels/18"
               }
             },
             {
@@ -1495,7 +1419,7 @@
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_3"
+                "$ref": "#/spec/panels/19"
               }
             },
             {
@@ -1504,7 +1428,7 @@
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_4"
+                "$ref": "#/spec/panels/20"
               }
             },
             {
@@ -1513,7 +1437,7 @@
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_5"
+                "$ref": "#/spec/panels/21"
               }
             },
             {
@@ -1522,7 +1446,7 @@
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_6"
+                "$ref": "#/spec/panels/22"
               }
             },
             {
@@ -1531,7 +1455,7 @@
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_7"
+                "$ref": "#/spec/panels/23"
               }
             }
           ]

--- a/charts/kubedb-perses-dashboards/dashboards/ignite/ignite_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/ignite/ignite_summary_dashboard.json
@@ -1,0 +1,1589 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "04033bf3-5d6f-43c7-b5b4-07048acbdea2",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / Ignite / Summary"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Datasource",
+            "hidden": false
+          },
+          "defaultValue": "default",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Ignite",
+            "hidden": false
+          },
+          "defaultValue": "ignite",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kubedb_com_ignite_status_phase{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Database Status",
+            "description": "Represent database status"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_ignite_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Version",
+            "description": "Ignite CR Name"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "mean",
+              "colorMode": "none",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": " version ",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              },
+              "valueFontSize": 50
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_ignite_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{ version }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage",
+            "description": "CPU Usage by Ignite pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Quota",
+            "description": "CPU Quote information in details"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp",
+                  "width": "auto"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Usage",
+            "description": "Memory Usage by Ignite pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Quota"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (RSS)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Cache)",
+                  "name": "value #7"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Swap)",
+                  "name": "value #8"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_rss{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_cache{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_swap{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk Usage",
+            "description": "Disk usage by Ignite pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk R/W Info",
+            "description": "System Disk Usage Information"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "IOPS (Reads+Writes)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m])))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ThroughPut (Read+Write)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Current Storage IO"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads)",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Writes)",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads + Writes)",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read)",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Write)",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read + Write)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_total{container!=\"\",pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_bytes_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\",pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Allocated Storage",
+            "description": "This panel describes allocated persistent storage in a table format\n"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": []
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Require Secure Transport",
+            "description": "When this option is enabled, connections attempted using insecure transport will be rejected."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_ignite_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{requireSSL}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage",
+            "description": "This panel shows the persistent volume usage in percentage. "
+          },
+          "plugin": {
+            "kind": "BarChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "percent"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage History",
+            "description": "This panel describes the persistent volume usage in a time series. "
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "right",
+                "values": [
+                  "max",
+                  "last-number"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineStyle": "solid",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decbytes"
+                },
+                "max": 5000,
+                "min": 0
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(kubelet_volume_stats_used_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) ",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Receive Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Transmit Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Deletion Policy",
+            "description": "KubeDB Database Resource deletionPolicy"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_ignite_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Nodes",
+            "description": "Total node count of Ignite cluster"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_ignite_replicas{namespace=\"$namespace\",app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Request (Core)",
+            "description": "Initial Requested CPU amount by Ignite Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_ignite_resource_request_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Limit (Core)",
+            "description": "CPU Limit in core by Ignite instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_ignite_resource_limit_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Request",
+            "description": "Initial Requested Memory amount by Ignite Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_ignite_resource_request_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Limit",
+            "description": "KubeDB Ignite Total Memory Limit"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_ignite_resource_limit_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Storage Request",
+            "description": "Total storage request by Ignite nodes"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_ignite_resource_request_storage{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 8,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 16,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 20,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 4,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 8,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 12,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 16,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 20,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 0,
+              "y": 22,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 0,
+              "y": 28,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 0,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 12,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 0,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 12,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            },
+            {
+              "x": 0,
+              "y": 51,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/18"
+              }
+            },
+            {
+              "x": 0,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/19"
+              }
+            },
+            {
+              "x": 12,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/20"
+              }
+            },
+            {
+              "x": 0,
+              "y": 65,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/21"
+              }
+            },
+            {
+              "x": 0,
+              "y": 74,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/22"
+              }
+            },
+            {
+              "x": 12,
+              "y": 74,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/23"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/kafka/kafka_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/kafka/kafka_database_dashboard.json
@@ -90,6 +90,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
+              "metricLabel": "phase",
               "thresholds": {
                 "steps": [
                   {
@@ -132,9 +134,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "seconds"
               },
+              "metricLabel": "",
               "thresholds": {
                 "steps": [
                   {
@@ -171,11 +175,7 @@
           "plugin": {
             "kind": "Table",
             "spec": {
-              "columnSettings": [
-                {
-                  "name": "IsUnderreplicated"
-                }
-              ]
+              "columnSettings": []
             }
           },
           "queries": [
@@ -415,7 +415,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kafka_server_kafkaserver_linux_disk_read_bytes{namespace=~\"$namespace\",pod=~\"$app.+$\"} / 1024 /1024",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -443,7 +443,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kafka_server_kafkaserver_linux_disk_write_bytes{namespace=~\"$namespace\",pod=~\"$app.+$\"} / 1024 /1024",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -477,7 +477,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kafka_server_brokertopicmetrics_messagesin_total{namespace=\"$namespace\", pod=~\"$app-.+$\", topic!~\"\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ topic }}` }}"
                   }
                 }
               }
@@ -496,6 +496,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
+              "metricLabel": "",
               "thresholds": {
                 "steps": [
                   {
@@ -549,7 +551,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kafka_server_brokertopicmetrics_totalproducerequests_total{namespace=\"$namespace\", pod=~\"$app-.+$\"} != 0",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -577,7 +579,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kafka_server_raft_metrics_commit_latency_avg{namespace=~\"$namespace\",pod=~\"$app.+$\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -605,7 +607,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kafka_server_raft_metrics_current_epoch{namespace=~\"$namespace\",pod=~\"$app.+$\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -633,7 +635,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(kafka_server_brokertopicmetrics_bytesin_total{pod=~\"$app-.+$\",namespace=~\"$namespace\",topic!~\"\"}[5m])) by (topic)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ topic }}` }} (in)"
                   }
                 }
               }
@@ -646,7 +648,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(kafka_server_brokertopicmetrics_bytesout_total{pod=~\"$app-.+$\",namespace=~\"$namespace\",topic!~\"\"}[5m])) by (topic)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ topic }}` }} (out)"
                   }
                 }
               }
@@ -680,7 +682,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kafka_server_kafkarequesthandlerpool_requesthandleravgidle_percent{namespace=\"$namespace\",pod=~\"$app-.+$\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -782,6 +784,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
+              "metricLabel": "pod",
               "thresholds": {
                 "steps": [
                   {
@@ -820,6 +824,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
+              "metricLabel": "jdk",
               "thresholds": {
                 "steps": [
                   {
@@ -878,7 +884,7 @@
                     },
                     "minStep": "",
                     "query": "kafka_controller_kafkacontroller_globaltopiccount{namespace=\"$namespace\", pod=~\"$app-.+$\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ $pod }}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/kafka/kafka_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/kafka/kafka_pod_dashboard.json
@@ -1,4 +1,5 @@
 {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
 {
   "kind": "Dashboard",
   "metadata": {
@@ -110,6 +111,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
+              "metricLabel": "phase",
               "thresholds": {
                 "steps": [
                   {
@@ -152,9 +155,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "seconds"
               },
+              "metricLabel": "",
               "thresholds": {
                 "steps": [
                   {
@@ -202,7 +207,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "jvm_memory_bytes_used{namespace=~\"$namespace\",pod=~\"$pod\",area=\"nonheap\"} / 1024 / 1024",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -230,7 +235,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "jvm_memory_bytes_used{namespace=~\"$namespace\",pod=~\"$pod\",area=\"heap\"} / 1024 / 1024",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -258,7 +263,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "jvm_memory_pool_bytes_used{namespace=~\"$namespace\",pod=\"$pod\"} / 1024 / 1024",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pool }}` }}"
                   }
                 }
               }
@@ -286,7 +291,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "increase(jvm_gc_collection_seconds_count{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}-{{ `{{ gc }}` }}"
                   }
                 }
               }
@@ -314,7 +319,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "increase(jvm_gc_collection_seconds_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}-{{ `{{ gc }}` }}"
                   }
                 }
               }
@@ -389,6 +394,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
+              "metricLabel": "",
               "thresholds": {
                 "steps": [
                   {
@@ -426,6 +433,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
+              "metricLabel": "",
               "thresholds": {
                 "steps": [
                   {
@@ -468,6 +477,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
+              "metricLabel": "",
               "thresholds": {
                 "steps": [
                   {
@@ -525,7 +536,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kafka_network_requestmetrics_localtimems_count{namespace=\"$namespace\",pod=~\"$pod\"} != 0 ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ request }}` }}"
                   }
                 }
               }
@@ -559,7 +570,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kafka_network_requestmetrics_responsequeuetimems_count{namespace=\"$namespace\",pod=~\"$pod\"} != 0",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ request }}` }}"
                   }
                 }
               }
@@ -587,7 +598,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kafka_server_socket_server_metrics_network_io_rate{namespace=\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}-{{ `{{ listener }}` }}"
                   }
                 }
               }
@@ -615,7 +626,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kafka_server_socket_server_metrics_successful_authentication_rate{namespace=\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}-{{ `{{ listener }}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/kafka/kafka_summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/kafka/kafka_summary.json
@@ -92,6 +92,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
               "thresholds": {
                 "steps": [
                   {
@@ -111,7 +113,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_kafka_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
                   }
                 }
               }
@@ -130,9 +132,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": " version ",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -158,7 +162,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_kafka_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ version }}` }}"
                   }
                 }
               }
@@ -186,7 +190,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(sum by (namespace, pod, container) (irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-.+$\"}[5m])) * on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-.+$\"}))) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -207,29 +211,48 @@
               "columnSettings": [
                 {
                   "header": "Time",
-                  "name": "timestamp"
+                  "name": "timestamp",
+                  "width": "auto"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -331,7 +354,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(container_memory_working_set_bytes{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-.+$\",container!=\"\"} * on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\"}))) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -354,38 +377,65 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (RSS)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Cache)",
-                  "name": "Value #G"
+                  "name": "value #7"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Swap)",
-                  "name": "Value #H"
+                  "name": "value #8"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -526,7 +576,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-.+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -560,7 +610,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-.+$\"}[5m])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
                   }
                 }
               }
@@ -573,7 +623,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-.+$\"}[5m])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
                   }
                 }
               }
@@ -606,7 +656,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-.+$\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-.+$\"}[5m])))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -639,7 +689,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-.+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-.+$\"}[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -662,30 +712,51 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads)",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Writes)",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads + Writes)",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read)",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Write)",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read + Write)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -815,6 +886,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -839,7 +911,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_kafka_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{requireSSL}}` }}"
                   }
                 }
               }
@@ -872,7 +944,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-.+$\",namespace=~\"$namespace\"}) )* 100",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -907,7 +979,7 @@
               },
               "yAxis": {
                 "format": {
-                  "unit": "bytes"
+                  "unit": "decbytes"
                 },
                 "max": 5000,
                 "min": 0
@@ -923,7 +995,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-.+$\",namespace=~\"$namespace\"}) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -950,7 +1022,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-.+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -983,7 +1055,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-.+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1002,6 +1074,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1022,7 +1095,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_kafka_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
                   }
                 }
               }
@@ -1041,6 +1114,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "thresholds": {
                 "steps": [
                   {
@@ -1083,6 +1157,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1122,6 +1197,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1161,6 +1237,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -1203,6 +1280,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -1245,6 +1323,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },

--- a/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-database.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-database.json
@@ -103,7 +103,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_up{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -132,7 +132,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_uptime{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -159,7 +159,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_open_files{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Open Files - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -172,7 +172,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_open_files_limit{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Open Files Limit - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -185,7 +185,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_innodb_num_open_files{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "InnoDB Open Files - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -212,7 +212,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_slow_queries{namespace=~\"$namespace\",service=~\"$app+-stats\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Slow Queries on {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -239,7 +239,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_aborted_connects{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Aborted Connects (attempts) on - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -252,7 +252,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_aborted_clients{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Aborted Clients (timeout) on - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -270,6 +270,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -370,7 +371,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_queries{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -397,7 +398,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_max_used_connections{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Current - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -410,7 +411,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_max_connections{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Max - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -437,7 +438,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_innodb_data_reads{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "reads - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -450,7 +451,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_innodb_data_writes{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "write - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -477,7 +478,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_bytes_received{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "received - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -490,7 +491,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_bytes_sent{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "sent - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -517,7 +518,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "topk(3, rate(mysql_global_status_commands_total{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }} = '{{ `{{ command }}` }}'"
                   }
                 }
               }
@@ -544,7 +545,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_opened_files{namespace=~\"$namespace\",service=~\"$app+-stats\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-galera.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-galera.json
@@ -1,4 +1,5 @@
 {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
 {
   "kind": "Dashboard",
   "metadata": {
@@ -90,6 +91,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "background_solid",
+              "metricLabel": "wsrep_cluster_name",
               "thresholds": {
                 "steps": [
                   {
@@ -113,7 +116,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg by(wsrep_cluster_name)(mysql_galera_variables_info{namespace=~\"$namespace\",service=~\"$app+-stats\"})",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{wsrep_cluster_name}}` }}"
                   }
                 }
               }
@@ -131,6 +134,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "background_solid",
               "thresholds": {
                 "steps": [
                   {
@@ -154,7 +158,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg by(pod)(mysql_galera_variables_info{namespace=~\"$namespace\",service=~\"$app+-stats\"})",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -181,7 +185,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg_over_time(mysql_galera_evs_repl_latency_avg_seconds{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} - Latency Average"
                   }
                 }
               }
@@ -208,7 +212,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_galera_evs_repl_latency_stdev{namespace=~\"$namespace\",service=~\"$app+-stats\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} - Latency Average"
                   }
                 }
               }
@@ -235,7 +239,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_galera_evs_repl_latency_sample_size{namespace=~\"$namespace\",service=~\"$app+-stats\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} - Latency Average"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-pod.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-pod.json
@@ -1,4 +1,5 @@
 {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
 {
   "kind": "Dashboard",
   "metadata": {
@@ -115,9 +116,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": "pod}} ",
               "thresholds": {
                 "steps": [
                   {
@@ -137,7 +140,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_up{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} "
                   }
                 }
               }
@@ -155,6 +158,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -181,7 +185,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_uptime{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -208,7 +212,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_threads_connected{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Threads Connected - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -221,7 +225,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_threads_running{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Threads Running - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -248,7 +252,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_thread_cache_size{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Thread Cache Size - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -261,7 +265,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_threads_cached{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Threads Cached - {{ `{{pod}}` }} "
                   }
                 }
               }
@@ -274,7 +278,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_threads_created{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Threads Created - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -301,7 +305,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_created_tmp_tables{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Created Tmp Tables - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -314,7 +318,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_created_tmp_disk_tables{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Created Tmp Disk Tables - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -327,7 +331,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_created_tmp_files{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Created Tmp Files - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -354,7 +358,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_slow_queries{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Slow Queries - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -381,7 +385,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_select_full_join{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Select Full Join - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -394,7 +398,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_select_scan{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Select Scan - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -421,7 +425,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_sort_rows{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Sort Rows - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -434,7 +438,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_sort_range{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Sort Range - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -447,7 +451,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_sort_merge_passes{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Sort Merge Passes - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -460,7 +464,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_sort_scan{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Sort Scan - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -487,7 +491,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_table_locks_immediate{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Table Locks Immediate - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -500,7 +504,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_table_locks_waited{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Table Locks Waited - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -527,7 +531,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_questions{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Questions - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -555,7 +559,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_bytes_received{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Inbound - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -568,7 +572,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_bytes_sent{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Outbound - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -596,7 +600,7 @@
                   "spec": {
                     "minStep": "1h",
                     "query": "increase(mysql_global_status_bytes_received{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[1h])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Received - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -609,7 +613,7 @@
                   "spec": {
                     "minStep": "1h",
                     "query": "increase(mysql_global_status_bytes_sent{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[1h])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Sent - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -627,9 +631,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": "version",
               "thresholds": {
                 "steps": [
                   {
@@ -653,7 +659,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_version_info{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{version}}` }}"
                   }
                 }
               }
@@ -686,7 +692,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_innodb_buffer_pool_size{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "InnoDB Buffer Pool Size - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -699,7 +705,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_innodb_log_buffer_size{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "InnoDB Log Buffer Size - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -712,7 +718,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_innodb_mem_dictionary{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "InnoDB Dictionary Size - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -725,7 +731,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_key_buffer_size{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Key Buffer Size - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -738,7 +744,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_query_cache_size{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Query Cache Size - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -751,7 +757,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_innodb_mem_adaptive_hash{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Adaptive Hash Index Size - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -778,7 +784,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "topk(5, rate(mysql_global_status_commands_total{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Com_{{ `{{ command }}` }} - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -812,7 +818,7 @@
                   "spec": {
                     "minStep": "1h",
                     "query": "topk(5, avg by (pod,command) (increase(mysql_global_status_commands_total{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[1h])>0))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Com_{{ `{{ command }}` }} - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -839,7 +845,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_handlers_total{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])>0",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ handler }}` }} - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -872,7 +878,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_qcache_free_memory{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Query Cache Size - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -905,7 +911,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_qcache_hits{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Hits - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -918,7 +924,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_qcache_inserts{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Inserts - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -931,7 +937,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_qcache_not_cached{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Not Cached - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -944,7 +950,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_qcache_lowmem_prunes{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Prunes - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -957,7 +963,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_qcache_queries_in_cache{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Queries in Cache - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -984,7 +990,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_opened_files{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Openings - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1011,7 +1017,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_open_files{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Open Files - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1024,7 +1030,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_open_files_limit{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Open Files Limit - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1037,7 +1043,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_innodb_num_open_files{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "InnoDB Open Files - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1064,7 +1070,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_opened_tables{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Openings - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1077,7 +1083,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_table_open_cache_hits{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Hits - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1090,7 +1096,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_table_open_cache_misses{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Misses - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1103,7 +1109,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_table_open_cache_overflows{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Misses due to Overflows - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1116,7 +1122,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_table_open_cache_hits{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Table Open Cache Hit Ratio - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1143,7 +1149,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_open_tables{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Open Tables - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1156,7 +1162,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_table_open_cache{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Table Open Cache - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1174,6 +1180,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -1196,7 +1203,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_queries{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1223,7 +1230,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_open_table_definitions{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Open Table Definitions - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1236,7 +1243,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_table_definition_cache{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Table Definitions Cache Size - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1249,7 +1256,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_opened_table_definitions{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Opened Table Definitions - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1267,6 +1274,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -1293,7 +1301,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_innodb_buffer_pool_size{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1326,7 +1334,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"$pod\", container!=\"\", image!=\"\"}[5m])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{container}}` }}"
                   }
                 }
               }
@@ -1359,7 +1367,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$pod\", container!=\"\", image!=\"\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1393,7 +1401,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(process_open_fds{pod=~\"$pod\", namespace=\"$namespace\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1420,7 +1428,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_max_used_connections{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Max Used Connects - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1433,7 +1441,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_max_connections{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Max Connects - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1460,7 +1468,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_aborted_connects{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Aborted Connects - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1473,7 +1481,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_aborted_clients{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Aborted Clients - {{ `{{pod}}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-standard-replication.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-standard-replication.json
@@ -1,4 +1,5 @@
 {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
 {
   "kind": "Dashboard",
   "metadata": {
@@ -101,7 +102,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_slave_status_master_server_id{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -130,7 +131,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_slaves_connected{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -159,7 +160,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_slave_status_slave_transactional_groups{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -188,7 +189,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_slave_status_slave_non_transactional_groups{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -217,7 +218,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_slave_status_last_io_error{namespace=~\"$namespace\",service=~\"$app+-stats\"} or mysql_slave_status_last_sql_error{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }} - Error"
                   }
                 }
               }
@@ -246,7 +247,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_slave_status_slave_sql_running{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -275,7 +276,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_slave_status_slave_io_running{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -304,7 +305,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_slave_status_last_errno{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -333,7 +334,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_slave_status_last_sql_errno{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -362,7 +363,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_slave_status_last_io_errno{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -391,7 +392,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_slave_status_seconds_behind_master{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -420,7 +421,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_slave_status_max_relay_log_size{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -449,7 +450,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_slave_status_relay_log_pos{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-summary.json
@@ -92,6 +92,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
               "thresholds": {
                 "steps": [
                   {
@@ -111,7 +113,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_mariadb_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
                   }
                 }
               }
@@ -130,9 +132,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": " version ",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -158,7 +162,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_mariadb_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ version }}` }}"
                   }
                 }
               }
@@ -186,7 +190,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -207,29 +211,48 @@
               "columnSettings": [
                 {
                   "header": "Time",
-                  "name": "timestamp"
+                  "name": "timestamp",
+                  "width": "auto"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -331,7 +354,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -354,38 +377,65 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (RSS)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Cache)",
-                  "name": "Value #G"
+                  "name": "value #7"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Swap)",
-                  "name": "Value #H"
+                  "name": "value #8"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -526,7 +576,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -560,7 +610,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
                   }
                 }
               }
@@ -573,7 +623,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
                   }
                 }
               }
@@ -606,7 +656,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m])))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -639,7 +689,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -662,30 +712,51 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads)",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Writes)",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads + Writes)",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read)",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Write)",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read + Write)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -815,6 +886,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -839,7 +911,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_mariadb_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{requireSSL}}` }}"
                   }
                 }
               }
@@ -872,7 +944,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -907,7 +979,7 @@
               },
               "yAxis": {
                 "format": {
-                  "unit": "bytes"
+                  "unit": "decbytes"
                 },
                 "max": 5000,
                 "min": 0
@@ -923,7 +995,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -950,7 +1022,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -983,7 +1055,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1002,6 +1074,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1022,7 +1095,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_mariadb_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
                   }
                 }
               }
@@ -1041,6 +1114,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "thresholds": {
                 "steps": [
                   {
@@ -1083,6 +1157,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1122,6 +1197,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1161,6 +1237,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -1203,6 +1280,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -1245,6 +1323,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },

--- a/charts/kubedb-perses-dashboards/dashboards/memcached/memcached_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/memcached/memcached_database_dashboard.json
@@ -11,7 +11,7 @@
   },
   "spec": {
     "display": {
-      "name": "Memcached Overview"
+      "name": "KubeDB / Memcached / Database"
     },
     "variables": [
       {
@@ -82,6 +82,113 @@
               "text": "**Migration from Grafana not supported !**"
             }
           }
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Hit Ratio Per Command"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "1m",
+                    "query": "sum (delta(memcached_commands_total{job=\"$job\", status=\"hit\",command=\"get\"}[1m]))  / sum (delta(memcached_commands_total{job=\"$job\",command=\"get\"}[1m])) * 100",
+                    "seriesNameFormat": "get"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "1m",
+                    "query": "sum (delta(memcached_commands_total{job=\"$job\", status=\"hit\",command=\"delete\"}[1m]))  / sum (delta(memcached_commands_total{job=\"$job\",command=\"delete\"}[1m])) * 100",
+                    "seriesNameFormat": "delete"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Command Total"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "1m",
+                    "query": "sum(delta(memcached_commands_total{job=\"$job\"}[1m])) by (command)",
+                    "seriesNameFormat": "{{ `{{ command }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "reclaimed / evicted"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "1m",
+                    "query": "delta(memcached_items_reclaimed_total{job=\"$job\"}[1m])",
+                    "seriesNameFormat": "reclaimed"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "1m",
+                    "query": "delta(memcached_items_evicted_total{job=\"$job\"}[1m])",
+                    "seriesNameFormat": "evicted"
+                  }
+                }
+              }
+            }
+          ]
         }
       },
       "2": {
@@ -233,6 +340,33 @@
             }
           ]
         }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Hit Ratio"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "1m",
+                    "query": "sum (delta(memcached_commands_total{job=\"$job\", status=\"hit\"}[1m]))  / sum (delta(memcached_commands_total{job=\"$job\"}[1m])) * 100",
+                    "seriesNameFormat": "Hit Ratio"
+                  }
+                }
+              }
+            }
+          ]
+        }
       }
     },
     "layouts": [
@@ -322,6 +456,42 @@
               "height": 9,
               "content": {
                 "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 12,
+              "y": 8,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 0,
+              "y": 17,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 0,
+              "y": 9,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/12"
               }
             }
           ]

--- a/charts/kubedb-perses-dashboards/dashboards/memcached/memcached_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/memcached/memcached_pod_dashboard.json
@@ -1,4 +1,5 @@
 {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
 {
   "kind": "Dashboard",
   "metadata": {
@@ -10,7 +11,7 @@
   },
   "spec": {
     "display": {
-      "name": "KubeDB / Memcache / Pod"
+      "name": "KubeDB / Memcached / Pod"
     },
     "variables": [
       {
@@ -101,7 +102,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(memcached_commands_total{pod=\"$pod\"}[1m]) * 60) by (command)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{command}}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/memcached/memcached_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/memcached/memcached_summary_dashboard.json
@@ -11,7 +11,7 @@
   },
   "spec": {
     "display": {
-      "name": "KubeDB / memcached / Summary"
+      "name": "KubeDB / Memcached / Summary"
     },
     "variables": [
       {
@@ -92,6 +92,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
               "thresholds": {
                 "steps": [
                   {
@@ -111,7 +113,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_memcached_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
                   }
                 }
               }
@@ -130,9 +132,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": " version ",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -158,7 +162,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_memcached_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ version }}` }}"
                   }
                 }
               }
@@ -186,7 +190,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -207,29 +211,48 @@
               "columnSettings": [
                 {
                   "header": "Time",
-                  "name": "timestamp"
+                  "name": "timestamp",
+                  "width": "auto"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -331,7 +354,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -354,38 +377,65 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (RSS)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Cache)",
-                  "name": "Value #G"
+                  "name": "value #7"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Swap)",
-                  "name": "Value #H"
+                  "name": "value #8"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -526,7 +576,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -560,7 +610,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
                   }
                 }
               }
@@ -573,7 +623,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
                   }
                 }
               }
@@ -606,7 +656,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m])))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -639,7 +689,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -666,7 +716,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -699,7 +749,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -718,6 +768,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -742,7 +793,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_memcached_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{requireSSL}}` }}"
                   }
                 }
               }
@@ -761,6 +812,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -781,7 +833,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_memcached_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
                   }
                 }
               }
@@ -800,6 +852,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "thresholds": {
                 "steps": [
                   {
@@ -842,6 +895,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -881,6 +935,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -920,6 +975,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -962,6 +1018,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -1004,6 +1061,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },

--- a/charts/kubedb-perses-dashboards/dashboards/milvus/milvus-database.json
+++ b/charts/kubedb-perses-dashboards/dashboards/milvus/milvus-database.json
@@ -1,0 +1,4968 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "uLf5cJ3Gz",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / Milvus / Database"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "kubedb",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "alphabetical-asc",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_pod_info"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Instance / Release",
+            "hidden": false
+          },
+          "defaultValue": [
+            "10.42.0.166:9091",
+            "10.42.0.167:9091",
+            "10.42.0.168:9091",
+            "10.42.0.170:9091",
+            "10.42.0.171:9091"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "sort": "alphabetical-asc",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "instance",
+              "matchers": [
+                "{namespace=\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "instance"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "collection_name",
+            "hidden": false
+          },
+          "defaultValue": [
+            "health_check_test"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "customAllValue": ".*",
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "collection_name",
+              "matchers": [
+                "milvus_proxy_req_count{namespace=\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "collection_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Pod",
+            "hidden": true
+          },
+          "defaultValue": [
+            "$__all"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "sort": "alphabetical-asc",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "pod",
+              "matchers": [
+                "kube_pod_info{namespace=\"$namespace\",created_by_kind=\"PetSet\",}"
+              ]
+            }
+          },
+          "name": "pod"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "job",
+            "hidden": false
+          },
+          "defaultValue": [
+            "milvus-cluster-stats"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "job",
+              "matchers": [
+                "{namespace=\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "job"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "node_id",
+            "hidden": false
+          },
+          "defaultValue": [
+            "$__all"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "node_id",
+              "matchers": [
+                "{namespace=\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "node_id"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "cache_name",
+            "hidden": false
+          },
+          "defaultValue": "GetCollectionID",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "cache_name",
+              "matchers": [
+                "{namespace=\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "cache_name"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "container",
+            "hidden": false
+          },
+          "defaultValue": [
+            "milvus"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "container",
+              "matchers": [
+                "{namespace=\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "container"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Search Vector Count Rate",
+            "description": "per-second increasing rate of searching vectors."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_proxy_search_vectors_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])/120) by (pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Insert Vector Count Rate",
+            "description": "per-second increasing rate of inserting vectors."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_proxy_insert_vectors_count{namespace=\"$namespace\",container=\"$container\",job=\"$job\"}[2m])/120) by (pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Success Request Rate",
+            "description": "per-second increasing rate of success requests."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_proxy_req_count{instance=~\"$instance\",namespace=\"$namespace\", status=\"success\"}[2m])/120) by(function_name, pod, node_id)",
+                    "seriesNameFormat": "{{ `{{function_name}}` }}-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "100": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Go Heap released",
+            "description": "Number of heap bytes released to OS."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "go_memstats_heap_released_bytes{container=\"$container\", instance=~\"$instance\", namespace=\"$namespace\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "101": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Go Heap in Use",
+            "description": "Number of heap bytes that be used."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "go_memstats_heap_inuse_bytes{container=\"$container\", instance=~\"$instance\", namespace=\"$namespace\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "102": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Container Threads",
+            "description": "Number of container threads created."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "container_threads{image=\"\", namespace=\"$namespace\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cache Hit rate",
+            "description": "Average cache hits per minute of cache operations."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(increase(milvus_proxy_cache_hit_count{namespace=\"$namespace\",cache_name=\"$cache_name\", cache_state=\"hit\"}[2m])) \n  by(cache_name, pod, node_id)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Apply Timestamp Latency",
+            "description": "The 99th percentile and average latency of apply timestamp over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, pod, node_id) (rate(milvus_proxy_apply_timestamp_latency_bucket{instance=~\"$instance\",namespace=\"$namespace\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_proxy_apply_timestamp_latency_sum{instance=~\"$instance\", namespace=\"$namespace\"}[2m])) by (pod, node_id) / sum(increase(milvus_proxy_apply_timestamp_latency_count{instance=~\"$instance\", namespace=\"$namespace\"}[2m])) by (pod, node_id)",
+                    "seriesNameFormat": "avg-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Received Byte Rate",
+            "description": "per-second increasing rate of bytes received  in proxy"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_proxy_receive_bytes_count{namespace=\"$namespace\",job=\"$job\"}[2m])/120) by(pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Apply PK Latency",
+            "description": "The 99th percentile of latency for applying PK over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, pod, node_id) (rate(milvus_proxy_apply_pk_latency_bucket{instance=~\"$instance\", namespace=\"$namespace\", job=\"$job\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_proxy_apply_pk_latency_sum{instance=~\"$instance\", namespace=\"$namespace\", job=\"$job\"}[2m])) by (pod, node_id) / sum(increase(milvus_proxy_apply_pk_latency_count{instance=~\"$instance\", namespace=\"$namespace\", job=\"$job\"}[2m])) by (pod, node_id)",
+                    "seriesNameFormat": "avg-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Request Latency",
+            "description": "The 99th percentile and average latency of request over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_proxy_req_latency_sum{instance=~\"$instance\", namespace=\"$namespace\"}[2m])) by (pod, node_id) / sum(increase(milvus_proxy_req_latency_count{instance=~\"$instance\", namespace=\"$namespace\"}[2m])) by (pod, node_id)",
+                    "seriesNameFormat": "avg-{{ `{{function_name}}` }}-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "migration_from_grafana_not_supported"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Faild Request Rate",
+            "description": "per-second increasing rate of faild requests."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(milvus_proxy_req_count{namespace=\"kubedb\",collection_name=\"health_check_test\", status=\"fail\"}[5m]) ",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Send Byte Rate",
+            "description": "per-second increasing rate of bytes sent back to the client by the Proxy in response to a Search or Query request."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(increase(milvus_proxy_send_bytes_count{namespace=\"$namespace\",job=\"$job\"}[2m])/120) by(pod, node_id)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Proxy Node Num",
+            "description": "Number of proxy nodes which has register with etcd"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_rootcoord_proxy_num{instance=~\"$instance\", namespace=\"$namespace\",container=\"$container\",job=\"$job\"}) by (instance)",
+                    "seriesNameFormat": "num"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Timestamp Saved",
+            "description": "RootCoord stores pre-assigned timestamps in the metastore"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "milvus_rootcoord_timestamp_saved{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}",
+                    "seriesNameFormat": "tiestamp"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Search Latency",
+            "description": "The 99th percentile and average latency of search request over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, query_type, pod, node_id) (rate(milvus_proxy_sq_latency_bucket{instance=~\"$instance\", namespace=\"$namespace\", collection_name=~\"$collection_name\",container=\"$container\",job=\"$job\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{query_type}}` }}-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(increase(milvus_proxy_sq_latency_sum{instance=~\"$instance\", namespace=\"$namespace\", collection_name=~\"$collection_name\",container=\"$container\",job=\"$job\"}[2m])) by (pod, node_id, query_type) / sum(increase(milvus_proxy_sq_latency_count{instance=~\"$instance\", namespace=\"$namespace\", collection_name=~\"$collection_name\",container=\"$container\",job=\"$job\"}[2m])) by (pod, node_id, query_type)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Produced Timetick Time Taken",
+            "description": "The 99th percentile and average latency for rootcoord to finish synchronizing timestamp messages to all pchanels."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99,sum by (le, pod) (rate(milvus_rootcoord_sync_timetick_latency_bucket{job=\"$job\",namespace=\"$namespace\"}[2m])))",
+                    "seriesNameFormat": "p99-latency"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(\n  increase(milvus_rootcoord_sync_timetick_latency_sum{instance=~\"$instance\", namespace=\"$namespace\", job=\"$job\", container=~\"$container\"}[2m])\n)\n/\nsum(\n  increase(milvus_rootcoord_sync_timetick_latency_count{instance=~\"$instance\", namespace=\"$namespace\", job=\"$job\", container=~\"$container\"}[2m])\n)",
+                    "seriesNameFormat": "avg-latency"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "DDL Request Latency",
+            "description": "The 99th percentile and average latency of DDL request over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, function_name) (rate(milvus_rootcoord_ddl_req_latency_bucket{instance=~\"$instance\", namespace=\"$namespace\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{function_name}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_rootcoord_ddl_req_latency_sum{instance=~\"$instance\", namespace=\"$namespace\"}[2m])) by (function_name) / sum(increase(milvus_rootcoord_ddl_req_latency_count{instance=~\"$instance\", namespace=\"$namespace\"}[2m])) by (function_name)",
+                    "seriesNameFormat": "avg-{{ `{{function_name}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "DML Channel Num",
+            "description": "The number of DML channels"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_rootcoord_dml_channel_num{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (instance)",
+                    "seriesNameFormat": "num"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "DDL Request Rate",
+            "description": "per-second increasing rate of DDL request"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_rootcoord_ddl_req_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])/120) by (status, function_name)",
+                    "seriesNameFormat": "{{ `{{function_name}}` }}-{{ `{{status}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "24": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Timestamp",
+            "description": "RoootCoord current latest timestamp"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "milvus_rootcoord_timestamp{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}",
+                    "seriesNameFormat": "tiestamp"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "25": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Msgstream Num",
+            "description": "The number of Msgstream objects."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_rootcoord_msgstream_obj_num{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (instance)",
+                    "seriesNameFormat": "num"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "26": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ID Alloc Rate",
+            "description": "per-second increasing rate of IDs assigned by RootCoord"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_rootcoord_id_alloc_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])/120)",
+                    "seriesNameFormat": "total"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "27": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Partition Num",
+            "description": "The number of partitions."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_rootcoord_partition_num{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (instance)",
+                    "seriesNameFormat": "num"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Credential Num",
+            "description": "The number of credential"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_rootcoord_credential_num{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (instance)",
+                    "seriesNameFormat": "num"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "29": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Collection Num",
+            "description": "The number of collections."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_rootcoord_collection_num{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (instance)",
+                    "seriesNameFormat": "num"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Collection Search Latency",
+            "description": "The 99th percentile and average latency of search request for a specified collection over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, query_type, pod, node_id) (rate(milvus_proxy_collection_sq_latency_bucket{instance=~\"$instance\",namespace=\"$namespace\", collection_name=~\"$collection_name\",container=\"$container\",job=\"$job\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{query_type}}` }}-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(increase(milvus_proxy_collection_sq_latency_sum{instance=~\"$instance\", namespace=\"$namespace\", collection_name=~\"$collection_name\",container=\"$container\",job=\"$job\"}[2m])) by (pod, node_id, query_type) / sum(increase(milvus_proxy_collection_sq_latency_count{instance=~\"$instance\", namespace=\"$namespace\", collection_name=~\"$collection_name\",container=\"$container\",job=\"$job\"}[2m])) by (pod, node_id, query_type)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "30": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Collection Loaded Num",
+            "description": "Total number of loaded collections."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_querycoord_collection_num{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (instance)",
+                    "seriesNameFormat": "num"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "31": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Load Request Latency",
+            "description": "The 99th percentile and average latency of load request over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le) (rate(milvus_querycoord_load_latency_bucket{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])))",
+                    "seriesNameFormat": "p99-latency"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_querycoord_load_latency_sum{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) / sum(increase(milvus_querycoord_load_latency_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m]))",
+                    "seriesNameFormat": "avg-latency"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "32": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Load Request Rate",
+            "description": "per-second increasing rate of load requests."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_querycoord_load_req_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])/120) by (status)",
+                    "seriesNameFormat": "{{ `{{status}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "33": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Release Request Rate",
+            "description": "per-second increasing rate of relaase requests."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_querycoord_release_req_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])/120) by (status)",
+                    "seriesNameFormat": "{{ `{{status}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "34": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Load Task",
+            "description": "Total number pf loading task."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_querycoord_task_num{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (instance)",
+                    "seriesNameFormat": "num"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "35": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Release Request Latency",
+            "description": "The 99th percentile and average latency of release request over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le) (rate(milvus_querycoord_release_latency_bucket{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])))",
+                    "seriesNameFormat": "p99-latency"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_querycoord_release_latency_sum{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) / sum(increase(milvus_querycoord_release_latency_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m]))",
+                    "seriesNameFormat": "avg-latency"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "36": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Query Node Num",
+            "description": "Number of Query nodes which has register with etcd."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_querycoord_querynode_num{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (instance)",
+                    "seriesNameFormat": "num"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "37": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Task Latency",
+            "description": "The 99th percentile and average latency of task request over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le) (rate(milvus_querycoord_task_latency_bucket{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])))",
+                    "seriesNameFormat": "p99-latency"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_querycoord_task_latency_sum{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) / sum(increase(milvus_querycoord_task_latency_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m]))",
+                    "seriesNameFormat": "avg-latency"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "38": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Collection Loaded Num",
+            "description": "Total number of the loaded collections in QueryNode."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_querynode_collection_num{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "39": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "DML Virtual Channel",
+            "description": "Total number of dml virtual channels for QueryNode watch"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_querynode_dml_vchannel_num{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Mutation Latency",
+            "description": "The 99th percentile and average latency of mutation request over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, msg_type, pod, node_id) (rate(milvus_proxy_mutation_latency_bucket{instance=~\"$instance\",namespace=\"$namespace\", collection_name=~\"$collection_name\",container=\"$container\",job=\"$job\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{msg_type}}` }}-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(increase(milvus_proxy_mutation_latency_sum{instance=~\"$instance\", namespace=\"$namespace\", collection_name=~\"$collection_name\",container=\"$container\",job=\"$job\"}[2m])) by (pod, node_id, msg_type) / sum(increase(milvus_proxy_mutation_latency_count{instance=~\"$instance\", namespace=\"$namespace\", collection_name=~\"$collection_name\",container=\"$container\",job=\"$job\"}[2m])) by (pod, node_id, msg_type)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "40": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Segment Loaded Num",
+            "description": "Total number of the loaded segment in QueryNode."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_querynode_segment_num{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (pod, node_id, segment_state)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{segment_state}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "41": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "TimeTick Lag Behind Now (Consumed)",
+            "description": "Average, maximum and minimum values of the  timestamps for time tick behind."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "avg(milvus_querynode_consume_tt_lag_ms{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\", msg_type=\"timetick\"}) by (pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}-avg"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "max(milvus_querynode_consume_tt_lag_ms{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\", msg_type=\"timetick\"}) by (pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}-max"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "min(milvus_querynode_consume_tt_lag_ms{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\", msg_type=\"timetick\"}) by (pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}-min"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "42": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Search Request Rate",
+            "description": "per-second increasing rate of searching requests."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_querynode_sq_req_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])/120) by (query_type, status, pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{query_type}}` }}-{{ `{{status}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "43": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Consumed Message Rate",
+            "description": "per-second increasing rate of consuming message"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_querynode_consume_msg_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])/120) by (pod, node_id, msg_type)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{msg_type}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_querynode_consume_msg_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])/120) by (pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}-all"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "44": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Queryable Entity Num",
+            "description": "Total number of the queryable entities  in QueryNode."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_querynode_entity_num{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "45": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Search Segment Latency",
+            "description": "The 99th percentile and average latency of search segment over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, pod, node_id, query_type, segment_state) (rate(milvus_querynode_sq_segment_latency_bucket{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{query_type}}` }}-{{ `{{segment_state}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_querynode_sq_segment_latency_sum{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id, query_type, segment_state) / sum(increase(milvus_querynode_sq_segment_latency_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id, query_type, segment_state)",
+                    "seriesNameFormat": "avg-{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{query_type}}` }}_{{ `{{segment_state}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "46": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Search Request Latency",
+            "description": "The 99th percentile and average latency of search and query request over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, pod, node_id, query_type) (rate(milvus_querynode_sq_req_latency_bucket{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{query_type}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_querynode_sq_req_latency_sum{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id, query_type) / sum(increase(milvus_querynode_sq_req_latency_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id, query_type)",
+                    "seriesNameFormat": "avg-{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{query_type}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "47": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Search in Queue Latency",
+            "description": "The 99th percentile and average latency of search or query in queue over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, pod, node_id, query_type) (rate(milvus_querynode_sq_queue_latency_bucket{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{query_type}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_querynode_sq_queue_latency_sum{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id, query_type) / sum(increase(milvus_querynode_sq_queue_latency_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id, query_type)",
+                    "seriesNameFormat": "avg-{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{query_type}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "48": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Load Segment Latency",
+            "description": "The 99th percentile and average latency of load segment over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, pod, node_id) (rate(milvus_querynode_load_segment_latency_bucket{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_querynode_load_segment_latency_sum{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id) / sum(increase(milvus_querynode_load_segment_latency_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id)",
+                    "seriesNameFormat": "avg-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "49": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Segcore Request Latency",
+            "description": "The 99th percentile and average latency of search at the segcore step over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, query_type, pod, node_id) (rate(milvus_querynode_sq_core_latency_bucket{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{query_type}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_querynode_sq_core_latency_sum{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id, query_type) / sum(increase(milvus_querynode_sq_core_latency_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id, query_type)",
+                    "seriesNameFormat": "avg-{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{query_type}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Collection Mutation Latency",
+            "description": "The 99th percentile and average latency of mutation request for a specified collection over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, msg_type, pod, node_id) (rate(milvus_proxy_collection_mutation_latency_bucket{instance=~\"$instance\",namespace=\"$namespace\", collection_name=~\"$collection_name\",container=\"$container\",job=\"$job\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{msg_type}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_proxy_collection_mutation_latency_sum{instance=~\"$instance\", namespace=\"$namespace\", collection_name=~\"$collection_name\",container=\"$container\",job=\"$job\"}[2m])) by (pod, node_id, msg_type) / sum(increase(milvus_proxy_collection_mutation_latency_count{instance=~\"$instance\", namespace=\"$namespace\", collection_name=~\"$collection_name\",container=\"$container\",job=\"$job\"}[2m])) by (pod, node_id, msg_type)",
+                    "seriesNameFormat": "avg-{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{msg_type}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "50": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Search Reduce Latency",
+            "description": "The 99th percentile and average latency of search or query reduce over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, pod, node_id, query_type) (rate(milvus_querynode_sq_reduce_latency_bucket{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{query_type}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_querynode_sq_reduce_latency_sum{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id, query_type) / sum(increase(milvus_querynode_sq_reduce_latency_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id, query_type)",
+                    "seriesNameFormat": "avg-{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{query_type}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "51": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Ready Read Task Length",
+            "description": "The length of the task queue of read requests to be executed"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_querynode_read_task_ready_len{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "52": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Flowgraph Num",
+            "description": "Total number of flowgraph"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_querynode_flowgraph_num{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "53": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Unsolved Read Task Length",
+            "description": "The length of the task queue for unsolved read requests"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_querynode_read_task_unsolved_len{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "54": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Search Group Size",
+            "description": "The number of original tasks contained in the merged search task"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, pod, node_id) (rate(milvus_querynode_search_group_size_bucket{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_querynode_search_group_size_sum{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id) / sum(increase(milvus_querynode_search_group_size_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id)",
+                    "seriesNameFormat": "avg-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "55": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Parallel Read Task Num",
+            "description": "Number of read requests currently being executed in parallel"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_querynode_read_task_concurrency{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "56": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Search Group NQ",
+            "description": "Number of queries for the merged search requests"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, pod, node_id) (rate(milvus_querynode_search_group_nq_bucket{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_querynode_search_group_nq_sum{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id) / sum(increase(milvus_querynode_search_group_nq_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id)",
+                    "seriesNameFormat": "avg-milvus_querynode_search_group_nq"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "57": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Search Top_K",
+            "description": "Top_K for search requests"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, pod, node_id) (rate(milvus_querynode_search_topk_bucket{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_querynode_search_topk_sum{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id) / sum(increase(milvus_querynode_search_topk_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id)",
+                    "seriesNameFormat": "avg-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "58": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Search NQ",
+            "description": "Number of queries for search requests"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, pod, node_id) (rate(milvus_querynode_search_nq_bucket{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_querynode_search_nq_sum{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id) / sum(increase(milvus_querynode_search_nq_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id)",
+                    "seriesNameFormat": "avg-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "59": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Search Group Top_K",
+            "description": "Top_K for the merged search requests."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, pod, node_id) (rate(milvus_querynode_search_group_topk_bucket{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_querynode_search_group_topk_sum{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id) / sum(increase(milvus_querynode_search_group_topk_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id)",
+                    "seriesNameFormat": "avg-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Wait Search Result Latency",
+            "description": "The 99th percentile and average latency of wait search result over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, query_type, pod, node_id) (rate(milvus_proxy_sq_wait_result_latency_bucket{instance=~\"$instance\", namespace=\"$namespace\",container=\"$container\",job=\"$job\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{query_type}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_proxy_sq_wait_result_latency_sum{instance=~\"$instance\", namespace=\"$namespace\",container=\"$container\",job=\"$job\"}[2m])) by (pod, node_id, query_type) / sum(increase(milvus_proxy_sq_wait_result_latency_count{instance=~\"$instance\", namespace=\"$namespace\",container=\"$container\",job=\"$job\"}[2m])) by (pod, node_id, query_type)",
+                    "seriesNameFormat": "avg-{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{query_type}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "60": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Data Node Num",
+            "description": "Number of data nodes which has register with etcd."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_datacoord_datanode_num{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (instance)",
+                    "seriesNameFormat": "total"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "61": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Segment Num",
+            "description": "Number of segments with different states in the Meta of DataCoord"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_datacoord_segment_num{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (segment_state)",
+                    "seriesNameFormat": "{{ `{{segment_state}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "62": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Stored Rows",
+            "description": "The number of rows of valid data accumulated in DataCoord that flushed."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_datacoord_stored_rows_num{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (instance)",
+                    "seriesNameFormat": "row"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "63": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Stored Binlog Size",
+            "description": "binlog size of all collections/segments, unit byte"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_datacoord_stored_binlog_size{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (instance)",
+                    "seriesNameFormat": "size"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "64": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Compact Segment Size",
+            "description": "Compacted segment size distribution buckets"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_datacoord_compacted_segment_size_bucket{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (instance)",
+                    "seriesNameFormat": "size"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(increase(milvus_datacoord_compacted_segment_size_sum{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id) / sum(increase(milvus_datacoord_compacted_segment_size_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "65": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Level-0 Segment Size",
+            "description": "Sum of Level-0 segment sizes"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_datacoord_store_level0_segment_size_bucket{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (instance)",
+                    "seriesNameFormat": "size"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(increase(milvus_datacoord_store_level0_segment_size_sum{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id) / sum(increase(milvus_datacoord_store_level0_segment_size_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "66": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Task Count",
+            "description": "Number of ongoing DataCoord tasks"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_datacoord_task_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (instance)",
+                    "seriesNameFormat": "size"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "67": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Index Req Count",
+            "description": "DataCoord total index request count"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_datacoord_index_req_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (instance)",
+                    "seriesNameFormat": "size"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "68": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Index Node Number",
+            "description": "DataCoord total index node number."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_datacoord_index_node_num{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (instance)",
+                    "seriesNameFormat": "size"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "69": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "DataCoord Collection Number",
+            "description": "DataCoord total collection number."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_datacoord_collection_num{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (instance)",
+                    "seriesNameFormat": "size"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Reduce Search Result Latency",
+            "description": "The 99th percentile and average latency of reduce search result over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, query_type, pod, node_id) (rate(milvus_proxy_sq_decode_result_latency_bucket{instance=~\"$instance\",namespace=\"$namespace\",container=\"$container\",job=\"$job\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{query_type}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_proxy_sq_reduce_result_latency_sum{instance=~\"$instance\", namespace=\"$namespace\",container=\"$container\",job=\"$job\"}[2m])) by (pod, node_id, query_type) / sum(increase(milvus_proxy_sq_reduce_result_latency_count{instance=~\"$instance\", namespace=\"$namespace\",container=\"$container\",job=\"$job\"}[2m])) by (pod, node_id, query_type)",
+                    "seriesNameFormat": "avg-{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{query_type}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "70": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Channel Checkpoint Unix Seconds",
+            "description": "Latest checkpoint timestamp per channel"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_datacoord_channel_checkpoint_unix_seconds{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (instance)",
+                    "seriesNameFormat": "size"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "71": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Flushed Data Rows",
+            "description": "DataNode total flushed rows count"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_datanode_flushed_data_rows{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "72": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Consume Bytes Count",
+            "description": "DataNode total consumed bytes count"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_datanode_consume_bytes_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "73": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "TimeTick Lag Behind Now (Consumed All)",
+            "description": "Average, maximum and minimum values of the  timestamps for time tick lag behind now."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "avg(milvus_datanode_consume_tt_lag_ms{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\", msg_type=\"all\"}) by (pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}-avg"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "max(milvus_datanode_consume_tt_lag_ms{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\", msg_type=\"all\"}) by (pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}-max"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "min(milvus_datanode_consume_tt_lag_ms{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\", msg_type=\"all\"}) by (pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}-min"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "74": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Flush Operate Rate",
+            "description": "per-second increasing rate of flush operete."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_datanode_flush_buffer_op_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])/120) by (status, pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{status}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "75": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Consumed Message Rate",
+            "description": "per-second increasing rate of consuming message"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_datanode_consume_msg_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])/120) by (pod, node_id, msg_type)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{msg_type}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "76": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Consumed Message Rate",
+            "description": "per-second increasing rate of consuming message"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_datanode_consume_msg_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])/120) by (pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "77": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Consume Bytes Count",
+            "description": "Volume of data processed by DataNode"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_datanode_consume_bytes_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (index_task_status)",
+                    "seriesNameFormat": "{{ `{{index_task_status}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "78": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Autoflush Operate Rate",
+            "description": "per-second increasing rate of auto flush operate."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_datanode_autoflush_buffer_op_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])/120) by (status, pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{status}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "79": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Msg Rows Consumed Rate",
+            "description": "per-second increasing rate of messages consumed for insert and delete operation."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_datanode_msg_rows_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])/120) by (msg_type, pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{msg_type}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Decode Search Result Latency",
+            "description": "The 99th percentile and average latency of decode search result over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_proxy_sq_decode_result_latency_sum{instance=~\"$instance\", namespace=\"$namespace\",container=\"$container\",job=\"$job\"}[2m])) by (pod, node_id, query_type) / sum(increase(milvus_proxy_sq_decode_result_latency_count{instance=~\"$instance\", namespace=\"$namespace\",container=\"$container\",job=\"$job\"}[2m])) by (pod, node_id, query_type)",
+                    "seriesNameFormat": "avg-{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{query_type}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, query_type, pod, node_id) (rate(milvus_proxy_sq_decode_result_latency_bucket{instance=~\"$instance\",namespace=\"$namespace\",container=\"$container\",job=\"$job\"}[2m])))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "80": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Buffer Size",
+            "description": "DataNode foreground flush buffer size"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(milvus_datanode_fg_buffer_size{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}) by (instance)",
+                    "seriesNameFormat": "total"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "81": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Save Data Latency",
+            "description": "The 99th percentile and average latency of writte the data in buffer to storage  over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, pod, node_id) (rate(milvus_datanode_save_latency_bucket{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_datanode_save_latency_sum{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id) / sum(increase(milvus_datanode_save_latency_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])) by(pod, node_id)",
+                    "seriesNameFormat": "avg-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "82": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Flush Data Size Rate",
+            "description": "per-second increasing rate of each message that has been flushed."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_datanode_flushed_data_size{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])/120) by (msg_type, pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{msg_type}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "83": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Write Data Count",
+            "description": "per-second count of write data."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_datanode_write_data_count{instance=~\"$instance\", container=\"$container\", namespace=\"$namespace\"}[2m])/120) by (status, pod, node_id)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-{{ `{{node_id}}` }}-{{ `{{status}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "84": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage Total",
+            "description": "Total cpu usage of all milvus components."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(rate(process_cpu_seconds_total{container=\"$container\", instance=~\"$instance\", namespace=\"$namespace\"}[5m]))",
+                    "seriesNameFormat": "cpu usage"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "85": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Total"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(process_resident_memory_bytes{container=\"$container\", instance=~\"$instance\", namespace=\"$namespace\"})",
+                    "seriesNameFormat": "memory"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "86": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Goroutines Total",
+            "description": "Number of goroutines that currently exist."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(go_goroutines{container=\"$container\", instance=~\"$instance\", namespace=\"$namespace\"})",
+                    "seriesNameFormat": "goroutines"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "87": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage",
+            "description": "process cpu usage"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(process_cpu_seconds_total{container=\"$container\", instance=~\"$instance\", namespace=\"$namespace\"}[5m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "88": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory",
+            "description": "Process memory of milvus pod."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "process_resident_memory_bytes{container=\"$container\", instance=~\"$instance\", namespace=\"$namespace\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "89": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Goroutines",
+            "description": "Number of goroutines that currently exist."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "go_goroutines{container=\"$container\", instance=~\"$instance\", namespace=\"$namespace\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cache Update Latency",
+            "description": "The 99th percentile and average latency of update cache over the last 2 minutes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "histogram_quantile(0.99, sum by (le, pod, node_id) (rate(milvus_proxy_cache_update_latency_bucket{instance=~\"$instance\", namespace=\"$namespace\"}[2m])))",
+                    "seriesNameFormat": "p99-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "sum(increase(milvus_proxy_cache_update_latency_sum{instance=~\"$instance\", namespace=\"$namespace\"}[2m])) by (pod, node_id) / sum(increase(milvus_proxy_cache_update_latency_count{instance=~\"$instance\", namespace=\"$namespace\"}[2m])) by (pod, node_id)",
+                    "seriesNameFormat": "avg-{{ `{{pod}}` }}-{{ `{{node_id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "90": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Go Allocated Memory",
+            "description": "Number of bytes allocated and still in use."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "go_memstats_alloc_bytes{container=\"$container\", instance=~\"$instance\", namespace=\"$namespace\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "91": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "GC Max duration seconds",
+            "description": "GC Max duration seconds."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "go_gc_duration_seconds{container=\"$container\", instance=~\"$instance\", namespace=\"$namespace\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "92": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "OS Threads",
+            "description": "Number of OS threads created."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "go_threads{container=\"$container\", instance=~\"$instance\", namespace=\"$namespace\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "93": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Next GC Bytes",
+            "description": "Next GC Bytes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "go_memstats_next_gc_bytes{container=\"$container\", instance=~\"$instance\", namespace=\"$namespace\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "94": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Process Opened Fds",
+            "description": "Number of process opened fds."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "process_open_fds{container=\"$container\", instance=~\"$instance\", namespace=\"$namespace\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "95": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Allocated Heap Objects",
+            "description": "Number of allocated heap objects."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "go_memstats_heap_objects{container=\"$container\", instance=~\"$instance\", namespace=\"$namespace\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "96": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Free Rate",
+            "description": "Rate of memory frees."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(go_memstats_frees_total{container=\"$container\", instance=~\"$instance\", namespace=\"$namespace\"}[5m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "97": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Go Memory mallocs rate.",
+            "description": "Rate of go memory mallocs."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(go_memstats_mallocs_total{container=\"$container\", instance=~\"$instance\", namespace=\"$namespace\"}[2m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "98": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Go Heap idle",
+            "description": "Number of heap bytes waiting to be used."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "go_memstats_heap_idle_bytes{container=\"$container\", instance=~\"$instance\", namespace=\"$namespace\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "99": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Allocated Rate",
+            "description": "Rate of bytes allocated, even if freed."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "$datasource"
+                    },
+                    "minStep": "",
+                    "query": "rate(go_memstats_alloc_bytes_total{container=\"$container\", instance=~\"$instance\", namespace=\"$namespace\"}[5m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 8,
+              "y": 1,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 16,
+              "y": 1,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 0,
+              "y": 7,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 8,
+              "y": 7,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 16,
+              "y": 7,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 0,
+              "y": 13,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 8,
+              "y": 13,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 16,
+              "y": 13,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 0,
+              "y": 19,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 8,
+              "y": 19,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 16,
+              "y": 19,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 0,
+              "y": 25,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 8,
+              "y": 25,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 16,
+              "y": 25,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 0,
+              "y": 31,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 8,
+              "y": 31,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 16,
+              "y": 31,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            },
+            {
+              "x": 0,
+              "y": 38,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/18"
+              }
+            },
+            {
+              "x": 8,
+              "y": 38,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/19"
+              }
+            },
+            {
+              "x": 16,
+              "y": 38,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/20"
+              }
+            },
+            {
+              "x": 0,
+              "y": 44,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/21"
+              }
+            },
+            {
+              "x": 8,
+              "y": 44,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/22"
+              }
+            },
+            {
+              "x": 16,
+              "y": 44,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/23"
+              }
+            },
+            {
+              "x": 0,
+              "y": 50,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/24"
+              }
+            },
+            {
+              "x": 8,
+              "y": 50,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/25"
+              }
+            },
+            {
+              "x": 16,
+              "y": 50,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/26"
+              }
+            },
+            {
+              "x": 0,
+              "y": 56,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/27"
+              }
+            },
+            {
+              "x": 8,
+              "y": 56,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/28"
+              }
+            },
+            {
+              "x": 16,
+              "y": 56,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/29"
+              }
+            },
+            {
+              "x": 0,
+              "y": 39,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/30"
+              }
+            },
+            {
+              "x": 8,
+              "y": 39,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/31"
+              }
+            },
+            {
+              "x": 16,
+              "y": 39,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/32"
+              }
+            },
+            {
+              "x": 0,
+              "y": 45,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/33"
+              }
+            },
+            {
+              "x": 8,
+              "y": 45,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/34"
+              }
+            },
+            {
+              "x": 16,
+              "y": 45,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/35"
+              }
+            },
+            {
+              "x": 0,
+              "y": 51,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/36"
+              }
+            },
+            {
+              "x": 8,
+              "y": 51,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/37"
+              }
+            },
+            {
+              "x": 0,
+              "y": 58,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/38"
+              }
+            },
+            {
+              "x": 8,
+              "y": 58,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/39"
+              }
+            },
+            {
+              "x": 16,
+              "y": 58,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/40"
+              }
+            },
+            {
+              "x": 0,
+              "y": 64,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/41"
+              }
+            },
+            {
+              "x": 8,
+              "y": 64,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/42"
+              }
+            },
+            {
+              "x": 16,
+              "y": 64,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/43"
+              }
+            },
+            {
+              "x": 0,
+              "y": 70,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/44"
+              }
+            },
+            {
+              "x": 8,
+              "y": 70,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/45"
+              }
+            },
+            {
+              "x": 16,
+              "y": 70,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/46"
+              }
+            },
+            {
+              "x": 0,
+              "y": 76,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/47"
+              }
+            },
+            {
+              "x": 8,
+              "y": 76,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/48"
+              }
+            },
+            {
+              "x": 16,
+              "y": 76,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/49"
+              }
+            },
+            {
+              "x": 0,
+              "y": 82,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/50"
+              }
+            },
+            {
+              "x": 8,
+              "y": 82,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/51"
+              }
+            },
+            {
+              "x": 16,
+              "y": 82,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/52"
+              }
+            },
+            {
+              "x": 0,
+              "y": 88,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/53"
+              }
+            },
+            {
+              "x": 8,
+              "y": 88,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/54"
+              }
+            },
+            {
+              "x": 16,
+              "y": 88,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/55"
+              }
+            },
+            {
+              "x": 0,
+              "y": 94,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/56"
+              }
+            },
+            {
+              "x": 8,
+              "y": 94,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/57"
+              }
+            },
+            {
+              "x": 16,
+              "y": 94,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/58"
+              }
+            },
+            {
+              "x": 0,
+              "y": 100,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/59"
+              }
+            },
+            {
+              "x": 0,
+              "y": 107,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/60"
+              }
+            },
+            {
+              "x": 8,
+              "y": 107,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/61"
+              }
+            },
+            {
+              "x": 16,
+              "y": 107,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/62"
+              }
+            },
+            {
+              "x": 0,
+              "y": 113,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/63"
+              }
+            },
+            {
+              "x": 8,
+              "y": 113,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/64"
+              }
+            },
+            {
+              "x": 16,
+              "y": 113,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/65"
+              }
+            },
+            {
+              "x": 0,
+              "y": 119,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/66"
+              }
+            },
+            {
+              "x": 8,
+              "y": 119,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/67"
+              }
+            },
+            {
+              "x": 16,
+              "y": 119,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/68"
+              }
+            },
+            {
+              "x": 0,
+              "y": 125,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/69"
+              }
+            },
+            {
+              "x": 8,
+              "y": 125,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/70"
+              }
+            },
+            {
+              "x": 0,
+              "y": 132,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/71"
+              }
+            },
+            {
+              "x": 8,
+              "y": 132,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/72"
+              }
+            },
+            {
+              "x": 16,
+              "y": 132,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/73"
+              }
+            },
+            {
+              "x": 0,
+              "y": 138,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/74"
+              }
+            },
+            {
+              "x": 8,
+              "y": 138,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/75"
+              }
+            },
+            {
+              "x": 16,
+              "y": 138,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/76"
+              }
+            },
+            {
+              "x": 0,
+              "y": 144,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/77"
+              }
+            },
+            {
+              "x": 8,
+              "y": 144,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/78"
+              }
+            },
+            {
+              "x": 16,
+              "y": 144,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/79"
+              }
+            },
+            {
+              "x": 0,
+              "y": 150,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/80"
+              }
+            },
+            {
+              "x": 8,
+              "y": 150,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/81"
+              }
+            },
+            {
+              "x": 16,
+              "y": 150,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/82"
+              }
+            },
+            {
+              "x": 0,
+              "y": 156,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/83"
+              }
+            },
+            {
+              "x": 0,
+              "y": 163,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/84"
+              }
+            },
+            {
+              "x": 8,
+              "y": 163,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/85"
+              }
+            },
+            {
+              "x": 16,
+              "y": 163,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/86"
+              }
+            },
+            {
+              "x": 0,
+              "y": 169,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/87"
+              }
+            },
+            {
+              "x": 8,
+              "y": 169,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/88"
+              }
+            },
+            {
+              "x": 16,
+              "y": 169,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/89"
+              }
+            },
+            {
+              "x": 0,
+              "y": 175,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/90"
+              }
+            },
+            {
+              "x": 8,
+              "y": 175,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/91"
+              }
+            },
+            {
+              "x": 16,
+              "y": 175,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/92"
+              }
+            },
+            {
+              "x": 0,
+              "y": 181,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/93"
+              }
+            },
+            {
+              "x": 8,
+              "y": 181,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/94"
+              }
+            },
+            {
+              "x": 16,
+              "y": 181,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/95"
+              }
+            },
+            {
+              "x": 0,
+              "y": 187,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/96"
+              }
+            },
+            {
+              "x": 8,
+              "y": 187,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/97"
+              }
+            },
+            {
+              "x": 16,
+              "y": 187,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/98"
+              }
+            },
+            {
+              "x": 0,
+              "y": 193,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/99"
+              }
+            },
+            {
+              "x": 8,
+              "y": 193,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/100"
+              }
+            },
+            {
+              "x": 16,
+              "y": 193,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/101"
+              }
+            },
+            {
+              "x": 0,
+              "y": 199,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/102"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/milvus/milvus-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/milvus/milvus-summary.json
@@ -1,0 +1,1598 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "milvusSumMaRyl",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / Milvus / Summary"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Datasource",
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "kubedb",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_created"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "App",
+            "hidden": false
+          },
+          "defaultValue": [
+            "milvus-cluster"
+          ],
+          "allowAllValue": true,
+          "allowMultiple": true,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kubedb_com_milvus_status_phase{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Database Status",
+            "description": "Represent database status"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": "phase",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_milvus_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Version",
+            "description": "Milvus CR Name"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "mean",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": " version ",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              },
+              "valueFontSize": 50
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_milvus_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{ version }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage",
+            "description": "CPU Usage by Milvus pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\",pod=~\"$app.*\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Quota",
+            "description": "CPU Quote information in details"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp",
+                  "width": "auto"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app.*\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app.*\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app.*\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app.*\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app.*\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app.*\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app.*\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Usage",
+            "description": "Memory Usage by Milvus pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app.*\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Quota"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (RSS)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Cache)",
+                  "name": "value #7"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Swap)",
+                  "name": "value #8"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app.*\",container!=\"\", image!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app.*\",container!=\"\", image!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app.*\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app.*\",container!=\"\", image!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\",pod=~\"$app.*\",container!=\"\", image!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app.*\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app.*\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_rss{namespace=\"$namespace\",pod=~\"$app.*$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_cache{namespace=\"$namespace\",pod=~\"$app.*\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_swap{namespace=\"$namespace\",pod=~\"$app.*\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk Usage",
+            "description": "Disk usage by Milvus pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app.*\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk R/W Info",
+            "description": "System Disk Usage Information"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app.*\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app.*\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "IOPS (Reads+Writes)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app.*\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app.*\"}[5m])))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ThroughPut (Read+Write)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app.*\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app.*\"}[5m]))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Current Storage IO"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads)",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Writes)",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads + Writes)",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read)",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Write)",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read + Write)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app.*\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_fs_writes_total{pod=~\"$app.*\",namespace=\"$namespace\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app.*\",namespace=~\"$namespace\"}[5m])) + sum(container_fs_writes_total{pod=~\"$app.*\",namespace=\"$namespace\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{pod=~\"$app.*\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_fs_writes_bytes_total{namespace=\"$namespace\", pod=~\"$app.*\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{pod=~\"$app.*\",namespace=~\"$namespace\"}[5m])) + sum(container_fs_writes_bytes_total{namespace=\"$namespace\", pod=~\"$app.*\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Allocated Storage",
+            "description": "This panel describes allocated persistent storage in a table format\n"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": []
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app.*\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Require Secure Transport",
+            "description": "When this option is enabled, connections attempted using insecure transport will be rejected."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_milvus_tls_enable{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{issuers_name}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage",
+            "description": "This panel shows the persistent volume usage in percentage. "
+          },
+          "plugin": {
+            "kind": "BarChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "percent"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"milvus-cluster.*\",namespace=\"kubedb\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage History",
+            "description": "This panel describes the persistent volume usage in a time series. "
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "right",
+                "values": [
+                  "max",
+                  "last-number"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineStyle": "solid",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decbytes"
+                },
+                "max": 5000,
+                "min": 0
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(kubelet_volume_stats_used_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app.*\",namespace=~\"$namespace\"}) ",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Receive Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app.*\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Transmit Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app.*\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Deletion Policy",
+            "description": "KubeDB Database Resource deletionPolicy"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_milvus_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Nodes",
+            "description": "Total node count of Milvus cluster"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_milvus_replicas{namespace=\"$namespace\",app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Request (Core)",
+            "description": "Initial Requested CPU amount by Milvus Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_milvus_resource_request_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Limit (Core)",
+            "description": "CPU Limit in core by Milvus instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_milvus_resource_limit_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Request",
+            "description": "Initial Requested Memory amount by Milvus Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_milvus_resource_request_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Limit",
+            "description": "KubeDB Milvus Total Memory Limit"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_milvus_resource_limit_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Storage Request",
+            "description": "Total storage request by Milvus nodes"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_milvus_resource_request_storage{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 8,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 16,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 20,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 4,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 8,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 12,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 16,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 20,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 0,
+              "y": 22,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 0,
+              "y": 28,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 0,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 12,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 0,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 12,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            },
+            {
+              "x": 0,
+              "y": 51,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/18"
+              }
+            },
+            {
+              "x": 0,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/19"
+              }
+            },
+            {
+              "x": 12,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/20"
+              }
+            },
+            {
+              "x": 0,
+              "y": 65,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/21"
+              }
+            },
+            {
+              "x": 0,
+              "y": 74,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/22"
+              }
+            },
+            {
+              "x": 12,
+              "y": 74,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/23"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/mongodb/mongodb-database-replset-dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mongodb/mongodb-database-replset-dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "76a6bafe-2c40-485d-b7a7-cb9be4bfbff1",
+    "name": "d0259b78-49c0-4614-bb8b-2ed302a5a8ec",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
@@ -146,6 +146,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "decimalPlaces": 0,
                 "unit": "decimal"
@@ -192,6 +193,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "decimalPlaces": 0,
                 "unit": "decimal"
@@ -265,6 +267,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "decimalPlaces": 1,
                 "unit": "seconds"
@@ -311,6 +314,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "decimalPlaces": 1,
                 "unit": "seconds"
@@ -357,6 +361,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "decimalPlaces": 0,
                 "unit": "decimal"
@@ -411,7 +416,7 @@
                   "spec": {
                     "minStep": "$interval",
                     "query": "rate(mongodb_ss_opcountersRepl{pod=~\"$pod\", legacy_op_type!~\"(command|getmore|query)\"}[$interval]) or irate(mongodb_ss_opcountersRepl{pod=~\"$pod\", legacy_op_type!~\"(command|getmore|query)\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{legacy_op_type}}` }}"
                   }
                 }
               }
@@ -466,7 +471,7 @@
                   "spec": {
                     "minStep": "$interval",
                     "query": "rate(mongodb_mongod_metrics_repl_network_getmores_total_milliseconds{pod=~\"$pod\"}[$interval]) or irate(mongodb_mongod_metrics_repl_network_getmores_total_milliseconds{pod=~\"$pod\"}[5m]) or rate(mongodb_ss_metrics_repl_network_getmores_totalMillis{pod=~\"$pod\"}[$interval]) or irate(mongodb_ss_metrics_repl_network_getmores_totalMillis{pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/mongodb/mongodb-pod-dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mongodb/mongodb-pod-dashboard.json
@@ -1,8 +1,9 @@
 {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "37b8207f-ab9e-442c-92eb-2364bfe2d7df",
+    "name": "e63d0da5-722a-4e00-aa0e-c25ee5d8cea4",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,
@@ -173,6 +174,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "seconds"
               },
@@ -363,7 +365,7 @@
                   "spec": {
                     "minStep": "$interval",
                     "query": "rate(mongodb_ss_asserts{pod=~\"$pod\"}[$interval]) or \nirate(mongodb_ss_asserts{pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{assert_type}}` }}"
                   }
                 }
               }
@@ -409,6 +411,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "ops/sec"
               },
@@ -454,6 +457,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -506,7 +510,7 @@
                   "spec": {
                     "minStep": "$interval",
                     "query": "rate(mongodb_ss_opcounters{pod=~\"$pod\", legacy_op_type!=\"command\"}[$interval])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{legacy_op_type}}` }}"
                   }
                 }
               }
@@ -519,7 +523,7 @@
                   "spec": {
                     "minStep": "$interval",
                     "query": "rate(mongodb_ss_opcountersRepl{pod=~\"$pod\", legacy_op_type!~\"(command|query|getmore)\"}[$interval])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "repl_{{ `{{legacy_op_type}}` }}"
                   }
                 }
               }
@@ -560,7 +564,7 @@
                   "spec": {
                     "minStep": "$interval",
                     "query": "avg by (service,op_type) (rate(mongodb_ss_opLatencies_latency{service=~\"${app}-stats\"}[$interval]) / (rate(mongodb_ss_opLatencies_ops{service=~\"${app}-stats\"}[$interval]) > 0) or irate(mongodb_ss_opLatencies_latency{service=~\"${app}-stats\"}[5m]) / (irate(mongodb_ss_opLatencies_ops{service=~\"${app}-stats\"}[5m]) > 0))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{op_type}}` }}"
                   }
                 }
               }
@@ -616,7 +620,7 @@
                   "spec": {
                     "minStep": "$interval",
                     "query": "mongodb_ss_metrics_cursor_open{pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{csr_type}}` }}"
                   }
                 }
               }
@@ -644,7 +648,7 @@
                   "spec": {
                     "minStep": "$interval",
                     "query": "rate(mongodb_ss_metrics_document{pod=~\"$pod\"}[$interval])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{doc_op_type}}` }}"
                   }
                 }
               }
@@ -672,7 +676,7 @@
                   "spec": {
                     "minStep": "$interval",
                     "query": "mongodb_ss_globalLock_currentQueue{pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{count_type}}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/mongodb/mongodb-summary-dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mongodb/mongodb-summary-dashboard.json
@@ -92,6 +92,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
               "thresholds": {
                 "steps": [
                   {
@@ -111,7 +113,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_mongodb_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
                   }
                 }
               }
@@ -130,6 +132,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "seconds"
               },
@@ -187,7 +190,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -208,29 +211,48 @@
               "columnSettings": [
                 {
                   "header": "Time",
-                  "name": "timestamp"
+                  "name": "timestamp",
+                  "width": "auto"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -332,7 +354,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",container!=\"\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -355,38 +377,65 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (RSS)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Cache)",
-                  "name": "Value #G"
+                  "name": "value #7"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Swap)",
-                  "name": "Value #H"
+                  "name": "value #8"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -532,7 +581,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -571,7 +620,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
                   }
                 }
               }
@@ -584,7 +633,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
                   }
                 }
               }
@@ -622,7 +671,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}[5m])))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -660,7 +709,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -683,30 +732,51 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads)",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Writes)",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads + Writes)",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read)",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Write)",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read + Write)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -836,6 +906,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -889,7 +960,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes{} / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes{} + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",namespace=~\"$namespace\"}) )* 100",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -924,7 +995,7 @@
               },
               "yAxis": {
                 "format": {
-                  "unit": "bytes"
+                  "unit": "decbytes"
                 },
                 "max": 5000,
                 "min": 0
@@ -940,7 +1011,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",namespace=~\"$namespace\"}) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -978,7 +1049,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1016,7 +1087,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1035,6 +1106,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -1077,6 +1149,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -1119,9 +1192,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": "version",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1146,7 +1221,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_mongodb_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{version}}` }}"
                   }
                 }
               }
@@ -1165,6 +1240,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "thresholds": {
                 "steps": [
                   {
@@ -1207,6 +1283,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1246,6 +1323,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -1288,6 +1366,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1308,7 +1387,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_mongodb_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/mssqlserver/mssqlserver_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mssqlserver/mssqlserver_database_dashboard.json
@@ -90,26 +90,6 @@
           "plugin": {
             "kind": "Table",
             "spec": {
-              "cellSettings": [
-                {
-                  "condition": {
-                    "kind": "Value",
-                    "spec": {
-                      "value": "0"
-                    }
-                  },
-                  "text": "DOWN"
-                },
-                {
-                  "condition": {
-                    "kind": "Value",
-                    "spec": {
-                      "value": "1"
-                    }
-                  },
-                  "text": "UP"
-                }
-              ],
               "columnSettings": []
             }
           },
@@ -122,7 +102,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "up{namespace=~\"$namespace\",service=~\"$app+-stats\",target=\"mssql_database\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -151,7 +131,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mssql_uptime_seconds{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -178,7 +158,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mssql_connections{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{db}}` }}"
                   }
                 }
               }
@@ -205,7 +185,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mssql_io_stall_total_seconds{}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{db}}` }}"
                   }
                 }
               }
@@ -223,6 +203,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -296,7 +277,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mssql_pod_role{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -319,14 +300,6 @@
                   {
                     "color": "#fade2a",
                     "value": 0
-                  },
-                  {
-                    "color": "#f2495c",
-                    "value": "SECONDARY"
-                  },
-                  {
-                    "color": "#73bf69",
-                    "value": "PRIMARY"
                   }
                 ]
               }
@@ -341,7 +314,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mssql_pod_role{namespace=~\"$namespace\", service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -431,7 +404,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mssql_pod_role{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{role}}` }}"
                   }
                 }
               }
@@ -458,7 +431,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(sqlserver_compilations_per_sec{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -485,7 +458,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mssql_batch_requests{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -512,7 +485,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mssql_log_growths{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{db}}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/mssqlserver/mssqlserver_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mssqlserver/mssqlserver_pod_dashboard.json
@@ -1,0 +1,944 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "9J6ObCEMz",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / MSSQLServer / Pod"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "ms-ag-mon-stats",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "job",
+              "matchers": [
+                "mssql_local_time_seconds"
+              ]
+            }
+          },
+          "name": "Job"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "$__all",
+          "allowAllValue": true,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "db",
+              "matchers": [
+                "mssql_connections"
+              ]
+            }
+          },
+          "name": "database"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "up{target=\"mssqlserver_database\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "mssqlserver",
+            "hidden": false
+          },
+          "defaultValue": "ms-ag-mon",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "alphabetical-asc",
+          "plugin": {
+            "kind": "PrometheusPromQLVariable",
+            "spec": {
+              "expr": "kubedb_com_mssqlserver_created{namespace=\"$namespace\"}",
+              "labelName": "app"
+            }
+          },
+          "name": "app"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Pod Name",
+            "hidden": false
+          },
+          "defaultValue": "ms-ag-mon-2",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "alphabetical-asc",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "pod",
+              "matchers": [
+                "up{target=\"mssqlserver_database\",namespace=~\"$namespace\",pod=~\"${app}-.*\"}"
+              ]
+            }
+          },
+          "name": "pod"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Pod Name"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": "pod}} ",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#3274d9",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_hostname{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} "
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Status"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 1,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "rgba(50, 172, 45, 0.97)",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "up{pod=~\"$pod\", target=\"mssql_database\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Database ${database} wait by I/O stall "
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_io_stall_seconds{db=\"$database\", pod=\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{db}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Database ${database} wait by I/O stall "
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_io_stall_seconds{db=\"$database\", pod=\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{db}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Database ${database} wait by I/O stall "
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_io_stall_seconds{db=\"$database\", pod=\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{db}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Role"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 0,
+                "unit": "decimal"
+              },
+              "metricLabel": "role",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_pod_role{pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{role}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Uptime"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "seconds"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "max(max_over_time(mssql_uptime_seconds{pod=~\"$pod\"}[$__interval]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Server Resource Overview"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Server local time",
+                  "name": "value #1"
+                },
+                {
+                  "header": "Total Available RAM",
+                  "name": "value #2"
+                },
+                {
+                  "header": "Total pagefile size (available)",
+                  "name": "value #4"
+                },
+                {
+                  "header": "Pagefile size (used)",
+                  "name": "value #5"
+                },
+                {
+                  "header": "RAM used",
+                  "name": "value #3"
+                },
+                {
+                  "header": "Batch reqs / sec",
+                  "name": "Value #BR"
+                },
+                {
+                  "header": "Page life expectancy (sec)",
+                  "name": "Value #PLE"
+                },
+                {
+                  "header": "Deadlocks",
+                  "name": "Value #DL"
+                },
+                {
+                  "header": "User errors / sec",
+                  "name": "Value #UE"
+                },
+                {
+                  "header": "Kill conn errors / sec",
+                  "name": "Value #KC"
+                },
+                {
+                  "header": "Total databases",
+                  "name": "Value #DBC"
+                },
+                {
+                  "align": "right",
+                  "header": "",
+                  "hide": true,
+                  "name": "/.*/"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(mssql_local_time_seconds{job=~\"$Job\", pod=\"$pod\"}*1000)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_os_memory{state=\"available\",job=~\"$Job\", pod=\"$pod\"}-0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_os_memory{state=\"used\",job=~\"$Job\", pod=\"$pod\"}-0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_os_page_file{state=\"available\",job=~\"$Job\", pod=\"$pod\"}-0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_os_page_file{state=\"used\",job=~\"$Job\", pod=\"$pod\"}-0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Server Resouce Overview"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Server local time",
+                  "name": "Value #LT"
+                },
+                {
+                  "header": "Total RAM (available)",
+                  "name": "Value #TM"
+                },
+                {
+                  "header": "Total page faults",
+                  "name": "value #1"
+                },
+                {
+                  "header": "Total RAM",
+                  "name": "Value #TM"
+                },
+                {
+                  "header": "Total pagefile size (available)",
+                  "name": "Value #PF"
+                },
+                {
+                  "header": "Pagefile size (used)",
+                  "name": "Value #APF"
+                },
+                {
+                  "header": "RAM used",
+                  "name": "Value #RA"
+                },
+                {
+                  "header": "Batch reqs / sec",
+                  "name": "value #2"
+                },
+                {
+                  "header": "Page life expectancy (sec)",
+                  "name": "value #3"
+                },
+                {
+                  "header": "Deadlocks",
+                  "name": "value #4"
+                },
+                {
+                  "header": "User errors / sec",
+                  "name": "value #5"
+                },
+                {
+                  "header": "Kill conn errors / sec",
+                  "name": "value #6"
+                },
+                {
+                  "header": "Total databases",
+                  "name": "value #7"
+                },
+                {
+                  "align": "right",
+                  "header": "",
+                  "hide": true,
+                  "name": "/.*/"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_page_fault_count{job=~\"$Job\", pod=\"$pod\"}-0",
+                    "seriesNameFormat": "Total page faults"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_batch_requests{job=~\"$Job\", pod=\"$pod\"}-0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_page_life_expectancy_seconds{job=~\"$Job\", pod=\"$pod\"}-0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_deadlocks{job=~\"$Job\", pod=\"$pod\"}-0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_user_errors{job=~\"$Job\", pod=\"$pod\"}-0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_kill_connection_errors{job=~\"$Job\", pod=\"$pod\"}-0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(mssql_database_state{job=~\"$Job\", pod=\"$pod\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Current database connections"
+          },
+          "plugin": {
+            "kind": "BarChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "decimal"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_connections{pod=\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{db}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "DB Log growth since last restart"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_log_growths{pod=\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{db}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total wait time of I/O stall"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_io_stall_total_seconds{pod=\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{db}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Database ${database} wait by I/O stall "
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_io_stall_seconds{db=\"$database\", pod=\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{db}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 6,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 6,
+              "y": 0,
+              "width": 6,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 12,
+              "y": 0,
+              "width": 6,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 18,
+              "y": 0,
+              "width": 6,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 0,
+              "y": 7,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 0,
+              "y": 14,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 0,
+              "y": 22,
+              "width": 7,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 7,
+              "y": 22,
+              "width": 9,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 16,
+              "y": 22,
+              "width": 8,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 0,
+              "y": 30,
+              "width": 8,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 8,
+              "y": 30,
+              "width": 8,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 16,
+              "y": 30,
+              "width": 8,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 0,
+              "y": 37,
+              "width": 8,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/mssqlserver/mssqlserver_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mssqlserver/mssqlserver_summary_dashboard.json
@@ -1,0 +1,1589 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "qDMhbh0Iz",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / MSSQLServer / Summary"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "mssqlserver",
+            "hidden": false
+          },
+          "defaultValue": "ms-ag-mon",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kubedb_com_mssqlserver_status_phase{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Database Status",
+            "description": "Represent database status"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_mssqlserver_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Version",
+            "description": "MSSQLServer CR Name"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "mean",
+              "colorMode": "none",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": " version ",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              },
+              "valueFontSize": 50
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_mssqlserver_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{ version }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage",
+            "description": "CPU Usage by MSSQLServer pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(sum by(namespace,pod,container)(irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[5m]))* on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}))) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Quota",
+            "description": "CPU Quote information in details"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp",
+                  "width": "auto"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(sum by(namespace,pod,container)(irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[5m]))* on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}))) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(sum by(namespace,pod,container)(irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[5m]))* on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}))) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(sum by(namespace,pod,container)(irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[5m]))* on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}))) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-aggregator\\\\d+$|$app-leaf\\\\d+$|$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Usage",
+            "description": "Memory Usage by MSSQLServer pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app-leaf-\\\\d+$|$app-aggregator-\\\\d+$|$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Quota"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (RSS)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Cache)",
+                  "name": "value #7"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Swap)",
+                  "name": "value #8"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_rss{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_cache{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_swap{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk Usage",
+            "description": "Disk usage by MSSQLServer pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk R/W Info",
+            "description": "System Disk Usage Information"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "IOPS (Reads+Writes)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\"}[5m])))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ThroughPut (Read+Write)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[5m]))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Current Storage IO"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads)",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Writes)",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads + Writes)",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read)",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Write)",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read + Write)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_total{container!=\"\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_total{container!=\"\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_bytes_total{container!=\"\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Allocated Storage",
+            "description": "This panel describes allocated persistent storage in a table format\n"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": []
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"^$app.*\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Require Secure Transport",
+            "description": "When this option is enabled, connections attempted using insecure transport will be rejected."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "clientTLS",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_mssqlserver_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{clientTLS}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage",
+            "description": "This panel shows the persistent volume usage in percentage. "
+          },
+          "plugin": {
+            "kind": "BarChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "percent"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"^$app.*\",namespace=~\"$namespace\"}) )* 100",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage History",
+            "description": "This panel describes the persistent volume usage in a time series. "
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "right",
+                "values": [
+                  "max",
+                  "last-number"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineStyle": "solid",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decbytes"
+                },
+                "max": 5000,
+                "min": 0
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(kubelet_volume_stats_used_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"^$app.*\",namespace=~\"$namespace\"}) ",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Receive Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Transmit Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Deletion Policy",
+            "description": "KubeDB Database Resource deletionPolicy"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_mssqlserver_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Nodes",
+            "description": "Total node count of MSSQLServer cluster"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_mssqlserver_replicas{namespace=\"$namespace\",app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Request (Core)",
+            "description": "Initial Requested CPU amount by MSSQLServer Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_mssqlserver_resource_request_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Limit (Core)",
+            "description": "CPU Limit in core by MSSQLServer instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_mssqlserver_resource_limit_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Request",
+            "description": "Initial Requested Memory amount by MSSQLServer Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_mssqlserver_resource_request_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Limit",
+            "description": "KubeDB MSSQLServer Total Memory Limit"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_mssqlserver_resource_limit_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Storage Request",
+            "description": "Total storage request by MSSQLServer nodes"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_mssqlserver_resource_request_storage{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 8,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 16,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 20,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 4,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 8,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 12,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 16,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 20,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 0,
+              "y": 22,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 0,
+              "y": 28,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 0,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 12,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 0,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 12,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            },
+            {
+              "x": 0,
+              "y": 51,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/18"
+              }
+            },
+            {
+              "x": 0,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/19"
+              }
+            },
+            {
+              "x": 12,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/20"
+              }
+            },
+            {
+              "x": 0,
+              "y": 65,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/21"
+              }
+            },
+            {
+              "x": 0,
+              "y": 74,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/22"
+              }
+            },
+            {
+              "x": 12,
+              "y": 74,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/23"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/mysql/mysql_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mysql/mysql_database_dashboard.json
@@ -102,7 +102,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_up{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -131,7 +131,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_uptime{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -158,7 +158,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_aborted_connects{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Aborted Connects (attempts) on - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -171,7 +171,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_aborted_clients{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Aborted Clients (timeout) on - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -198,7 +198,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_queries{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -225,7 +225,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_max_used_connections{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Current - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -238,7 +238,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_max_connections{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Max - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -265,7 +265,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_innodb_data_reads{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "reads - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -278,7 +278,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_innodb_data_writes{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "write - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -305,7 +305,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_bytes_received{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "received - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -318,7 +318,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_bytes_sent{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "sent - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -345,7 +345,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "topk(3, rate(mysql_global_status_commands_total{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }} = '{{ `{{ command }}` }}'"
                   }
                 }
               }
@@ -372,7 +372,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_opened_files{namespace=~\"$namespace\",service=~\"$app+-stats\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -399,7 +399,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_open_files{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Open Files - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -412,7 +412,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_open_files_limit{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Open Files Limit - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -425,7 +425,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_innodb_num_open_files{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "InnoDB Open Files - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -452,7 +452,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_slow_queries{namespace=~\"$namespace\",service=~\"$app+-stats\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Slow Queries on {{ `{{ pod }}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/mysql/mysql_group_replication.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mysql/mysql_group_replication.json
@@ -1,4 +1,5 @@
 {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
 {
   "kind": "Dashboard",
   "metadata": {
@@ -90,6 +91,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "background_solid",
               "thresholds": {
                 "steps": [
                   {
@@ -113,7 +115,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg by(member_host)(mysql_perf_schema_replication_group_member_info{namespace=~\"$namespace\",service=~\"$app+-stats\"})",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{member_host}}` }}"
                   }
                 }
               }
@@ -131,6 +133,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "background_solid",
               "thresholds": {
                 "steps": [
                   {
@@ -154,7 +157,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg by(member_host)(mysql_perf_schema_replication_group_member_info{namespace=~\"$namespace\",service=~\"$app+-stats\", member_role=\"PRIMARY\"})",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{member_host}}` }}"
                   }
                 }
               }
@@ -181,7 +184,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg by (pod)(rate(mysql_perf_schema_transactions_local_proposed_total{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -208,7 +211,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg by (pod)(rate(mysql_perf_schema_transactions_remote_in_applier_queue{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -235,7 +238,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg by (pod)(rate(mysql_perf_schema_transactions_local_rollback_total{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -262,7 +265,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg by (pod)(rate(mysql_perf_schema_transactions_in_queue{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m]) or rate(mysql_perf_schema_5_transactions_in_queue{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -289,7 +292,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg by (pod)(rate(mysql_perf_schema_conflicts_detected_total{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m]) or rate(mysql_perf_schema_5_conflicts_detected_total{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -316,7 +319,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "max by (pod)(max_over_time(mysql_perf_schema_replication_group_worker_lag_in_seconds{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -343,7 +346,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "max by (pod)(max_over_time(mysql_perf_schema_replication_group_worker_transport_time_seconds{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])) < 20000000",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -370,7 +373,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "max by (pod)(max_over_time(mysql_perf_schema_replication_group_worker_apply_time_seconds{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])) < 20000000",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -397,7 +400,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "max by (pod)(max_over_time(mysql_perf_schema_replication_group_worker_apply_time_seconds{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])) < 20000000",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -424,7 +427,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "max by (pod)(max_over_time(mysql_perf_schema_replication_group_worker_time_RL_seconds{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])) < 20000000",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -451,7 +454,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg by (pod)(rate(mysql_perf_schema_transactions_checked_total{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m]) or rate(mysql_perf_schema_5_transactions_checked_total{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -478,7 +481,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg by (pod)(rate(mysql_perf_schema_transactions_rows_validating_total{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m]) or rate(mysql_perf_schema_5_transactions_rows_validating_total{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -505,7 +508,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg by (pod)(rate(mysql_perf_schema_transactions_remote_applied_total{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/mysql/mysql_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mysql/mysql_pod_dashboard.json
@@ -1,4 +1,5 @@
 {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
 {
   "kind": "Dashboard",
   "metadata": {
@@ -115,9 +116,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": "pod}} ",
               "thresholds": {
                 "steps": [
                   {
@@ -137,7 +140,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_up{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} "
                   }
                 }
               }
@@ -155,6 +158,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -181,7 +185,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_uptime{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -208,7 +212,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_threads_connected{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Threads Connected - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -221,7 +225,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_threads_running{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Threads Running - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -248,7 +252,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_thread_cache_size{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Thread Cache Size - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -261,7 +265,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_threads_cached{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Threads Cached - {{ `{{pod}}` }} "
                   }
                 }
               }
@@ -274,7 +278,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_threads_created{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Threads Created - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -301,7 +305,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_created_tmp_tables{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Created Tmp Tables - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -314,7 +318,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_created_tmp_disk_tables{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Created Tmp Disk Tables - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -327,7 +331,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_created_tmp_files{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Created Tmp Files - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -354,7 +358,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_slow_queries{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Slow Queries - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -381,7 +385,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_select_full_join{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Select Full Join - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -394,7 +398,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_select_scan{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Select Scan - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -421,7 +425,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_sort_rows{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Sort Rows - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -434,7 +438,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_sort_range{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Sort Range - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -447,7 +451,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_sort_merge_passes{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Sort Merge Passes - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -460,7 +464,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_sort_scan{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Sort Scan - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -487,7 +491,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_table_locks_immediate{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Table Locks Immediate - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -500,7 +504,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_table_locks_waited{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Table Locks Waited - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -527,7 +531,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_questions{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Questions - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -555,7 +559,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_bytes_received{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Inbound - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -568,7 +572,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_bytes_sent{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Outbound - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -596,7 +600,7 @@
                   "spec": {
                     "minStep": "1h",
                     "query": "increase(mysql_global_status_bytes_received{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[1h])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Received - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -609,7 +613,7 @@
                   "spec": {
                     "minStep": "1h",
                     "query": "increase(mysql_global_status_bytes_sent{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[1h])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Sent - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -627,9 +631,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": "version",
               "thresholds": {
                 "steps": [
                   {
@@ -653,7 +659,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_version_info{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{version}}` }}"
                   }
                 }
               }
@@ -686,7 +692,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_innodb_buffer_pool_size{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "InnoDB Buffer Pool Size - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -699,7 +705,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_innodb_log_buffer_size{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "InnoDB Log Buffer Size - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -712,7 +718,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_innodb_mem_dictionary{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "InnoDB Dictionary Size - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -725,7 +731,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_key_buffer_size{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Key Buffer Size - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -738,7 +744,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_query_cache_size{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Query Cache Size - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -751,7 +757,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_innodb_mem_adaptive_hash{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Adaptive Hash Index Size - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -778,7 +784,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "topk(5, rate(mysql_global_status_commands_total{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Com_{{ `{{ command }}` }} - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -812,7 +818,7 @@
                   "spec": {
                     "minStep": "1h",
                     "query": "topk(5, avg by (pod,command) (increase(mysql_global_status_commands_total{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[1h])>0))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Com_{{ `{{ command }}` }} - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -839,7 +845,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_handlers_total{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])>0",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ handler }}` }} - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -872,7 +878,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_qcache_free_memory{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Query Cache Size - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -905,7 +911,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_qcache_hits{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Hits - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -918,7 +924,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_qcache_inserts{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Inserts - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -931,7 +937,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_qcache_not_cached{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Not Cached - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -944,7 +950,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_qcache_lowmem_prunes{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Prunes - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -957,7 +963,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_qcache_queries_in_cache{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Queries in Cache - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -984,7 +990,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_opened_files{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Openings - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1011,7 +1017,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_open_files{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Open Files - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1024,7 +1030,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_open_files_limit{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Open Files Limit - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1037,7 +1043,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_innodb_num_open_files{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "InnoDB Open Files - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1064,7 +1070,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_opened_tables{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Openings - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1077,7 +1083,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_table_open_cache_hits{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Hits - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1090,7 +1096,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_table_open_cache_misses{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Misses - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1103,7 +1109,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_table_open_cache_overflows{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Misses due to Overflows - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1116,7 +1122,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_table_open_cache_hits{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Table Open Cache Hit Ratio - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1143,7 +1149,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_open_tables{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Open Tables - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1156,7 +1162,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_table_open_cache{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Table Open Cache - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1174,6 +1180,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -1196,7 +1203,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_queries{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1223,7 +1230,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_open_table_definitions{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Open Table Definitions - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1236,7 +1243,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_table_definition_cache{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Table Definitions Cache Size - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1249,7 +1256,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_opened_table_definitions{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Opened Table Definitions - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1267,6 +1274,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -1293,7 +1301,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_innodb_buffer_pool_size{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1326,7 +1334,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"$pod\", container!=\"\", image!=\"\"}[5m])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{container}}` }}"
                   }
                 }
               }
@@ -1359,7 +1367,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$pod\", container!=\"\", image!=\"\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1393,7 +1401,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(process_open_fds{pod=~\"$pod\", namespace=\"$namespace\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1420,7 +1428,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_max_used_connections{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Max Used Connects - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1433,7 +1441,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_max_connections{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Max Connects - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1460,7 +1468,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_aborted_connects{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Aborted Connects - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1473,7 +1481,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_aborted_clients{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Aborted Clients - {{ `{{pod}}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/mysql/mysql_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mysql/mysql_summary_dashboard.json
@@ -91,6 +91,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
               "thresholds": {
                 "steps": [
                   {
@@ -110,7 +112,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_mysql_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
                   }
                 }
               }
@@ -129,9 +131,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": " version ",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -157,7 +161,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_mysql_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ version }}` }}"
                   }
                 }
               }
@@ -176,6 +180,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -227,7 +232,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -248,29 +253,48 @@
               "columnSettings": [
                 {
                   "header": "Time",
-                  "name": "timestamp"
+                  "name": "timestamp",
+                  "width": "auto"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -372,7 +396,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -395,38 +419,65 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (RSS)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Cache)",
-                  "name": "Value #G"
+                  "name": "value #7"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Swap)",
-                  "name": "Value #H"
+                  "name": "value #8"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -567,7 +618,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -601,7 +652,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
                   }
                 }
               }
@@ -614,7 +665,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
                   }
                 }
               }
@@ -647,7 +698,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m])))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -680,7 +731,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -703,30 +754,51 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads)",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Writes)",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads + Writes)",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read)",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Write)",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read + Write)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -826,9 +898,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": " useAddressType ",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -854,7 +928,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_mysql_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ useAddressType }}` }}"
                   }
                 }
               }
@@ -917,7 +991,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -952,7 +1026,7 @@
               },
               "yAxis": {
                 "format": {
-                  "unit": "bytes"
+                  "unit": "decbytes"
                 },
                 "max": 5000,
                 "min": 0
@@ -968,7 +1042,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -995,7 +1069,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1028,7 +1102,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1047,6 +1121,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1071,7 +1146,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_mysql_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{requireSSL}}` }}"
                   }
                 }
               }
@@ -1090,6 +1165,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1110,7 +1186,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_mysql_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
                   }
                 }
               }
@@ -1129,6 +1205,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "thresholds": {
                 "steps": [
                   {
@@ -1171,6 +1248,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1210,6 +1288,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1249,6 +1328,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -1291,6 +1371,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },

--- a/charts/kubedb-perses-dashboards/dashboards/neo4j/neo4j-database.json
+++ b/charts/kubedb-perses-dashboards/dashboards/neo4j/neo4j-database.json
@@ -1,0 +1,1399 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "fifRHuGDz",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / Neo4j / Database"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Datasource",
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Neo4j",
+            "hidden": false
+          },
+          "defaultValue": "neo4j",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kubedb_com_neo4j_status_phase{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "neo4j",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "StaticListVariable",
+            "spec": {
+              "values": [
+                "grafana",
+                "migration",
+                "not",
+                "supported"
+              ]
+            }
+          },
+          "name": "database"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "neo4j-1",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusPromQLVariable",
+            "spec": {
+              "expr": "neo4j_database_${database}_cluster_raft_is_leader{namespace=~\"$namespace\"} == 1",
+              "labelName": "app"
+            }
+          },
+          "name": "leader"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Uptime"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "seconds"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "time() - max(max_over_time(container_start_time_seconds{namespace=~\"$namespace\",pod=~\"$app-.*\"}[$__interval]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Nodes"
+          },
+          "plugin": {
+            "kind": "GaugeChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_${database}_neo4j_count_node{namespace=~\"$namespace\",job=~\"$app-stats\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Committed transactions"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_${database}_transaction_committed_total{namespace=~\"$namespace\",job=~\"$app-stats\"}",
+                    "seriesNameFormat": "Total Committed Tr.s {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_${database}_transaction_committed_read_total{namespace=~\"$namespace\",job=~\"$app-stats\"}",
+                    "seriesNameFormat": "Committed Read Tr.s {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_${database}_transaction_committed_write_total{namespace=~\"$namespace\",job=~\"$app-stats\"}",
+                    "seriesNameFormat": "Committed Write Tr.s {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Active Transactions",
+            "description": "Active Transactions - Read and Write - \nand Peak concurrent"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_neo4j_transaction_active_read{namespace=~\"$namespace\",job=~\"$app-stats\"}",
+                    "seriesNameFormat": "Active read {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_neo4j_transaction_active_write{namespace=~\"$namespace\",job=~\"$app-stats\"}",
+                    "seriesNameFormat": "Active write {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_neo4j_transaction_peak_concurrent_total{namespace=~\"$namespace\",job=~\"$app-stats\"}",
+                    "seriesNameFormat": "Peak concurrent {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Page cache faults"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_dbms_page_cache_page_faults_total{namespace=~\"$namespace\",job=~\"$app-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Page cache faults/sec"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(neo4j_dbms_page_cache_page_faults_total{namespace=~\"$namespace\",job=~\"$app-stats\"}[$__interval])",
+                    "seriesNameFormat": "{{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Page Cache Hit Ratio",
+            "description": "The ratio of hits to the total number of lookups in the page cache"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_dbms_page_cache_hit_ratio{namespace=~\"$namespace\",job=~\"$app-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Page Cache Hits Rate (hits/sec)",
+            "description": "Per-second Neo4j Page Cache Hits"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(neo4j_dbms_page_cache_hits_total{namespace=~\"$namespace\",job=~\"$app-stats\"}[$__interval])",
+                    "seriesNameFormat": "{{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Page Cache Hits",
+            "description": "The total number of page hits happened in the page cache"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_dbms_page_cache_hits_total{namespace=~\"$namespace\",job=~\"$app-stats\"}",
+                    "seriesNameFormat": "{{ `{{__name__}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Checkpoints",
+            "description": "Neo4j Checkpoints. \nCheckpointing is the process of flushing all pending page updates from the page cache to the store files"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "label_replace({__name__=~\"neo4j_database_${database}_check_point_(events|total_time)_total\", namespace=~\"$namespace\",job=~\"$app-stats\"}, \"label\", \"$1\", \"__name__\", \"neo4j_(.*)\")",
+                    "seriesNameFormat": "{{ `{{label}}` }} {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Checkpoint event duration sec"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_${database}_check_point_duration{namespace=~\"$namespace\",job=~\"$app-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Bolt Messages Queue",
+            "description": "Messages received - Messages started"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_dbms_bolt_messages_received_total{namespace=~\"$namespace\",job=~\"$app-stats\"} - neo4j_dbms_bolt_messages_started_total{namespace=~\"$namespace\",job=~\"$app-stats\"}",
+                    "seriesNameFormat": "Bolt Msg Queue Length {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "label_replace({__name__=~\"neo4j_dbms_bolt_messages_(received|started)_total\", namespace=~\"$namespace\",job=~\"$app-stats\"}, \"label\", \"$1\", \"__name__\", \"neo4j_dbms_bolt_messages_(.+)\")",
+                    "seriesNameFormat": "{{ `{{label}}` }} {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(neo4j_dbms_bolt_messages_received_total{namespace=~\"$namespace\",job=~\"$app-stats\"}[$__interval])",
+                    "seriesNameFormat": "Bolt msg received rate {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(neo4j_dbms_bolt_messages_started_total{namespace=~\"$namespace\",job=~\"$app-stats\"}[$__interval])",
+                    "seriesNameFormat": "Bolt msg started rate {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Relationships"
+          },
+          "plugin": {
+            "kind": "GaugeChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_${database}_neo4j_count_relationship{namespace=~\"$namespace\",job=~\"$app-stats\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Bolt Connections"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "label_replace({__name__=~\"neo4j_dbms_bolt_connections_.+\", namespace=~\"$namespace\",job=~\"$app-stats\"}, \"label\", \"$1\", \"__name__\", \"neo4j_dbms_bolt_connections_(.+)\")",
+                    "seriesNameFormat": "{{ `{{label}}` }} {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "JVM Heap Size",
+            "description": "Heap memory (eden space, old generation, survivor space)\nNon-heap memory (metaspace, compressed class space, code cache)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decbytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum({__name__=~\"neo4j_dbms_vm_memory_pool_g1_(eden|old|survivor).*\",namespace=~\"$namespace\",job=~\"$app-stats\"})",
+                    "seriesNameFormat": "{{ `{{instance}}` }} heap"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "VM Live Threads"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_dbms_vm_threads{namespace=~\"$namespace\",job=~\"$app-stats\"}",
+                    "seriesNameFormat": "vm live threads {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "JVM Used Buffer rate"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_dbms_vm_memory_buffer_direct_used{namespace=~\"$namespace\",job=~\"$app-stats\"}",
+                    "seriesNameFormat": "memory buffer direct used {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_dbms_vm_memory_buffer_mapped_used{namespace=~\"$namespace\",job=~\"$app-stats\"}",
+                    "seriesNameFormat": "memory buffer mapped used{{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "24": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "VM Garbage Collector",
+            "description": "Time and counters"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "{__name__=~\"neo4j_dbms_vm_gc_time_g1_.+_generation_total\", namespace=~\"$namespace\",job=~\"$app-stats\"}",
+                    "seriesNameFormat": "{{ `{{__name__}}` }} {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "delta(neo4j_dbms_vm_gc_time_g1_old_generation_total{namespace=~\"$namespace\",job=~\"$app-stats\"}[$__interval])",
+                    "seriesNameFormat": "delta g1 old g total {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "delta(neo4j_dbms_vm_gc_time_g1_young_generation_total{namespace=~\"$namespace\",job=~\"$app-stats\"}[$__interval])",
+                    "seriesNameFormat": "delta g1 young g total {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "25": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cyper wait time",
+            "description": "The total number of seconds waited between query replans"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_${database}_cypher_replan_wait_time{namespace=~\"$namespace\",job=~\"$app-stats\"}",
+                    "seriesNameFormat": "{{ `{{__name__}}` }} {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "26": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cyper replan events"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_${database}_cypher_replan_events_total{namespace=~\"$namespace\",job=~\"$app-stats\"}",
+                    "seriesNameFormat": "{{ `{{__name__}}` }} {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Memory Used"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=~\"$namespace\",pod=~\"$app-.*\"}) / 1024 / 1024",
+                    "seriesNameFormat": "used memory"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Average CPU Usage",
+            "description": "Average user and system CPU time spent in seconds."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\",pod=~\"$app-.*\"}[5m])) / count(node_cpu_seconds_total{mode=\"system\"}) * 100",
+                    "seriesNameFormat": "CPU used (%)"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Last Committed Write Transaction ID"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 1
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_${database}_transaction_last_committed_tx_id_total{namespace=~\"$namespace\",job=~\"$app-stats\"}",
+                    "seriesNameFormat": "Last Closed Write Transaction ID"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Committed Transaction Rate",
+            "description": "Per-second average rate of increase of Committed Transactions"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom",
+                "values": [
+                  "mean",
+                  "last-number",
+                  "max",
+                  "min",
+                  "sum"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.2,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(neo4j_database_${database}_transaction_committed_total{namespace=~\"$namespace\",job=~\"$app-stats\"}[$__interval])",
+                    "seriesNameFormat": "rate {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "irate(neo4j_database_${database}_transaction_committed_total{namespace=~\"$namespace\",job=~\"$app-stats\"}[$__interval])",
+                    "seriesNameFormat": "iRate {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Committed Write Transaction Rate",
+            "description": "Per-second average rate of increase of Committed Transactions"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom",
+                "values": [
+                  "mean",
+                  "last-number",
+                  "max",
+                  "min",
+                  "sum"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.22,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 3
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(neo4j_database_${database}_transaction_committed_write_total{namespace=~\"$namespace\",job=~\"$app-stats\"}[$__interval])",
+                    "seriesNameFormat": "rate {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Transactions",
+            "description": "All transaction metrics"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "label_replace({__name__=~\"neo4j_database_${database}_transaction_(committed|rollbacks)_total\", namespace=~\"$namespace\",job=~\"$app-stats\"}, \"label\", \"$1\", \"__name__\", \"neo4j_transaction_(.+)\")",
+                    "seriesNameFormat": "{{ `{{label}}` }} {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Committed Read Transaction Rate",
+            "description": "Per-second average rate of increase of Committed Transactions"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(neo4j_database_${database}_transaction_committed_read_total{namespace=~\"$namespace\",job=~\"$app-stats\"}[$__interval])",
+                    "seriesNameFormat": "{{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 8,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 8,
+              "y": 1,
+              "width": 6,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 15,
+              "y": 1,
+              "width": 8,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 0,
+              "y": 6,
+              "width": 12,
+              "height": 11,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 12,
+              "y": 6,
+              "width": 12,
+              "height": 11,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 0,
+              "y": 18,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 4,
+              "y": 18,
+              "width": 10,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 15,
+              "y": 18,
+              "width": 9,
+              "height": 13,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 0,
+              "y": 23,
+              "width": 7,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 7,
+              "y": 23,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 0,
+              "y": 31,
+              "width": 9,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 9,
+              "y": 31,
+              "width": 15,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 0,
+              "y": 38,
+              "width": 7,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 7,
+              "y": 38,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 15,
+              "y": 38,
+              "width": 9,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 0,
+              "y": 45,
+              "width": 6,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 6,
+              "y": 45,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 12,
+              "y": 45,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            },
+            {
+              "x": 18,
+              "y": 45,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/18"
+              }
+            },
+            {
+              "x": 0,
+              "y": 53,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/19"
+              }
+            },
+            {
+              "x": 12,
+              "y": 53,
+              "width": 11,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/20"
+              }
+            },
+            {
+              "x": 0,
+              "y": 63,
+              "width": 13,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/21"
+              }
+            },
+            {
+              "x": 14,
+              "y": 63,
+              "width": 8,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/22"
+              }
+            },
+            {
+              "x": 0,
+              "y": 72,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/23"
+              }
+            },
+            {
+              "x": 12,
+              "y": 72,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/24"
+              }
+            },
+            {
+              "x": 0,
+              "y": 82,
+              "width": 11,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/25"
+              }
+            },
+            {
+              "x": 11,
+              "y": 82,
+              "width": 13,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/26"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/neo4j/neo4j-pod.json
+++ b/charts/kubedb-perses-dashboards/dashboards/neo4j/neo4j-pod.json
@@ -1,0 +1,1455 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "fifRHuGDz",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / Neo4j / Pod"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Datasource",
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Neo4j",
+            "hidden": false
+          },
+          "defaultValue": "neo4j",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kubedb_com_neo4j_status_phase{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "neo4j-0",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "pod",
+              "matchers": [
+                "neo4j_database_neo4j_check_point_duration{namespace=~\"$namespace\",pod=~\"${app}-.*\"}"
+              ]
+            }
+          },
+          "name": "pod"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "system",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "StaticListVariable",
+            "spec": {
+              "values": [
+                "grafana",
+                "migration",
+                "not",
+                "supported"
+              ]
+            }
+          },
+          "name": "database"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "neo4j-0",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusPromQLVariable",
+            "spec": {
+              "expr": "neo4j_database_${database}_cluster_raft_is_leader{namespace=~\"$namespace\"} == 1",
+              "labelName": "app"
+            }
+          },
+          "name": "leader"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Status"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "decimalPlaces": 1,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "rgba(50, 172, 45, 0.97)",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kube_pod_status_phase{pod=~\"$pod\",phase=~\"Running\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Uptime"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "seconds"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "time() - max(max_over_time(container_start_time_seconds{pod=~\"$pod\",namespace=~\"$namespace\"}[$__interval]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Transactions",
+            "description": "All transaction metrics"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "label_replace({__name__=~\"neo4j_database_${database}_transaction_(committed|rollbacks)_total\", pod='$pod',namespace=~\"$namespace\"}, \"label\", \"$1\", \"__name__\", \"neo4j_transaction_(.+)\")",
+                    "seriesNameFormat": "{{ `{{label}}` }} {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Committed Read Transaction Rate",
+            "description": "Per-second average rate of increase of Committed Transactions"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(neo4j_database_${database}_transaction_committed_read_total{pod=~\"$pod\",namespace=~\"$namespace\"}[$__interval])",
+                    "seriesNameFormat": "{{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Committed Write Transaction Rate",
+            "description": "Per-second average rate of increase of Committed Transactions"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(neo4j_database_${database}_transaction_committed_write_total{pod=~\"$pod\",namespace=~\"$namespace\"}[$__interval])",
+                    "seriesNameFormat": "rate {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Committed transactions"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_${database}_transaction_committed_total{pod =~\"$pod\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": "Total Committed Tr.s {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_${database}_transaction_committed_read_total{pod=~\"$pod\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": "Committed Read Tr.s {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_${database}_transaction_committed_write_total{pod=~\"$pod\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": "Committed Write Tr.s {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Active Transactions",
+            "description": "Active Transactions - Read and Write - \nand Peak concurrent"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_neo4j_transaction_active_read{pod=~\"$pod\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": "Active read {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_neo4j_transaction_active_write{pod=~\"$pod\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": "Active write {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_neo4j_transaction_peak_concurrent_total{pod=~\"$pod\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": "Peak concurrent {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Page cache faults"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_dbms_page_cache_page_faults_total{pod=~\"$pod\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Page cache faults/sec"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(neo4j_dbms_page_cache_page_faults_total{pod=~\"$pod\",namespace=~\"$namespace\"}[$__interval])",
+                    "seriesNameFormat": "{{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Page Cache Hit Ratio",
+            "description": "The ratio of hits to the total number of lookups in the page cache"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_dbms_page_cache_hit_ratio{pod=~\"$pod\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Page Cache Hits Rate (hits/sec)",
+            "description": "Per-second Neo4j Page Cache Hits"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(neo4j_dbms_page_cache_hits_total{pod=~\"$pod\",namespace=~\"$namespace\"}[$__interval])",
+                    "seriesNameFormat": "{{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Page Cache Hits",
+            "description": "The total number of page hits happened in the page cache"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_dbms_page_cache_hits_total{pod=~'$pod',namespace=~\"$namespace\"}",
+                    "seriesNameFormat": "{{ `{{__name__}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Connections"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_dbms_bolt_connections_running{pod=~\"$pod\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Checkpoints",
+            "description": "Neo4j Checkpoints. \nCheckpointing is the process of flushing all pending page updates from the page cache to the store files"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "label_replace({__name__=~\"neo4j_database_neo4j_check_point_(events|total_time)_total\", pod=~\"$pod\",namespace=~\"$namespace\"}, \"label\", \"$1\", \"__name__\", \"neo4j_(.*)\")",
+                    "seriesNameFormat": "{{ `{{label}}` }} {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Checkpoint event duration sec"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_neo4j_check_point_duration{pod=~\"$pod\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Bolt Messages Queue",
+            "description": "Messages received - Messages started"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_dbms_bolt_messages_received_total{pod=~\"$pod\"} - neo4j_dbms_bolt_messages_started_total{pod=~\"$pod\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": "Bolt Msg Queue Length {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "label_replace({__name__=~\"neo4j_dbms_bolt_messages_(received|started)_total\", pod=\"$pod\",namespace=~\"$namespace\"}, \"label\", \"$1\", \"__name__\", \"neo4j_dbms_bolt_messages_(.+)\")",
+                    "seriesNameFormat": "{{ `{{label}}` }} {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(neo4j_dbms_bolt_messages_received_total{pod=~\"$pod\",namespace=~\"$namespace\"}[$__interval])",
+                    "seriesNameFormat": "Bolt msg received rate {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(neo4j_dbms_bolt_messages_started_total{pod=\"$pod\",namespace=~\"$namespace\"}[$__interval])",
+                    "seriesNameFormat": "Bolt msg started rate {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Bolt Connections"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "label_replace({__name__=~\"neo4j_dbms_bolt_connections_.+\", pod=~\"$pod\"}, \"label\", \"$1\", \"__name__\", \"neo4j_dbms_bolt_connections_(.+)\")",
+                    "seriesNameFormat": "{{ `{{label}}` }} {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "24": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "JVM Heap Size",
+            "description": "Heap memory (eden space, old generation, survivor space)\nNon-heap memory (metaspace, compressed class space, code cache)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decbytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum({__name__=~\"neo4j_dbms_vm_memory_pool_g1_(eden|old|survivor).*\", pod=~\"$pod\",namespace=~\"$namespace\"})",
+                    "seriesNameFormat": "{{ `{{instance}}` }} heap"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "25": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "VM Live Threads"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_dbms_vm_threads{pod=~\"$pod\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": "vm live threads {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "26": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "JVM Used Buffer rate"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_dbms_vm_memory_buffer_direct_used{pod=~\"$pod\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": "memory buffer direct used {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_dbms_vm_memory_buffer_mapped_used{pod=~\"$pod\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": "memory buffer mapped used{{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "27": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "VM Garbage Collector",
+            "description": "Time and counters"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "{__name__=~\"neo4j_dbms_vm_gc_time_g1_.+_generation_total\", pod=~\"$pod\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": "{{ `{{__name__}}` }} {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "delta(neo4j_dbms_vm_gc_time_g1_old_generation_total{pod=~\"$pod\",namespace=~\"$namespace\"}[$__interval])",
+                    "seriesNameFormat": "delta g1 old g total {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "delta(neo4j_dbms_vm_gc_time_g1_young_generation_total{pod=~\"$pod\",namespace=~\"$namespace\"}[$__interval])",
+                    "seriesNameFormat": "delta g1 young g total {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cyper wait time",
+            "description": "The total number of seconds waited between query replans"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_neo4j_cypher_replan_wait_time{pod=~\"$pod\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": "{{ `{{__name__}}` }} {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "29": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cyper replan events"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_neo4j_cypher_replan_events_total{pod=~\"$pod\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": "{{ `{{__name__}}` }} {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Memory Used"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{pod=\"$pod\",namespace=~\"$namespace\"}) / 1024 / 1024",
+                    "seriesNameFormat": "used memory"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Average CPU Usage",
+            "description": "Average user and system CPU time spent in seconds."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_cpu_usage_seconds_total{pod=~\"$pod\",namespace=~\"$namespace\"}[5m])) / count(node_cpu_seconds_total{mode=\"system\"}) * 100",
+                    "seriesNameFormat": "CPU used (%)"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Last Committed Write Transaction ID"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "neo4j_database_${database}_transaction_last_committed_tx_id_total{pod=~\"$pod\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": "Last Closed Write Transaction ID"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Committed Transaction Speed",
+            "description": "Instant rate"
+          },
+          "plugin": {
+            "kind": "Markdown",
+            "spec": {
+              "text": "**Migration from Grafana not supported !**"
+            }
+          }
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Property creation speed (ids)",
+            "description": "This is in reality the change in neo4j ids.\nIf the transaction is rolled-back nodes will not be created but will increase this gauge.\n\nMaximum speed is set to 30k nodes/sec\nEmpirically we saw this is the maximum handled by the production machine"
+          },
+          "plugin": {
+            "kind": "Markdown",
+            "spec": {
+              "text": "**Migration from Grafana not supported !**"
+            }
+          }
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Rolled back Transaction Speed",
+            "description": "Instant rate"
+          },
+          "plugin": {
+            "kind": "Markdown",
+            "spec": {
+              "text": "**Migration from Grafana not supported !**"
+            }
+          }
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Committed Transaction Rate",
+            "description": "Per-second average rate of increase of Committed Transactions"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(neo4j_database_${database}_transaction_committed_total{pod=~\"$pod\",namespace=~\"$namespace\"}[$__interval])",
+                    "seriesNameFormat": "rate {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "irate(neo4j_database_${database}_transaction_committed_total{pod=~\"$pod\",namespace=~\"$namespace\"}[$__interval])",
+                    "seriesNameFormat": "iRate {{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 8,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 8,
+              "y": 1,
+              "width": 8,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 16,
+              "y": 1,
+              "width": 8,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 0,
+              "y": 6,
+              "width": 12,
+              "height": 11,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 12,
+              "y": 6,
+              "width": 12,
+              "height": 11,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 0,
+              "y": 18,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 4,
+              "y": 18,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 8,
+              "y": 18,
+              "width": 3,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 11,
+              "y": 18,
+              "width": 3,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 14,
+              "y": 18,
+              "width": 10,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 0,
+              "y": 22,
+              "width": 7,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 7,
+              "y": 23,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 15,
+              "y": 23,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 0,
+              "y": 31,
+              "width": 9,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 9,
+              "y": 31,
+              "width": 15,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 0,
+              "y": 38,
+              "width": 7,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 7,
+              "y": 38,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 15,
+              "y": 38,
+              "width": 9,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            },
+            {
+              "x": 0,
+              "y": 45,
+              "width": 6,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/18"
+              }
+            },
+            {
+              "x": 6,
+              "y": 45,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/19"
+              }
+            },
+            {
+              "x": 12,
+              "y": 45,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/20"
+              }
+            },
+            {
+              "x": 18,
+              "y": 45,
+              "width": 6,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/21"
+              }
+            },
+            {
+              "x": 1,
+              "y": 53,
+              "width": 10,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/22"
+              }
+            },
+            {
+              "x": 12,
+              "y": 53,
+              "width": 11,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/23"
+              }
+            },
+            {
+              "x": 0,
+              "y": 63,
+              "width": 13,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/24"
+              }
+            },
+            {
+              "x": 14,
+              "y": 63,
+              "width": 8,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/25"
+              }
+            },
+            {
+              "x": 0,
+              "y": 72,
+              "width": 11,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/26"
+              }
+            },
+            {
+              "x": 13,
+              "y": 72,
+              "width": 8,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/27"
+              }
+            },
+            {
+              "x": 0,
+              "y": 82,
+              "width": 11,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/28"
+              }
+            },
+            {
+              "x": 11,
+              "y": 82,
+              "width": 13,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/29"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/neo4j/neo4j-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/neo4j/neo4j-summary.json
@@ -1,0 +1,1596 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "neo4jSumMaRy",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / Neo4j / Summary"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Datasource",
+            "hidden": false
+          },
+          "defaultValue": "default",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Neo4j",
+            "hidden": false
+          },
+          "defaultValue": "neo4j",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kubedb_com_neo4j_status_phase{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Database Status",
+            "description": "Represent database status"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": "phase",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_neo4j_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Version",
+            "description": "NEO4J CR Name"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "mean",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": " version ",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              },
+              "valueFontSize": 50
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_neo4j_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{ version }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage",
+            "description": "CPU Usage by NEO4J pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Quota",
+            "description": "CPU Quote information in details"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp",
+                  "width": "auto"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Usage",
+            "description": "Memory Usage by NEO4J pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Quota"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (RSS)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Cache)",
+                  "name": "value #7"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Swap)",
+                  "name": "value #8"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_rss{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_cache{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_swap{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk Usage",
+            "description": "Disk usage by NEO4J pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk R/W Info",
+            "description": "System Disk Usage Information"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "IOPS (Reads+Writes)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m])))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ThroughPut (Read+Write)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Current Storage IO"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads)",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Writes)",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads + Writes)",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read)",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Write)",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read + Write)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_total{container!=\"\",pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_bytes_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\",pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Allocated Storage",
+            "description": "This panel describes allocated persistent storage in a table format\n"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": []
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Require Secure Transport",
+            "description": "When this option is enabled, connections attempted using insecure transport will be rejected."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_neo4j_tls_enable{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{issuers_name}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage",
+            "description": "This panel shows the persistent volume usage in percentage. "
+          },
+          "plugin": {
+            "kind": "BarChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "percent"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage History",
+            "description": "This panel describes the persistent volume usage in a time series. "
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "right",
+                "values": [
+                  "max",
+                  "last-number"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineStyle": "solid",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decbytes"
+                },
+                "max": 5000,
+                "min": 0
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(kubelet_volume_stats_used_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) ",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Receive Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Transmit Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Deletion Policy",
+            "description": "KubeDB Database Resource deletionPolicy"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_neo4j_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Nodes",
+            "description": "Total node count of NEO4J cluster"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_neo4j_replicas{namespace=\"$namespace\",app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Request (Core)",
+            "description": "Initial Requested CPU amount by NEO4J Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_neo4j_resource_request_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Limit (Core)",
+            "description": "CPU Limit in core by NEO4J instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_neo4j_resource_limit_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Request",
+            "description": "Initial Requested Memory amount by NEO4J Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_neo4j_resource_request_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Limit",
+            "description": "KubeDB NEO4J Total Memory Limit"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_neo4j_resource_limit_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Storage Request",
+            "description": "Total storage request by NEO4J nodes"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_neo4j_resource_request_storage{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 8,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 16,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 20,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 4,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 8,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 12,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 16,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 20,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 0,
+              "y": 22,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 0,
+              "y": 28,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 0,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 12,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 0,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 12,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            },
+            {
+              "x": 0,
+              "y": 51,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/18"
+              }
+            },
+            {
+              "x": 0,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/19"
+              }
+            },
+            {
+              "x": 12,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/20"
+              }
+            },
+            {
+              "x": 0,
+              "y": 65,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/21"
+              }
+            },
+            {
+              "x": 0,
+              "y": 74,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/22"
+              }
+            },
+            {
+              "x": 12,
+              "y": 74,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/23"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/oracle/oracle_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/oracle/oracle_database_dashboard.json
@@ -1,0 +1,619 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "ohrahgv7T",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / Oracle / Database"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Datasource",
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "exporter",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Oracle",
+            "hidden": false
+          },
+          "defaultValue": "oracle",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kubedb_com_oracle_status_phase{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Service Status"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": []
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "up{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Service Uptime"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": []
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "oracledb_uptime_uptime_seconds{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "SQL Server Connections"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "oracledb_connections_sessions_current{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{db}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total wait time of I/O stall"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_io_stall_total_seconds{}",
+                    "seriesNameFormat": "{{ `{{db}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "AG Cluster Active Replica"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#f2495c",
+                    "value": 0
+                  },
+                  {
+                    "color": "#fade2a",
+                    "value": 2
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 3
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "oracledb_ag_cluster_size_cluster_size{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cluster Status"
+          },
+          "plugin": {
+            "kind": "GaugeChart",
+            "spec": {
+              "calculation": "last-number",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#fade2a",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 0
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "oracledb_pod_role_role_status{namespace=~\"$namespace\",service=~\"$app+-stats\",role=\"PRIMARY\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Pod Role"
+          },
+          "plugin": {
+            "kind": "GaugeChart",
+            "spec": {
+              "calculation": "last-number",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#fade2a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_pod_role{namespace=~\"$namespace\", service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cluster Status"
+          },
+          "plugin": {
+            "kind": "GaugeChart",
+            "spec": {
+              "calculation": "last-number",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#fade2a",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 0
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_status_wsrep_cluster_status{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cluster Status"
+          },
+          "plugin": {
+            "kind": "GaugeChart",
+            "spec": {
+              "calculation": "last-number",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#fade2a",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 0
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_pod_role{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{role}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "SQL Compilations/sec"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(oracledb_compilations_compilations_total{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Batch Requests per Second"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(oracledb_batch_requests_batch_requests_total{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "SQL Server log growths"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(oracledb_log_growth_archived_logs_bytes{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
+                    "seriesNameFormat": "{{ `{{db}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 0,
+              "y": 7,
+              "width": 12,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 12,
+              "y": 7,
+              "width": 12,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 12,
+              "y": 7,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 12,
+              "y": 7,
+              "width": 12,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 12,
+              "y": 7,
+              "width": 12,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 0,
+              "y": 12,
+              "width": 12,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 12,
+              "y": 12,
+              "width": 12,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 0,
+              "y": 22,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 12,
+              "y": 22,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 0,
+              "y": 29,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/oracle/oracle_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/oracle/oracle_pod_dashboard.json
@@ -1,0 +1,836 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "9J6ObCEMz",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / Oracle / Pod"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "oracle-stats",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "job",
+              "matchers": [
+                "oracledb_up"
+              ]
+            }
+          },
+          "name": "Job"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "$__all",
+          "allowAllValue": true,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "db",
+              "matchers": [
+                "oracledb_connections_sessions_current"
+              ]
+            }
+          },
+          "name": "database"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "exporter",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "oracle",
+            "hidden": false
+          },
+          "defaultValue": "oracle",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "alphabetical-asc",
+          "plugin": {
+            "kind": "PrometheusPromQLVariable",
+            "spec": {
+              "expr": "kubedb_com_oracle_created{namespace=\"$namespace\"}",
+              "labelName": "app"
+            }
+          },
+          "name": "app"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Pod Name",
+            "hidden": false
+          },
+          "defaultValue": "oracle-0",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "alphabetical-asc",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "pod",
+              "matchers": [
+                "up{job=\"$Job\",namespace=~\"$namespace\",pod=~\"${app}-.*\"}"
+              ]
+            }
+          },
+          "name": "pod"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Pod Name"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": "pod}} ",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#3274d9",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "up{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} "
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Status"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 1,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "rgba(50, 172, 45, 0.97)",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "up{pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Role"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 0,
+                "unit": "decimal"
+              },
+              "metricLabel": "role",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "oracledb_pod_role_role_status{pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{role}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Uptime"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "seconds"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "max(max_over_time(oracledb_uptime_uptime_seconds{pod=~\"$pod\"}[$__interval]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Server Resource Overview"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Server local time",
+                  "name": "value #1"
+                },
+                {
+                  "header": "Total Available RAM",
+                  "name": "value #2"
+                },
+                {
+                  "header": "Total pagefile size (available)",
+                  "name": "value #4"
+                },
+                {
+                  "header": "Pagefile size (used)",
+                  "name": "value #5"
+                },
+                {
+                  "header": "RAM used",
+                  "name": "value #3"
+                },
+                {
+                  "header": "Batch reqs / sec",
+                  "name": "Value #BR"
+                },
+                {
+                  "header": "Page life expectancy (sec)",
+                  "name": "Value #PLE"
+                },
+                {
+                  "header": "Deadlocks",
+                  "name": "Value #DL"
+                },
+                {
+                  "header": "User errors / sec",
+                  "name": "Value #UE"
+                },
+                {
+                  "header": "Kill conn errors / sec",
+                  "name": "Value #KC"
+                },
+                {
+                  "header": "Total databases",
+                  "name": "Value #DBC"
+                },
+                {
+                  "align": "right",
+                  "header": "",
+                  "hide": true,
+                  "name": "/.*/"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(oracledb_local_time_local_time_seconds{job=~\"$Job\", pod=\"$pod\"}*1000)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "oracledb_os_memory_total_memory_total_bytes{job=~\"$Job\", pod=\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_os_memory{state=\"used\",job=~\"$Job\", pod=\"$pod\"}-0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_os_page_file{state=\"available\",job=~\"$Job\", pod=\"$pod\"}-0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_os_page_file{state=\"used\",job=~\"$Job\", pod=\"$pod\"}-0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Server Resouce Overview"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Server local time",
+                  "name": "Value #LT"
+                },
+                {
+                  "header": "Total RAM (available)",
+                  "name": "Value #TM"
+                },
+                {
+                  "header": "Total page faults",
+                  "name": "value #1"
+                },
+                {
+                  "header": "Total RAM",
+                  "name": "Value #TM"
+                },
+                {
+                  "header": "Total pagefile size (available)",
+                  "name": "Value #PF"
+                },
+                {
+                  "header": "Pagefile size (used)",
+                  "name": "Value #APF"
+                },
+                {
+                  "header": "RAM used",
+                  "name": "Value #RA"
+                },
+                {
+                  "header": "Batch reqs / sec",
+                  "name": "value #2"
+                },
+                {
+                  "header": "Page life expectancy (sec)",
+                  "name": "value #3"
+                },
+                {
+                  "header": "Deadlocks",
+                  "name": "value #4"
+                },
+                {
+                  "header": "User errors / sec",
+                  "name": "value #5"
+                },
+                {
+                  "header": "Kill conn errors / sec",
+                  "name": "value #6"
+                },
+                {
+                  "header": "Total databases",
+                  "name": "value #7"
+                },
+                {
+                  "align": "right",
+                  "header": "",
+                  "hide": true,
+                  "name": "/.*/"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(oracledb_buffer_cache_physical_reads_total{job=~\"$Job\", pod=\"$pod\"}[5m]) - 0",
+                    "seriesNameFormat": "Total page faults"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(oracledb_batch_requests_batch_requests_total{job=~\"$Job\", pod=\"$pod\"}[5m]) - 0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "oracledb_buffer_cache_hit_ratio_cache_hit_ratio{job=~\"$Job\", pod=\"$pod\"}-0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(oracledb_deadlocks_deadlocks_total{job=~\"$Job\", pod=\"$pod\"}[5m]) - 0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(oracledb_user_errors_user_errors_total{job=~\"$Job\", pod=\"$pod\"}[5m]) - 0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mssql_kill_connection_errors{job=~\"$Job\", pod=\"$pod\"}-0",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(oracledb_database_state_database_open_mode{job=~\"$Job\", pod=\"$pod\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Current database connections"
+          },
+          "plugin": {
+            "kind": "BarChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "decimal"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "oracledb_connections_sessions_current{pod=\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{db}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "DB Log growth since last restart"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "oracledb_log_growth_archived_logs_bytes{pod=\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{db}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total wait time of I/O stall"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "oracledb_wait_time_system_io{pod=\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{db}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Database ${database} wait by I/O stall "
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "oracledb_wait_time_user_io{pod=\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{db}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 6,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 6,
+              "y": 0,
+              "width": 6,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 12,
+              "y": 0,
+              "width": 6,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 18,
+              "y": 0,
+              "width": 6,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 0,
+              "y": 7,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 0,
+              "y": 14,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 0,
+              "y": 22,
+              "width": 7,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 7,
+              "y": 22,
+              "width": 9,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 16,
+              "y": 22,
+              "width": 8,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 0,
+              "y": 30,
+              "width": 8,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/oracle/oracle_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/oracle/oracle_summary_dashboard.json
@@ -1,0 +1,1629 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "92M7QvyVk",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / Oracle / Summary"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Datasource",
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "exporter",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Oracle",
+            "hidden": false
+          },
+          "defaultValue": "oracle",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kubedb_com_oracle_status_phase{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Database Status",
+            "description": "Represent database status"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_oracle_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Database Up-time",
+            "description": "OracleVersion CR Name"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "seconds"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "time() - kubedb_com_oracle_created{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage",
+            "description": "CPU Usage by Oracle pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Quota",
+            "description": "CPU Quote information in details"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp",
+                  "width": "auto"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Usage",
+            "description": "Memory Usage by Oracle pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Quota"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (RSS)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Cache)",
+                  "name": "value #7"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Swap)",
+                  "name": "value #8"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",container!=\"\", image!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\",pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_rss{namespace=\"$namespace\",pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_cache{namespace=\"$namespace\",pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_swap{namespace=\"$namespace\",pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk Usage",
+            "description": "Disk usage by Oracle pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom",
+                "values": []
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk R/W Info",
+            "description": "System Disk Usage Information"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom",
+                "values": []
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "IOPS (Reads+Writes)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom",
+                "values": []
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}[5m])))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ThroughPut (Read+Write)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom",
+                "values": []
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}[5m]))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Current Storage IO"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads)",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Writes)",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads + Writes)",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read)",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Write)",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read + Write)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_total{container!=\"\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_total{container!=\"\",pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_bytes_total{container!=\"\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\",pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Allocated Storage",
+            "description": "This panel describes allocated persistent storage in a table format\n"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": []
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}\n* on(persistentvolumeclaim, namespace) group_left(pod)\nkube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"^$app.*\", namespace=~\"$namespace\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Limit (Core)",
+            "description": "CPU Limit in core by Oracle instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_oracle_resource_limit_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage",
+            "description": "This panel shows the persistent volume usage in percentage. "
+          },
+          "plugin": {
+            "kind": "BarChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "percent"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(\n  kubelet_volume_stats_used_bytes{job=\"kubelet\"}\n  * on(persistentvolumeclaim, namespace) group_left(pod)\n  kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"^$app.*\", namespace=~\"$namespace\"}\n)\n/\n(\n  kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}\n  * on(persistentvolumeclaim, namespace) group_left(pod)\n  kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"^$app.*\", namespace=~\"$namespace\"}\n)\n* 100",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage History",
+            "description": "This panel describes the persistent volume usage in a time series. "
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "right",
+                "values": [
+                  "max",
+                  "last-number"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineStyle": "solid",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decbytes"
+                },
+                "max": 5000,
+                "min": 0
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubelet_volume_stats_used_bytes{job=\"kubelet\"}\n* on(persistentvolumeclaim, namespace) group_left(pod)\nkube_pod_spec_volumes_persistentvolumeclaims_info{\n  pod=~\"^$app.*\",\n  namespace=~\"$namespace\"\n}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Receive Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom",
+                "values": []
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Transmit Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom",
+                "values": []
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Limit",
+            "description": "KubeDB Oracle Total Memory Limit"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_oracle_resource_limit_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Storage Request",
+            "description": "Total storage request by Oracle nodes"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_oracle_resource_request_storage{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Version",
+            "description": "OracleVersion CR Name"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "mean",
+              "colorMode": "none",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": "version",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_oracle_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{version}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Nodes",
+            "description": "Total node count of Oracle cluster"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_oracle_replicas{namespace=\"$namespace\",app=\"$app\"} or (kubedb_com_oracle_shard_shards{namespace=\"$namespace\",app=\"$app\"} * kubedb_com_oracle_shard_replicas{namespace=\"$namespace\",app=\"$app\"} +kubedb_com_oracle_mongos_replicas{namespace=\"$namespace\",app=\"$app\"}+ kubedb_com_oracle_configsvr_replicas{namespace=\"$namespace\",app=\"$app\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Request (Core)",
+            "description": "Initial Requested CPU amount by Oracle Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_oracle_resource_request_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Request",
+            "description": "Initial Requested Memory amount by Oracle Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_oracle_resource_request_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Deletion Policy",
+            "description": "KubeDB Database Resource deletionPolicy"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_oracle_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 8,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 12,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 16,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 20,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 8,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 12,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 16,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 20,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 0,
+              "y": 22,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 0,
+              "y": 28,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 0,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 12,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 0,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 12,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            },
+            {
+              "x": 0,
+              "y": 51,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/18"
+              }
+            },
+            {
+              "x": 0,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/19"
+              }
+            },
+            {
+              "x": 12,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/20"
+              }
+            },
+            {
+              "x": 0,
+              "y": 65,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/21"
+              }
+            },
+            {
+              "x": 0,
+              "y": 74,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/22"
+              }
+            },
+            {
+              "x": 12,
+              "y": 74,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/23"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/perconaxtradb/perconaxtradb-database.json
+++ b/charts/kubedb-perses-dashboards/dashboards/perconaxtradb/perconaxtradb-database.json
@@ -91,26 +91,6 @@
           "plugin": {
             "kind": "Table",
             "spec": {
-              "cellSettings": [
-                {
-                  "condition": {
-                    "kind": "Value",
-                    "spec": {
-                      "value": "0"
-                    }
-                  },
-                  "text": "DOWN"
-                },
-                {
-                  "condition": {
-                    "kind": "Value",
-                    "spec": {
-                      "value": "1"
-                    }
-                  },
-                  "text": "UP"
-                }
-              ],
               "columnSettings": []
             }
           },
@@ -123,7 +103,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_up{namespace=~\"$namespace\",service=~\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -152,7 +132,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_uptime{namespace=~\"$namespace\",service=~\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -179,7 +159,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_open_files{namespace=~\"$namespace\",service=~\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Open Files - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -192,7 +172,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_open_files_limit{namespace=~\"$namespace\",service=~\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Open Files Limit - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -205,7 +185,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_innodb_num_open_files{namespace=~\"$namespace\",service=~\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "InnoDB Open Files - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -232,7 +212,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_slow_queries{namespace=~\"$namespace\",service=~\"$app\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Slow Queries on {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -259,7 +239,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_aborted_connects{namespace=~\"$namespace\",service=~\"$app\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Aborted Connects (attempts) on - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -272,7 +252,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_aborted_clients{namespace=~\"$namespace\",service=~\"$app\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Aborted Clients (timeout) on - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -290,6 +270,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -390,7 +371,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_queries{namespace=~\"$namespace\",service=~\"$app\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -417,7 +398,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_max_used_connections{namespace=~\"$namespace\",service=~\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Current - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -430,7 +411,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_max_connections{namespace=~\"$namespace\",service=~\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Max - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -457,7 +438,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_innodb_data_reads{namespace=~\"$namespace\",service=~\"$app\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "reads - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -470,7 +451,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_innodb_data_writes{namespace=~\"$namespace\",service=~\"$app\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "write - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -497,7 +478,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_bytes_received{namespace=~\"$namespace\",service=~\"$app\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "received - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -510,7 +491,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_bytes_sent{namespace=~\"$namespace\",service=~\"$app\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "sent - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -537,7 +518,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "topk(3, rate(mysql_global_status_commands_total{namespace=~\"$namespace\",service=~\"$app\"}[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }} = '{{ `{{ command }}` }}'"
                   }
                 }
               }
@@ -564,7 +545,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_opened_files{namespace=~\"$namespace\",service=~\"$app\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/perconaxtradb/perconaxtradb-galera.json
+++ b/charts/kubedb-perses-dashboards/dashboards/perconaxtradb/perconaxtradb-galera.json
@@ -1,0 +1,310 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "Zmva7c57k",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / PerconaXtraDB / Galera-Cluster"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Datasource",
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "PerconaXtraDB",
+            "hidden": false
+          },
+          "defaultValue": "sample-perconaxtradb-stats",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "service",
+              "matchers": [
+                "mysql_up{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cluster Name"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "metricLabel": "wsrep_cluster_name",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#5794f2",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg by(wsrep_cluster_name)(mysql_galera_variables_info{namespace=~\"$namespace\",service=~\"$app\"})",
+                    "seriesNameFormat": "{{ `{{wsrep_cluster_name}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cluster Members"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 2
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg by(pod)(mysql_galera_variables_info{namespace=~\"$namespace\",service=~\"$app\"})",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Average: Galera Replication Latency"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg_over_time(mysql_galera_evs_repl_latency_avg_seconds{namespace=~\"$namespace\",service=~\"$app\"}[5m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }} - Latency Average"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Standard Deviation: Galera Replication Latency"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_galera_evs_repl_latency_stdev{namespace=~\"$namespace\",service=~\"$app\"}[1m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }} - Latency Average"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Sample Size: Galera Replication Latency"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_galera_evs_repl_latency_sample_size{namespace=~\"$namespace\",service=~\"$app\"}[1m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }} - Latency Average"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 24,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 0,
+              "y": 3,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 0,
+              "y": 11,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 0,
+              "y": 19,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 0,
+              "y": 27,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/perconaxtradb/perconaxtradb-pod.json
+++ b/charts/kubedb-perses-dashboards/dashboards/perconaxtradb/perconaxtradb-pod.json
@@ -1,4 +1,5 @@
 {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
 {
   "kind": "Dashboard",
   "metadata": {
@@ -105,7 +106,7 @@
       }
     ],
     "panels": {
-      "0_0": {
+      "0": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -115,9 +116,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": "pod}} ",
               "thresholds": {
                 "steps": [
                   {
@@ -137,7 +140,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_up{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} "
                   }
                 }
               }
@@ -145,7 +148,7 @@
           ]
         }
       },
-      "0_1": {
+      "1": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -155,6 +158,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -181,7 +185,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_uptime{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -189,7 +193,435 @@
           ]
         }
       },
-      "0_2": {
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL Client Thread Activity"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_status_threads_connected{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Threads Connected - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_status_threads_running{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Threads Running - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL Thread Cache"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_variables_thread_cache_size{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Thread Cache Size - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_status_threads_cached{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Threads Cached - {{ `{{pod}}` }} "
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_status_threads_created{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Threads Created - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL Temporary Objects"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_created_tmp_tables{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Created Tmp Tables - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_created_tmp_disk_tables{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Created Tmp Disk Tables - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_status_created_tmp_files{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Created Tmp Files - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL Slow Queries"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_status_slow_queries{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Slow Queries - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL Select Types"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_select_full_join{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Select Full Join - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_select_scan{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Select Scan - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL Sorts"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_sort_rows{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Sort Rows - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_sort_range{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Sort Range - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_sort_merge_passes{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Sort Merge Passes - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_sort_scan{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Sort Scan - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL Table Locks"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_table_locks_immediate{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Table Locks Immediate - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_table_locks_waited{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Table Locks Waited - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL Questions"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_questions{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Questions - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL Network Traffic",
+            "description": "\n\nHere we can see how much network traffic is generated by MySQL. Outbound is network traffic sent from MySQL and Inbound is network traffic MySQL has received."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_bytes_received{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Inbound - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_bytes_sent{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Outbound - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL Network Usage Hourly",
+            "description": "\n\nHere we can see how much network traffic is generated by MySQL. Outbound is network traffic sent from MySQL and Inbound is network traffic MySQL has received."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "1h",
+                    "query": "increase(mysql_global_status_bytes_received{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[1h])",
+                    "seriesNameFormat": "Received - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "1h",
+                    "query": "increase(mysql_global_status_bytes_sent{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[1h])",
+                    "seriesNameFormat": "Sent - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -199,9 +631,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": "version",
               "thresholds": {
                 "steps": [
                   {
@@ -225,7 +659,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_version_info{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{version}}` }}"
                   }
                 }
               }
@@ -233,7 +667,510 @@
           ]
         }
       },
-      "0_3": {
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL Internal Memory Overview"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_variables_innodb_buffer_pool_size{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
+                    "seriesNameFormat": "InnoDB Buffer Pool Size - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_variables_innodb_log_buffer_size{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
+                    "seriesNameFormat": "InnoDB Log Buffer Size - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_status_innodb_mem_dictionary{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
+                    "seriesNameFormat": "InnoDB Dictionary Size - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_variables_key_buffer_size{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
+                    "seriesNameFormat": "Key Buffer Size - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_variables_query_cache_size{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
+                    "seriesNameFormat": "Query Cache Size - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_status_innodb_mem_adaptive_hash{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
+                    "seriesNameFormat": "Adaptive Hash Index Size - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Top Command Counters"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "topk(5, rate(mysql_global_status_commands_total{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m]))",
+                    "seriesNameFormat": "Com_{{ `{{ command }}` }} - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Top Command Counter Hourly",
+            "description": "\n\nHere we can see how much network traffic is generated by MySQL. Outbound is network traffic sent from MySQL and Inbound is network traffic MySQL has received."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "1h",
+                    "query": "topk(5, avg by (pod,command) (increase(mysql_global_status_commands_total{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[1h])>0))",
+                    "seriesNameFormat": "Com_{{ `{{ command }}` }} - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL Handlers"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_handlers_total{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])>0",
+                    "seriesNameFormat": "{{ `{{ handler }}` }} - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "24": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL Query Cache Memory"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_qcache_free_memory{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Query Cache Size - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "25": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL Query Cache Activity"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_qcache_hits{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Hits - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_qcache_inserts{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Inserts - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_qcache_not_cached{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Not Cached - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_qcache_lowmem_prunes{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Prunes - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_qcache_queries_in_cache{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Queries in Cache - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "26": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL File Openings"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_status_opened_files{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Openings - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "27": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL Open Files"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_status_open_files{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Open Files - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_variables_open_files_limit{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Open Files Limit - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_status_innodb_num_open_files{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "InnoDB Open Files - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL Table Open Cache Status"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_opened_tables{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Openings - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_table_open_cache_hits{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Hits - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_table_open_cache_misses{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Misses - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_table_open_cache_overflows{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Misses due to Overflows - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(mysql_global_status_table_open_cache_hits{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Table Open Cache Hit Ratio - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "29": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL Open Tables"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_status_open_tables{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Open Tables - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_variables_table_open_cache{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Table Open Cache - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -243,6 +1180,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -265,7 +1203,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(mysql_global_status_queries{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -273,7 +1211,60 @@
           ]
         }
       },
-      "0_4": {
+      "30": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL Table Definition Cache"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_status_open_table_definitions{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Open Table Definitions - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_variables_table_definition_cache{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Table Definitions Cache Size - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "mysql_global_status_opened_table_definitions{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Opened Table Definitions - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -283,6 +1274,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -309,7 +1301,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_innodb_buffer_pool_size{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -317,377 +1309,7 @@
           ]
         }
       },
-      "10_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL Query Cache Memory"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "bytes"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_qcache_free_memory{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "10_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL Query Cache Activity"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_qcache_hits{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_qcache_inserts{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_qcache_not_cached{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_qcache_lowmem_prunes{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_qcache_queries_in_cache{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "11_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL File Openings"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_status_opened_files{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "11_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL Open Files"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_status_open_files{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_variables_open_files_limit{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_status_innodb_num_open_files{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "12_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL Table Open Cache Status"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_opened_tables{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_table_open_cache_hits{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_table_open_cache_misses{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_table_open_cache_overflows{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_table_open_cache_hits{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "12_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL Open Tables"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_status_open_tables{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_variables_table_open_cache{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "12_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL Table Definition Cache"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_status_open_table_definitions{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_variables_table_definition_cache{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_status_opened_table_definitions{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "1_0": {
+      "5": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -712,7 +1334,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}[5m])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{container}}` }}"
                   }
                 }
               }
@@ -720,7 +1342,7 @@
           ]
         }
       },
-      "1_1": {
+      "6": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -745,7 +1367,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=\"$pod\", container!=\"\", image!=\"\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -753,7 +1375,7 @@
           ]
         }
       },
-      "1_2": {
+      "7": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -779,7 +1401,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(process_open_fds{pod=\"$pod\", namespace=\"$namespace\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -787,7 +1409,7 @@
           ]
         }
       },
-      "2_0": {
+      "8": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -806,7 +1428,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_max_used_connections{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Max Used Connects - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -819,7 +1441,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_variables_max_connections{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Max Connects - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -827,7 +1449,7 @@
           ]
         }
       },
-      "2_1": {
+      "9": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -846,7 +1468,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_aborted_connects{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Aborted Connects - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -859,621 +1481,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "mysql_global_status_aborted_clients{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL Client Thread Activity"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_status_threads_connected{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_status_threads_running{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL Thread Cache"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_variables_thread_cache_size{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_status_threads_cached{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_status_threads_created{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "4_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL Temporary Objects"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_created_tmp_tables{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_created_tmp_disk_tables{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_status_created_tmp_files{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "4_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL Slow Queries"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_status_slow_queries{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL Select Types"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_select_full_join{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_select_scan{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL Sorts"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_sort_rows{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_sort_range{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_sort_merge_passes{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_sort_scan{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "6_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL Table Locks"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_table_locks_immediate{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_table_locks_waited{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "6_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL Questions"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_questions{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "7_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL Network Traffic",
-            "description": "\n\nHere we can see how much network traffic is generated by MySQL. Outbound is network traffic sent from MySQL and Inbound is network traffic MySQL has received."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_bytes_received{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_bytes_sent{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "7_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL Network Usage Hourly",
-            "description": "\n\nHere we can see how much network traffic is generated by MySQL. Outbound is network traffic sent from MySQL and Inbound is network traffic MySQL has received."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "1h",
-                    "query": "increase(mysql_global_status_bytes_received{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[1h])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "1h",
-                    "query": "increase(mysql_global_status_bytes_sent{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[1h])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "8_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL Internal Memory Overview"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "bytes"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_variables_innodb_buffer_pool_size{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_variables_innodb_log_buffer_size{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_status_innodb_mem_dictionary{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_variables_key_buffer_size{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_variables_query_cache_size{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "mysql_global_status_innodb_mem_adaptive_hash{namespace=\"$namespace\",service=\"$app\",pod=\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "9_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Top Command Counters"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "topk(5, rate(mysql_global_status_commands_total{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m]))",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "9_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Top Command Counter Hourly",
-            "description": "\n\nHere we can see how much network traffic is generated by MySQL. Outbound is network traffic sent from MySQL and Inbound is network traffic MySQL has received."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "1h",
-                    "query": "topk(5, avg by (pod,command) (increase(mysql_global_status_commands_total{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[1h])>0))",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "9_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL Handlers"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(mysql_global_status_handlers_total{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])>0",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Aborted Clients - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1487,10 +1495,7 @@
         "kind": "Grid",
         "spec": {
           "display": {
-            "title": "PerconaXtraDB Pod Summary",
-            "collapse": {
-              "open": true
-            }
+            "title": "Panel Group 1"
           },
           "items": [
             {
@@ -1499,7 +1504,7 @@
               "width": 5,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_0"
+                "$ref": "#/spec/panels/0"
               }
             },
             {
@@ -1508,7 +1513,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_1"
+                "$ref": "#/spec/panels/1"
               }
             },
             {
@@ -1517,7 +1522,7 @@
               "width": 6,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_2"
+                "$ref": "#/spec/panels/2"
               }
             },
             {
@@ -1526,7 +1531,7 @@
               "width": 5,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_3"
+                "$ref": "#/spec/panels/3"
               }
             },
             {
@@ -1535,29 +1540,16 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_4"
+                "$ref": "#/spec/panels/4"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Pod CPU, Memory and File Descriptor Stats",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 5,
               "width": 8,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/1_0"
+                "$ref": "#/spec/panels/5"
               }
             },
             {
@@ -1566,7 +1558,7 @@
               "width": 8,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/1_1"
+                "$ref": "#/spec/panels/6"
               }
             },
             {
@@ -1575,29 +1567,16 @@
               "width": 8,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/1_2"
+                "$ref": "#/spec/panels/7"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Connections",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 13,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2_0"
+                "$ref": "#/spec/panels/8"
               }
             },
             {
@@ -1606,29 +1585,16 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2_1"
+                "$ref": "#/spec/panels/9"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Client Threads",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 21,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_0"
+                "$ref": "#/spec/panels/10"
               }
             },
             {
@@ -1637,29 +1603,16 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_1"
+                "$ref": "#/spec/panels/11"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Temporary Objects & Slow Queries",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 29,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/4_0"
+                "$ref": "#/spec/panels/12"
               }
             },
             {
@@ -1668,29 +1621,16 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/4_1"
+                "$ref": "#/spec/panels/13"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Select Types and Sorts",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 37,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_0"
+                "$ref": "#/spec/panels/14"
               }
             },
             {
@@ -1699,29 +1639,16 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_1"
+                "$ref": "#/spec/panels/15"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Table Locks and Questions",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 45,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/6_0"
+                "$ref": "#/spec/panels/16"
               }
             },
             {
@@ -1730,29 +1657,16 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/6_1"
+                "$ref": "#/spec/panels/17"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Network",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 53,
               "width": 24,
               "height": 10,
               "content": {
-                "$ref": "#/spec/panels/7_0"
+                "$ref": "#/spec/panels/18"
               }
             },
             {
@@ -1761,51 +1675,25 @@
               "width": 24,
               "height": 10,
               "content": {
-                "$ref": "#/spec/panels/7_1"
+                "$ref": "#/spec/panels/19"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Memory",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 74,
               "width": 24,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/8_0"
+                "$ref": "#/spec/panels/20"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Command, Handlers",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 83,
               "width": 24,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/9_0"
+                "$ref": "#/spec/panels/21"
               }
             },
             {
@@ -1814,7 +1702,7 @@
               "width": 24,
               "height": 10,
               "content": {
-                "$ref": "#/spec/panels/9_1"
+                "$ref": "#/spec/panels/22"
               }
             },
             {
@@ -1823,29 +1711,16 @@
               "width": 24,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/9_2"
+                "$ref": "#/spec/panels/23"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Query Cache",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 110,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/10_0"
+                "$ref": "#/spec/panels/24"
               }
             },
             {
@@ -1854,29 +1729,16 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/10_1"
+                "$ref": "#/spec/panels/25"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Files and Tables",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 118,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/11_0"
+                "$ref": "#/spec/panels/26"
               }
             },
             {
@@ -1885,29 +1747,16 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/11_1"
+                "$ref": "#/spec/panels/27"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "MySQL Table Openings and Definition Cache",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 126,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/12_0"
+                "$ref": "#/spec/panels/28"
               }
             },
             {
@@ -1916,7 +1765,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/12_1"
+                "$ref": "#/spec/panels/29"
               }
             },
             {
@@ -1925,7 +1774,7 @@
               "width": 24,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/12_2"
+                "$ref": "#/spec/panels/30"
               }
             }
           ]

--- a/charts/kubedb-perses-dashboards/dashboards/perconaxtradb/perconaxtradb-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/perconaxtradb/perconaxtradb-summary.json
@@ -1,0 +1,1589 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "VnOgk2Hnkx",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / PerconaXtraDB / Summary"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Datasource",
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "PerconaXtraDB",
+            "hidden": false
+          },
+          "defaultValue": "coreos-prom-px",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kubedb_com_perconaxtradb_status_phase{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Database Status",
+            "description": "Represent database status"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_perconaxtradb_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Version",
+            "description": "PerconaXtraDB CR Name"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "mean",
+              "colorMode": "none",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": " version ",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              },
+              "valueFontSize": 50
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_perconaxtradb_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{ version }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage",
+            "description": "CPU Usage by PerconaXtraDB pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Quota",
+            "description": "CPU Quote information in details"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp",
+                  "width": "auto"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Usage",
+            "description": "Memory Usage by PerconaXtraDB pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Quota"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (RSS)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Cache)",
+                  "name": "value #7"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Swap)",
+                  "name": "value #8"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_rss{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_cache{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_swap{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk Usage",
+            "description": "Disk usage by PerconaXtraDB pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk R/W Info",
+            "description": "System Disk Usage Information"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "IOPS (Reads+Writes)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m])))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ThroughPut (Read+Write)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Current Storage IO"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads)",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Writes)",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads + Writes)",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read)",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Write)",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read + Write)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_total{container!=\"\",pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_bytes_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\",pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Allocated Storage",
+            "description": "This panel describes allocated persistent storage in a table format\n"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": []
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Require Secure Transport",
+            "description": "When this option is enabled, connections attempted using insecure transport will be rejected."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_perconaxtradb_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{requireSSL}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage",
+            "description": "This panel shows the persistent volume usage in percentage. "
+          },
+          "plugin": {
+            "kind": "BarChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "percent"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage History",
+            "description": "This panel describes the persistent volume usage in a time series. "
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "right",
+                "values": [
+                  "max",
+                  "last-number"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineStyle": "solid",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decbytes"
+                },
+                "max": 5000,
+                "min": 0
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(kubelet_volume_stats_used_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) ",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Receive Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Transmit Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Deletion Policy",
+            "description": "KubeDB Database Resource deletionPolicy"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_perconaxtradb_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Nodes",
+            "description": "Total node count of PerconaXtraDB cluster"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_perconaxtradb_replicas{namespace=\"$namespace\",app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Request (Core)",
+            "description": "Initial Requested CPU amount by PerconaXtraDB Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_perconaxtradb_resource_request_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Limit (Core)",
+            "description": "CPU Limit in core by PerconaXtraDB instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_perconaxtradb_resource_limit_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Request",
+            "description": "Initial Requested Memory amount by PerconaXtraDB Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_perconaxtradb_resource_request_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Limit",
+            "description": "KubeDB perconaxtradb Total Memory Limit"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_perconaxtradb_resource_limit_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Storage Request",
+            "description": "Total storage request by perconaxtradb nodes"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_perconaxtradb_resource_request_storage{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 8,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 16,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 20,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 4,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 8,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 12,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 16,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 20,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 0,
+              "y": 22,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 0,
+              "y": 28,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 0,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 12,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 0,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 12,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            },
+            {
+              "x": 0,
+              "y": 51,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/18"
+              }
+            },
+            {
+              "x": 0,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/19"
+              }
+            },
+            {
+              "x": 12,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/20"
+              }
+            },
+            {
+              "x": 0,
+              "y": 65,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/21"
+              }
+            },
+            {
+              "x": 0,
+              "y": 74,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/22"
+              }
+            },
+            {
+              "x": 12,
+              "y": 74,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/23"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/pgbouncer/pgbouncer_database.json
+++ b/charts/kubedb-perses-dashboards/dashboards/pgbouncer/pgbouncer_database.json
@@ -138,6 +138,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "background_solid",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -160,7 +161,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "(sum by (pod) (pgbouncer_databases_disabled{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}))/2",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }} )"
                   }
                 }
               }
@@ -179,6 +182,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "background_solid",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -201,7 +205,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "(sum by (pod) (pgbouncer_databases_paused{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}))/2",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }} )"
                   }
                 }
               }
@@ -221,8 +227,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -239,7 +244,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "sum by (pod) (pgbouncer_stats_xact_count_total{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }
@@ -259,8 +266,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -277,7 +283,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "(sum by (pod) (pgbouncer_databases_current_connections{namespace=~\"$namespace\",pod=~\"$pod\"}))/(sum by (pod) (pgbouncer_databases_max_connections{namespace=~\"$namespace\",pod=~\"$pod\"}))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -303,7 +311,8 @@
                 "mode": "list",
                 "position": "right"
               },
-              "radius": 50
+              "radius": 50,
+              "showLabels": true
             }
           },
           "queries": [
@@ -313,7 +322,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "(sum by (pod) (pgbouncer_databases_current_connections{namespace=~\"$namespace\",pod=~\"$pod\"}))-(sum by (pod) (pgbouncer_databases_current_connections{namespace=~\"$namespace\",pod=~\"$pod\", name=\"pgbouncer\"}))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}  (Used child process)"
                   }
                 }
               }
@@ -324,7 +335,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgbouncer_databases_current_connections{namespace=~\"$namespace\",pod=~\"$pod\", name=\"pgbouncer\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} (Total child process)"
                   }
                 }
               }
@@ -344,8 +357,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -362,7 +374,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgbouncer_config_log_pooler_errors{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }
@@ -382,8 +396,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0.1,
@@ -400,7 +413,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "sum by (pod) (pgbouncer_stats_query_count_total{namespace=~\"$namespace\",pod=~\"$pod\"})",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -419,6 +434,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -443,7 +459,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by (pod) (pgbouncer_stats_avg_query_time_microseconds{namespace=~\"$namespace\",pod=~\"$pod\"})",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -462,6 +478,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -486,7 +503,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pgbouncer_config_query_wait_timeout_seconds{namespace=~\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -505,6 +522,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -527,7 +545,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "sum(irate(pgbouncer_stats_query_time_microseconds_total{namespace=~\"$namespace\",pod=~\"$pod\"}[5m]))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -570,7 +590,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "sum by (pod) (pgbouncer_stats_avg_xact_count{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"})",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/pgbouncer/pgbouncer_pod.json
+++ b/charts/kubedb-perses-dashboards/dashboards/pgbouncer/pgbouncer_pod.json
@@ -1,4 +1,5 @@
 {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
 {
   "kind": "Dashboard",
   "metadata": {
@@ -116,9 +117,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": "pod",
               "thresholds": {
                 "steps": [
                   {
@@ -138,7 +141,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pgbouncer_up{namespace=~\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -157,6 +160,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "seconds"
               },
@@ -183,7 +187,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "time() - kube_pod_start_time{namespace=~\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -202,6 +206,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -226,7 +231,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pgbouncer_scrapes_total{namespace=~\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -260,7 +265,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\", image!=\"\"}[5m])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{container}}` }}"
                   }
                 }
               }
@@ -294,7 +299,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(container_memory_working_set_bytes{namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\", image!=\"\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -313,6 +318,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -340,7 +346,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(sum by (pod) (pgbouncer_databases_max_connections{namespace=~\"$namespace\",pod=~\"$pod\"}))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -359,6 +365,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -386,7 +393,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by (pod) (pgbouncer_config_max_db_connections{namespace=~\"$namespace\",pod=~\"$pod\"})",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -405,6 +412,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -429,7 +437,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by (pod) (pgbouncer_databases_current_connections{namespace=~\"$namespace\",pod=~\"$pod\"})",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -463,7 +471,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(sum by (pod) (pgbouncer_databases_current_connections{namespace=~\"$namespace\",pod=~\"$pod\"}))/(sum by (pod) (pgbouncer_databases_max_connections{namespace=~\"$namespace\",pod=~\"$pod\"}))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -482,6 +490,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -509,7 +518,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pgbouncer_last_scrape_error{namespace=~\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -543,7 +552,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pgbouncer_last_scrape_duration_seconds{namespace=~\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/pgbouncer/pgbouncer_summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/pgbouncer/pgbouncer_summary.json
@@ -91,6 +91,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
               "thresholds": {
                 "steps": [
                   {
@@ -110,7 +112,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_pgbouncer_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
                   }
                 }
               }
@@ -129,9 +131,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": " version ",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -157,7 +161,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_pgbouncer_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ version }}` }}"
                   }
                 }
               }
@@ -185,7 +189,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -206,29 +210,48 @@
               "columnSettings": [
                 {
                   "header": "Time",
-                  "name": "timestamp"
+                  "name": "timestamp",
+                  "width": "auto"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -330,7 +353,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -353,38 +376,65 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (RSS)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Cache)",
-                  "name": "Value #G"
+                  "name": "value #7"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Swap)",
-                  "name": "Value #H"
+                  "name": "value #8"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -525,7 +575,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -559,7 +609,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
                   }
                 }
               }
@@ -572,7 +622,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
                   }
                 }
               }
@@ -605,7 +655,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m])))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -638,7 +688,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -665,7 +715,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -698,7 +748,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -717,6 +767,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
+              "metricLabel": " backend ",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -742,7 +794,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_pgbouncer_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ backend }}` }}"
                   }
                 }
               }
@@ -761,6 +813,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -784,7 +837,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_pgbouncer_info{namespace=\"$namespace\", app=\"$app\", ssl!~\"^$\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ssl}}` }}"
                   }
                 }
               }
@@ -803,6 +856,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "thresholds": {
                 "steps": [
                   {
@@ -845,6 +899,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -884,6 +939,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -923,6 +979,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -965,6 +1022,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -1007,6 +1065,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1027,7 +1086,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_pgbouncer_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/pgpool/pgpool_database.json
+++ b/charts/kubedb-perses-dashboards/dashboards/pgpool/pgpool_database.json
@@ -141,6 +141,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "background_solid",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -163,7 +164,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_nodes_status{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }} )"
                   }
                 }
               }
@@ -183,8 +186,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0.1,
@@ -206,7 +208,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_nodes_replication_delay{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }
@@ -226,8 +230,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -244,7 +247,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_backend_stats_update_cnt{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }
@@ -264,8 +269,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -282,7 +286,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_backend_stats_ddl_cnt{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }
@@ -302,8 +308,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -320,7 +325,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_backend_stats_other_cnt{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }
@@ -340,8 +347,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0.1,
@@ -363,7 +369,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_cache_cache_hit_ratio{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -383,8 +391,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -403,7 +410,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pgpool2_pool_cache_num_cache_entries{namespace=~\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -423,8 +430,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0.1,
@@ -448,7 +454,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pgpool2_pool_cache_num_hash_entries{namespace=~\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} (Total hash entries)"
                   }
                 }
               }
@@ -461,7 +467,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pgpool2_pool_cache_used_hash_entries{namespace=~\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} (Used hash entries)"
                   }
                 }
               }
@@ -481,8 +487,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0.1,
@@ -492,7 +497,7 @@
               },
               "yAxis": {
                 "format": {
-                  "unit": "bytes"
+                  "unit": "decbytes"
                 }
               }
             }
@@ -506,7 +511,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pgpool2_pool_cache_free_cache_entries_size{namespace=~\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} (Free hash entries)"
                   }
                 }
               }
@@ -519,7 +524,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pgpool2_pool_cache_used_cache_entries_size{namespace=~\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} (Used hash entries)"
                   }
                 }
               }
@@ -539,8 +544,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -559,7 +563,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pgpool2_pool_cache_num_selects{namespace=~\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -579,8 +583,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -590,7 +593,7 @@
               },
               "yAxis": {
                 "format": {
-                  "unit": "bytes"
+                  "unit": "decbytes"
                 }
               }
             }
@@ -604,7 +607,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pgpool2_pool_cache_fragment_cache_entries_size{namespace=~\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -624,8 +627,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0.1,
@@ -647,7 +649,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_health_check_stats_total_count{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }
@@ -667,8 +671,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -685,7 +688,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_frontend_used_ratio{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -705,8 +710,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -723,7 +727,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_health_check_stats_success_count{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }
@@ -743,8 +749,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -761,7 +766,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_health_check_stats_fail_count{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }
@@ -781,8 +788,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -799,7 +805,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_health_check_stats_skip_count{hostname=~\"$backend_nodes\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }
@@ -819,8 +827,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -837,7 +844,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_health_check_stats_retry_count{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }
@@ -857,8 +866,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -875,7 +883,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_health_check_stats_max_retry_count{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }
@@ -895,8 +905,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -913,7 +922,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_health_check_stats_average_retry_count{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }
@@ -933,8 +944,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -956,7 +966,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_health_check_stats_average_duration{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }
@@ -976,8 +988,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -999,7 +1010,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_health_check_stats_min_duration{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }
@@ -1019,8 +1032,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -1042,7 +1054,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_health_check_stats_max_duration{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }
@@ -1068,7 +1082,8 @@
                 "mode": "list",
                 "position": "right"
               },
-              "radius": 50
+              "radius": 50,
+              "showLabels": true
             }
           },
           "queries": [
@@ -1078,7 +1093,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "sum by (pod) (pgpool2_frontend_used{namespace=~\"$namespace\",pod=~\"$pod\"})",
+                    "seriesNameFormat": "{{ `{{pod}}` }}  (Used child process)"
                   }
                 }
               }
@@ -1089,7 +1106,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_frontend_total{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} (Total child process)"
                   }
                 }
               }
@@ -1109,8 +1128,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -1127,7 +1145,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_backend_stats_error_cnt{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }
@@ -1147,8 +1167,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -1165,7 +1184,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_backend_stats_fatal_cnt{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }
@@ -1185,8 +1206,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -1203,7 +1223,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_backend_stats_panic_cnt{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }
@@ -1223,8 +1245,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -1241,7 +1262,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_backend_stats_select_cnt{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }
@@ -1261,8 +1284,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -1279,7 +1301,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_backend_stats_delete_cnt{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }
@@ -1299,8 +1323,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0,
@@ -1317,7 +1340,9 @@
                 "plugin": {
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
-                    "query": "migration_from_grafana_not_supported"
+                    "minStep": "",
+                    "query": "pgpool2_pool_backend_stats_insert_cnt{hostname=~\"$backend_nodes\",namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }} ({{ `{{role}}` }})"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/pgpool/pgpool_pod.json
+++ b/charts/kubedb-perses-dashboards/dashboards/pgpool/pgpool_pod.json
@@ -1,4 +1,5 @@
 {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
 {
   "kind": "Dashboard",
   "metadata": {
@@ -116,9 +117,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": "pod",
               "thresholds": {
                 "steps": [
                   {
@@ -138,7 +141,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pgpool2_up{namespace=~\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -157,6 +160,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "seconds"
               },
@@ -183,7 +187,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "time() - kube_pod_start_time{namespace=~\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -202,6 +206,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -226,7 +231,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pgpool2_scrapes_total{namespace=~\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -260,7 +265,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\", image!=\"\"}[5m])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{container}}` }}"
                   }
                 }
               }
@@ -294,7 +299,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(container_memory_working_set_bytes{namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\", image!=\"\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -313,6 +318,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -340,7 +346,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pgpool2_backend_total{namespace=~\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -359,6 +365,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -386,7 +393,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by (pod) (pgpool2_backend_by_process_total{namespace=~\"$namespace\",pod=~\"$pod\"})",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -405,6 +412,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -429,7 +437,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pgpool2_backend_used{namespace=~\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -463,7 +471,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pgpool2_backend_used_ratio{namespace=~\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -482,6 +490,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -509,7 +518,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pgpool2_last_scrape_error{namespace=~\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -543,7 +552,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pgpool2_last_scrape_duration_seconds{namespace=~\"$namespace\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/pgpool/pgpool_summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/pgpool/pgpool_summary.json
@@ -91,6 +91,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
               "thresholds": {
                 "steps": [
                   {
@@ -110,7 +112,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_pgpool_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
                   }
                 }
               }
@@ -129,9 +131,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": " version ",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -157,7 +161,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_pgpool_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ version }}` }}"
                   }
                 }
               }
@@ -185,7 +189,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -206,29 +210,48 @@
               "columnSettings": [
                 {
                   "header": "Time",
-                  "name": "timestamp"
+                  "name": "timestamp",
+                  "width": "auto"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -330,7 +353,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -353,38 +376,65 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (RSS)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Cache)",
-                  "name": "Value #G"
+                  "name": "value #7"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Swap)",
-                  "name": "Value #H"
+                  "name": "value #8"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -525,7 +575,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -559,7 +609,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
                   }
                 }
               }
@@ -572,7 +622,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
                   }
                 }
               }
@@ -605,7 +655,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m])))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -638,7 +688,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -665,7 +715,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -698,7 +748,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -717,6 +767,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
+              "metricLabel": " backend ",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -742,7 +794,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_pgpool_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ backend }}` }}"
                   }
                 }
               }
@@ -761,6 +813,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -784,7 +837,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_pgpool_info{namespace=\"$namespace\", app=\"$app\", ssl!~\"^$\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ssl}}` }}"
                   }
                 }
               }
@@ -803,6 +856,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "thresholds": {
                 "steps": [
                   {
@@ -845,6 +899,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -884,6 +939,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -923,6 +979,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -965,6 +1022,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -1007,6 +1065,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1027,7 +1086,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_pgpool_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/postgres/postgres_databases_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/postgres/postgres_databases_dashboard.json
@@ -135,6 +135,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -186,7 +187,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "irate(pg_stat_database_xact_commit{pod=\"$pod\", namespace=\"$namespace\", datname=~\"$datname\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{datname}}` }} commits"
                   }
                 }
               }
@@ -199,7 +200,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "irate(pg_stat_database_xact_rollback{pod=\"$pod\", namespace=\"$namespace\", datname=~\"$datname\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{datname}}` }} rollbacks"
                   }
                 }
               }
@@ -226,7 +227,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "irate(pg_stat_bgwriter_buffers_backend{pod=\"$pod\", namespace=\"$namespace\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "buffers_backend"
                   }
                 }
               }
@@ -239,7 +240,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "irate(pg_stat_bgwriter_buffers_alloc{pod=\"$pod\", namespace=\"$namespace\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "buffers_alloc"
                   }
                 }
               }
@@ -252,7 +253,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "irate(pg_stat_bgwriter_buffers_backend_fsync{pod=\"$pod\", namespace=\"$namespace\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "backend_fsync"
                   }
                 }
               }
@@ -265,7 +266,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "irate(pg_stat_bgwriter_buffers_checkpoint{pod=\"$pod\", namespace=\"$namespace\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "buffers_checkpoint"
                   }
                 }
               }
@@ -278,7 +279,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "irate(pg_stat_bgwriter_buffers_clean{pod=\"$pod\", namespace=\"$namespace\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "buffers_clean"
                   }
                 }
               }
@@ -305,7 +306,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "irate(pg_stat_database_conflicts{pod=\"$pod\", namespace=\"$namespace\", datname=~\"$datname\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{datname}}` }} conflicts"
                   }
                 }
               }
@@ -318,7 +319,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "irate(pg_stat_database_deadlocks{pod=\"$pod\", namespace=\"$namespace\", datname=~\"$datname\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{datname}}` }} deadlocks"
                   }
                 }
               }
@@ -345,7 +346,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pg_stat_database_blks_hit{pod=\"$pod\", namespace=\"$namespace\", datname=~\"$datname\"} / (pg_stat_database_blks_read{pod=\"$pod\", namespace=\"$namespace\", datname=~\"$datname\"} + pg_stat_database_blks_hit{pod=\"$pod\", namespace=\"$namespace\", datname=~\"$datname\"})",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ datname }}` }}"
                   }
                 }
               }
@@ -373,7 +374,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "irate(pg_stat_database_temp_bytes{pod=\"$pod\", namespace=\"$namespace\", datname=~\"$datname\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{datname}}` }}"
                   }
                 }
               }
@@ -537,7 +538,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pg_stat_database_tup_updated{datname=~\"$datname\", pod=\"$pod\", namespace=\"$namespace\"} != 0",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{datname}}` }}"
                   }
                 }
               }
@@ -564,7 +565,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pg_stat_activity_count{datname=~\"$datname\", pod=\"$pod\", namespace=\"$namespace\"} !=0",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{datname}}` }}, s: {{ `{{state}}` }}"
                   }
                 }
               }
@@ -591,7 +592,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pg_stat_database_tup_inserted{datname=~\"$datname\", pod=\"$pod\", namespace=\"$namespace\"} != 0",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{datname}}` }}"
                   }
                 }
               }
@@ -618,7 +619,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pg_locks_count{datname=~\"$datname\", pod=\"$pod\", namespace=\"$namespace\"} != 0",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{datname}}` }},{{ `{{mode}}` }}"
                   }
                 }
               }
@@ -645,7 +646,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pg_stat_database_tup_fetched{datname=~\"$datname\",pod=\"$pod\", namespace=\"$namespace\"} != 0",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{datname}}` }}"
                   }
                 }
               }
@@ -672,7 +673,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pg_stat_activity_count{datname=~\"$datname\", pod=\"$pod\", namespace=\"$namespace\", state=~\"idle|idle in transaction|idle in transaction (aborted)\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{datname}}` }}, s: {{ `{{state}}` }}"
                   }
                 }
               }
@@ -699,7 +700,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pg_stat_database_tup_deleted{datname=~\"$datname\", pod=\"$pod\", namespace=\"$namespace\"} != 0",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{datname}}` }}"
                   }
                 }
               }
@@ -726,7 +727,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pg_stat_database_tup_returned{datname=~\"$datname\",pod=\"$pod\", namespace=\"$namespace\"} != 0",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{datname}}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/postgres/postgres_pods_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/postgres/postgres_pods_dashboard.json
@@ -1,4 +1,5 @@
 {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
 {
   "kind": "Dashboard",
   "metadata": {
@@ -111,6 +112,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
@@ -152,6 +154,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -192,6 +195,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -236,6 +240,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -280,6 +285,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -324,6 +330,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -368,6 +375,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "decimalPlaces": 1,
                 "unit": "bytes"
@@ -413,6 +421,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
@@ -457,6 +466,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
@@ -501,6 +511,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
@@ -546,6 +557,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "thresholds": {
                 "steps": [
                   {
@@ -583,8 +595,9 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
-                "unit": "bytes"
+                "unit": "decbytes"
               },
               "thresholds": {
                 "steps": [
@@ -623,8 +636,9 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
-                "unit": "bytes"
+                "unit": "decbytes"
               },
               "thresholds": {
                 "steps": [
@@ -663,8 +677,9 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
-                "unit": "bytes"
+                "unit": "decbytes"
               },
               "thresholds": {
                 "steps": [
@@ -703,6 +718,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
@@ -754,19 +770,6 @@
                     "minStep": "",
                     "query": "avg(rate(process_cpu_seconds_total{pod=\"$pod\", namespace=\"$namespace\"}[5m]) * 1000)",
                     "seriesNameFormat": "CPU Time"
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "",
-                    "seriesNameFormat": ""
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/postgres/postgres_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/postgres/postgres_summary_dashboard.json
@@ -89,6 +89,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
@@ -112,7 +113,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_postgres_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{version}}` }}"
                   }
                 }
               }
@@ -131,6 +132,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "seconds"
               },
@@ -173,6 +175,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -215,6 +218,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -269,7 +273,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "AVG(rate(pg_stat_replication_reply_time{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -303,7 +307,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(pg_stat_activity_count{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"}) by (state)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{state}}` }}"
                   }
                 }
               }
@@ -337,7 +341,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "pg_stat_replication_pg_wal_lsn_diff{namespace=\"$namespace\",application_name=~\"$app-\\\\d+$\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{application_name}}` }}"
                   }
                 }
               }
@@ -357,8 +361,7 @@
             "spec": {
               "legend": {
                 "mode": "list",
-                "position": "bottom",
-                "values": []
+                "position": "bottom"
               },
               "visual": {
                 "areaOpacity": 0.1,
@@ -416,7 +419,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -440,26 +443,44 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -566,7 +587,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -589,38 +610,65 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (RSS)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Cache)",
-                  "name": "Value #G"
+                  "name": "value #7"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Swap)",
-                  "name": "Value #H"
+                  "name": "value #8"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -746,6 +794,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "thresholds": {
                 "steps": [
                   {
@@ -808,7 +857,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -847,7 +896,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
                   }
                 }
               }
@@ -860,7 +909,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
                   }
                 }
               }
@@ -898,7 +947,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m])))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -936,7 +985,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -959,30 +1008,51 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads)",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Writes)",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads + Writes)",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read)",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Write)",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read + Write)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
                 }
@@ -1126,7 +1196,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1161,7 +1231,7 @@
               },
               "yAxis": {
                 "format": {
-                  "unit": "bytes"
+                  "unit": "decbytes"
                 },
                 "max": 5000,
                 "min": 0
@@ -1177,7 +1247,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1215,7 +1285,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1253,7 +1323,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1272,6 +1342,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1292,7 +1364,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_postgres_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
                   }
                 }
               }
@@ -1311,6 +1383,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1331,7 +1404,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_postgres_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{sslMode}}` }}"
                   }
                 }
               }
@@ -1350,6 +1423,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1370,7 +1444,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_postgres_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
                   }
                 }
               }
@@ -1389,6 +1463,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1428,6 +1503,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -1467,6 +1543,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -1509,6 +1586,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },

--- a/charts/kubedb-perses-dashboards/dashboards/proxysql/proxysql-database.json
+++ b/charts/kubedb-perses-dashboards/dashboards/proxysql/proxysql-database.json
@@ -81,7 +81,7 @@
       }
     ],
     "panels": {
-      "0_0": {
+      "0": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -102,7 +102,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "proxysql_uptime_seconds_total{namespace=~\"$namespace\",service=~\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -110,7 +110,7 @@
           ]
         }
       },
-      "0_1": {
+      "1": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -131,7 +131,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "proxysql_uptime_seconds_total{namespace=~\"$namespace\",service=~\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -139,850 +139,7 @@
           ]
         }
       },
-      "10_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Client Active"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_stmt_client_active{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "10_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Unique Client Active"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_stmt_client_active_unique{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "10_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Server Active"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_stmt_server_active{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "10_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Unique Server Active"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_stmt_server_active_unique{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "10_4": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Max STMT ID"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_stmt_max_stmt_id{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "10_5": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Cached STMT"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_stmt_cached{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "10_6": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Total Backend STMT"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "sum(rate(proxysql_com_backend_stmt_total{namespace=~\"$namespace\",service=\"$app\"}[1m])) by(op)",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "10_7": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Total Frontend STMT"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "sum(rate(proxysql_com_frontend_stmt_total{namespace=~\"$namespace\",service=\"$app\"}[1m])) by(op)",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "11_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Users Table (bytes)"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_mysql_firewall_users_table_bytes{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "11_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Users Config (bytes)"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_mysql_firewall_users_config_bytes{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "11_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Rules Table (bytes)"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_mysql_firewall_rules_table_bytes{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "11_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Rules Config (bytes)"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_mysql_firewall_rules_config_bytes{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "12_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Connect Checks (ok)"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_mysql_monitor_connect_check_total{namespace=~\"$namespace\",service=\"$app\",status=\"ok\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "12_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Connect Checks (err)"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_mysql_monitor_connect_check_total{namespace=~\"$namespace\",service=\"$app\",status=\"err\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "12_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Read-Only Check (ok)"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_mysql_monitor_read_only_check_total{namespace=~\"$namespace\",service=\"$app\",status=\"ok\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "12_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Read-Only Check (err)"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_mysql_monitor_read_only_check_total{namespace=~\"$namespace\",service=\"$app\",status=\"err\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "12_4": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Replication-Lag Checks (ok)"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_mysql_monitor_replication_lag_check_total{namespace=~\"$namespace\",service=\"$app\",status=\"ok\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "12_5": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Replication-Lag Checks (err)"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_mysql_monitor_replication_lag_check_total{namespace=~\"$namespace\",service=\"$app\",status=\"err\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "12_6": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Ping Checks (err)"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_mysql_monitor_ping_check_total{namespace=~\"$namespace\",service=\"$app\",status=\"err\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "12_7": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Ping Checks (ok)"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_mysql_monitor_ping_check_total{namespace=~\"$namespace\",service=\"$app\",status=\"ok\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "1_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "ProxySQL Connections"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "sum(rate(proxysql_connpool_conns{status=\"free\",namespace=~\"$namespace\",service=~\"$app\"}[1m]) ) by(pod)",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "sum(rate(proxysql_connpool_conns{status=\"used\",namespace=~\"$namespace\",service=~\"$app\"}[1m]) ) by(pod)",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "1_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "ProxySQL network received vs sent"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_queries_frontends_bytes_total{traffic_flow=\"received\",namespace=~\"$namespace\",service=~\"$app\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_queries_frontends_bytes_total{traffic_flow=\"sent\",namespace=~\"$namespace\",service=~\"$app\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "1_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "ProxySQL Slow Queries"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_slow_queries_total{namespace=~\"$namespace\",service=~\"$app\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "1_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "ProxySQL Aborted Connections"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_server_connections_total{namespace=~\"$namespace\",service=~\"$app\",status=\"aborted\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_server_connections_total{namespace=~\"$namespace\",service=~\"$app\",status=\"aborted\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Total Questions"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_questions_total{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Slow Queries"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_slow_queries_total{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "GTID Session Collected"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_gtid_session_collected_total{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "GTID Consistent Queries"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_gtid_consistent_queries_total{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_4": {
+      "10": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1001,7 +158,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_generated_error_packets_total{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1009,7 +166,7 @@
           ]
         }
       },
-      "2_5": {
+      "11": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1028,7 +185,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_backend_lagging_during_query_total{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1036,7 +193,7 @@
           ]
         }
       },
-      "2_6": {
+      "12": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1055,7 +212,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_backend_offline_during_query_total{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1063,7 +220,7 @@
           ]
         }
       },
-      "3_0": {
+      "13": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1082,7 +239,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_query_cache_count_get_total{namespace=~\"$namespace\",service=\"$app\"}[5m]) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}:{{ `{{status}}` }}"
                   }
                 }
               }
@@ -1090,7 +247,7 @@
           ]
         }
       },
-      "3_1": {
+      "14": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1109,7 +266,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_query_cache_count_set_total{namespace=~\"$namespace\",service=\"$app\"}[5m]) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}:{{ `{{status}}` }}"
                   }
                 }
               }
@@ -1117,7 +274,7 @@
           ]
         }
       },
-      "3_2": {
+      "15": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1136,7 +293,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_query_cache_bytes_total{namespace=~\"$namespace\",service=\"$app\"}[5m]) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}:{{ `{{op}}` }}"
                   }
                 }
               }
@@ -1144,7 +301,7 @@
           ]
         }
       },
-      "3_3": {
+      "16": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1163,7 +320,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_query_cache_memory_bytes{namespace=~\"$namespace\",service=\"$app\"}[5m]) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}:{{ `{{op}}` }}"
                   }
                 }
               }
@@ -1171,7 +328,7 @@
           ]
         }
       },
-      "3_4": {
+      "17": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1190,7 +347,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_query_cache_entries_total{namespace=~\"$namespace\",service=\"$app\"}[5m]) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}:{{ `{{op}}` }}"
                   }
                 }
               }
@@ -1198,7 +355,7 @@
           ]
         }
       },
-      "3_5": {
+      "18": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1217,7 +374,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_query_cache_purged_total{namespace=~\"$namespace\",service=\"$app\"}[5m]) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1225,7 +382,7 @@
           ]
         }
       },
-      "4_0": {
+      "19": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1244,7 +401,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_mysql_unexpected_frontend_com_quit_total{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1252,7 +409,47 @@
           ]
         }
       },
-      "4_1": {
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ProxySQL Connections"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(proxysql_connpool_conns{status=\"free\",namespace=~\"$namespace\",service=~\"$app\"}[1m]) ) by(pod)",
+                    "seriesNameFormat": "Free_connecntions - {{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(proxysql_connpool_conns{status=\"used\",namespace=~\"$namespace\",service=~\"$app\"}[1m]) ) by(pod)",
+                    "seriesNameFormat": "Used_connections - {{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1271,7 +468,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_mysql_unexpected_frontend_packets_total{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1279,7 +476,7 @@
           ]
         }
       },
-      "4_2": {
+      "21": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1298,7 +495,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_automatic_detected_sql_injection_total{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1306,7 +503,7 @@
           ]
         }
       },
-      "5_0": {
+      "22": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1325,7 +522,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(proxysql_cluster_pulled_total{namespace=~\"$namespace\",service=\"$app\",module_name=~\"mysql_variables|admin_variables|proxysql_servers|mysql_servers\"}[1m])) by(module_name,status)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{module_name}}` }} : {{ `{{status}}` }}"
                   }
                 }
               }
@@ -1333,7 +530,7 @@
           ]
         }
       },
-      "5_1": {
+      "23": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1352,7 +549,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(proxysql_cluster_syn_conflict_total{namespace=~\"$namespace\",service=\"$app\",module_name=~\"mysql_variables|admin_variables|proxysql_servers|mysql_servers\"}[1m])) by(module_name)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{module_name}}` }}"
                   }
                 }
               }
@@ -1360,7 +557,7 @@
           ]
         }
       },
-      "6_0": {
+      "24": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1379,7 +576,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(proxysql_server_connections_total{namespace=~\"$namespace\",service=\"$app\"}[1m])) by(status)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{status}}` }}"
                   }
                 }
               }
@@ -1387,7 +584,7 @@
           ]
         }
       },
-      "6_1": {
+      "25": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1406,7 +603,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(proxysql_client_connections_total{namespace=~\"$namespace\",service=\"$app\"}[1m])) by(status)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{status}}` }}"
                   }
                 }
               }
@@ -1414,271 +611,7 @@
           ]
         }
       },
-      "6_10": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Active Transactions"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "proxysql_active_transactions{namespace=~\"$namespace\",service=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "6_11": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Client Connection Non Idle"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "proxysql_client_connections_non_idle{namespace=~\"$namespace\",service=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "6_12": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL Thread Workers"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "proxysql_mysql_thread_workers{namespace=~\"$namespace\",service=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "6_13": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL Session Internal Bytes"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_mysql_session_internal_bytes{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "6_14": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "MySQL Session Internal Bytes"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_connpool_memory_bytes{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "6_15": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Connection Pool Data Bytes"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "sum(rate(proxysql_connpool_data_bytes_total{namespace=~\"$namespace\",service=\"$app\"}[1m])) by(hostgroup,traffic_flow)",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "6_16": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "HG Connection Pool Connections"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "sum(rate(proxysql_connpool_conns_total{namespace=~\"$namespace\",service=\"$app\"}[1m])) by(hostgroup)",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "6_17": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "HG Connection Queries "
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "sum(rate(proxysql_connpool_conns_queries_total{namespace=~\"$namespace\",service=\"$app\"}[1m])) by(hostgroup)",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "6_2": {
+      "26": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1697,7 +630,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_server_connections_connected{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1705,7 +638,7 @@
           ]
         }
       },
-      "6_3": {
+      "27": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1724,7 +657,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_client_connections_connected{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1732,7 +665,7 @@
           ]
         }
       },
-      "6_4": {
+      "28": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1751,7 +684,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "proxysql_connpool_conns_latency_us{namespace=~\"$namespace\",service=\"$app\",hostgroup=\"3\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}:{{ `{{endpoint}}` }}"
                   }
                 }
               }
@@ -1759,7 +692,7 @@
           ]
         }
       },
-      "6_5": {
+      "29": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1778,7 +711,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "proxysql_connpool_conns_latency_us{namespace=~\"$namespace\",service=\"$app\",hostgroup=\"2\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1786,7 +719,47 @@
           ]
         }
       },
-      "6_6": {
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ProxySQL network received vs sent"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_queries_frontends_bytes_total{traffic_flow=\"received\",namespace=~\"$namespace\",service=~\"$app\"}[5m])",
+                    "seriesNameFormat": "received - {{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_queries_frontends_bytes_total{traffic_flow=\"sent\",namespace=~\"$namespace\",service=~\"$app\"}[5m])",
+                    "seriesNameFormat": "sent - {{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "30": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1811,7 +784,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "proxysql_connpool_conns_status{namespace=~\"$namespace\",service=\"$app\",hostgroup=\"3\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} : {{ `{{endpoint}}` }}"
                   }
                 }
               }
@@ -1819,7 +792,7 @@
           ]
         }
       },
-      "6_7": {
+      "31": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1844,7 +817,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "proxysql_connpool_conns_status{namespace=~\"$namespace\",service=\"$app\",hostgroup=\"2\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} : {{ `{{endpoint}}` }}"
                   }
                 }
               }
@@ -1852,7 +825,7 @@
           ]
         }
       },
-      "6_8": {
+      "32": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1877,7 +850,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(proxysql_connpool_conns{namespace=~\"$namespace\",service=\"$app\",hostgroup=\"3\"}) by(status,pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} : {{ `{{status}}` }}"
                   }
                 }
               }
@@ -1885,7 +858,7 @@
           ]
         }
       },
-      "6_9": {
+      "33": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1910,7 +883,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(proxysql_connpool_conns{namespace=~\"$namespace\",service=\"$app\",hostgroup=\"2\"}) by(status,pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} : {{ `{{status}}` }}"
                   }
                 }
               }
@@ -1918,7 +891,298 @@
           ]
         }
       },
-      "7_0": {
+      "34": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Active Transactions"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "proxysql_active_transactions{namespace=~\"$namespace\",service=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "35": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Client Connection Non Idle"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "proxysql_client_connections_non_idle{namespace=~\"$namespace\",service=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "36": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL Thread Workers"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "proxysql_mysql_thread_workers{namespace=~\"$namespace\",service=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "37": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL Session Internal Bytes"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_mysql_session_internal_bytes{namespace=~\"$namespace\",service=\"$app\"}[1m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "38": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "MySQL Session Internal Bytes"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_connpool_memory_bytes{namespace=~\"$namespace\",service=\"$app\"}[1m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "39": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Connection Pool Data Bytes"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(proxysql_connpool_data_bytes_total{namespace=~\"$namespace\",service=\"$app\"}[1m])) by(hostgroup,traffic_flow)",
+                    "seriesNameFormat": "HG {{ `{{hostgroup}}` }} : Data {{ `{{traffic_flow}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ProxySQL Slow Queries"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_slow_queries_total{namespace=~\"$namespace\",service=~\"$app\"}[1m])",
+                    "seriesNameFormat": "Slow Queries on {{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "40": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "HG Connection Pool Connections"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(proxysql_connpool_conns_total{namespace=~\"$namespace\",service=\"$app\"}[1m])) by(hostgroup)",
+                    "seriesNameFormat": "HG {{ `{{hostgroup}}` }} "
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "41": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "HG Connection Queries "
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(proxysql_connpool_conns_queries_total{namespace=~\"$namespace\",service=\"$app\"}[1m])) by(hostgroup)",
+                    "seriesNameFormat": "HG {{ `{{hostgroup}}` }} "
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "42": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1937,7 +1201,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_myhgm_myconnpool_get_total{namespace=~\"$namespace\",service=\"$app\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1945,7 +1209,7 @@
           ]
         }
       },
-      "7_1": {
+      "43": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1964,7 +1228,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_myhgm_myconnpool_get_ok_total{namespace=~\"$namespace\",service=\"$app\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1972,7 +1236,7 @@
           ]
         }
       },
-      "7_2": {
+      "44": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1991,7 +1255,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_myhgm_myconnpool_get_ping_total{namespace=~\"$namespace\",service=\"$app\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1999,7 +1263,7 @@
           ]
         }
       },
-      "7_3": {
+      "45": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2018,7 +1282,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_myhgm_myconnpool_push_total{namespace=~\"$namespace\",service=\"$app\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -2026,7 +1290,7 @@
           ]
         }
       },
-      "7_4": {
+      "46": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2045,7 +1309,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_myhgm_myconnpool_reset_total{namespace=~\"$namespace\",service=\"$app\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -2053,7 +1317,7 @@
           ]
         }
       },
-      "7_5": {
+      "47": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2072,7 +1336,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_myhgm_myconnpool_destroy_total{namespace=~\"$namespace\",service=\"$app\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -2080,7 +1344,7 @@
           ]
         }
       },
-      "7_6": {
+      "48": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2099,7 +1363,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_myhgm_auto_increment_multiplex_total{namespace=~\"$namespace\",service=\"$app\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -2107,7 +1371,7 @@
           ]
         }
       },
-      "8_0": {
+      "49": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2126,7 +1390,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_access_denied_wrong_password_total{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -2134,7 +1398,47 @@
           ]
         }
       },
-      "8_1": {
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ProxySQL Aborted Connections"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_server_connections_total{namespace=~\"$namespace\",service=~\"$app\",status=\"aborted\"}[5m])",
+                    "seriesNameFormat": "Aborted Connects (attempts) on - {{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_server_connections_total{namespace=~\"$namespace\",service=~\"$app\",status=\"aborted\"}[5m])",
+                    "seriesNameFormat": "Aborted Clients (timeout) on - {{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "50": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2153,7 +1457,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_access_denied_max_connections_total{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -2161,7 +1465,7 @@
           ]
         }
       },
-      "8_2": {
+      "51": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2180,7 +1484,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_access_denied_max_user_connections_total{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -2188,7 +1492,7 @@
           ]
         }
       },
-      "9_0": {
+      "52": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2207,7 +1511,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_stack_memory_mysql_threads_bytes{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -2215,7 +1519,7 @@
           ]
         }
       },
-      "9_1": {
+      "53": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2234,7 +1538,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_stack_memory_admin_threads_bytes{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -2242,7 +1546,7 @@
           ]
         }
       },
-      "9_2": {
+      "54": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2261,7 +1565,703 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_stack_memory_cluster_threads{namespace=~\"$namespace\",service=\"$app\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "55": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Client Active"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_stmt_client_active{namespace=~\"$namespace\",service=\"$app\"}[1m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "56": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Unique Client Active"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_stmt_client_active_unique{namespace=~\"$namespace\",service=\"$app\"}[1m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "57": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Server Active"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_stmt_server_active{namespace=~\"$namespace\",service=\"$app\"}[1m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "58": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Unique Server Active"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_stmt_server_active_unique{namespace=~\"$namespace\",service=\"$app\"}[1m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "59": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Max STMT ID"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_stmt_max_stmt_id{namespace=~\"$namespace\",service=\"$app\"}[1m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Questions"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_questions_total{namespace=~\"$namespace\",service=\"$app\"}[1m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "60": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cached STMT"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_stmt_cached{namespace=~\"$namespace\",service=\"$app\"}[1m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "61": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Backend STMT"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(proxysql_com_backend_stmt_total{namespace=~\"$namespace\",service=\"$app\"}[1m])) by(op)",
+                    "seriesNameFormat": "{{ `{{op}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "62": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Frontend STMT"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(proxysql_com_frontend_stmt_total{namespace=~\"$namespace\",service=\"$app\"}[1m])) by(op)",
+                    "seriesNameFormat": "{{ `{{op}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "63": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Users Table (bytes)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_mysql_firewall_users_table_bytes{namespace=~\"$namespace\",service=\"$app\"}[1m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "64": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Users Config (bytes)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_mysql_firewall_users_config_bytes{namespace=~\"$namespace\",service=\"$app\"}[1m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "65": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Rules Table (bytes)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_mysql_firewall_rules_table_bytes{namespace=~\"$namespace\",service=\"$app\"}[1m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "66": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Rules Config (bytes)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_mysql_firewall_rules_config_bytes{namespace=~\"$namespace\",service=\"$app\"}[1m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "67": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Connect Checks (ok)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_mysql_monitor_connect_check_total{namespace=~\"$namespace\",service=\"$app\",status=\"ok\"}[5m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "68": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Connect Checks (err)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_mysql_monitor_connect_check_total{namespace=~\"$namespace\",service=\"$app\",status=\"err\"}[5m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "69": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Read-Only Check (ok)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_mysql_monitor_read_only_check_total{namespace=~\"$namespace\",service=\"$app\",status=\"ok\"}[5m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Slow Queries"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_slow_queries_total{namespace=~\"$namespace\",service=\"$app\"}[1m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "70": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Read-Only Check (err)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_mysql_monitor_read_only_check_total{namespace=~\"$namespace\",service=\"$app\",status=\"err\"}[5m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "71": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Replication-Lag Checks (ok)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_mysql_monitor_replication_lag_check_total{namespace=~\"$namespace\",service=\"$app\",status=\"ok\"}[5m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }} "
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "72": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Replication-Lag Checks (err)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_mysql_monitor_replication_lag_check_total{namespace=~\"$namespace\",service=\"$app\",status=\"err\"}[5m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }} "
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "73": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Ping Checks (err)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_mysql_monitor_ping_check_total{namespace=~\"$namespace\",service=\"$app\",status=\"err\"}[5m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "74": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Ping Checks (ok)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_mysql_monitor_ping_check_total{namespace=~\"$namespace\",service=\"$app\",status=\"ok\"}[5m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "GTID Session Collected"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_gtid_session_collected_total{namespace=~\"$namespace\",service=\"$app\"}[1m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "GTID Consistent Queries"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_gtid_consistent_queries_total{namespace=~\"$namespace\",service=\"$app\"}[1m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -2275,10 +2275,7 @@
         "kind": "Grid",
         "spec": {
           "display": {
-            "title": "Service Status",
-            "collapse": {
-              "open": false
-            }
+            "title": "Panel Group 1"
           },
           "items": [
             {
@@ -2287,7 +2284,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/0_0"
+                "$ref": "#/spec/panels/0"
               }
             },
             {
@@ -2296,29 +2293,16 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/0_1"
+                "$ref": "#/spec/panels/1"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Proxy Network",
-            "collapse": {
-              "open": false
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 9,
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/1_0"
+                "$ref": "#/spec/panels/2"
               }
             },
             {
@@ -2327,7 +2311,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/1_1"
+                "$ref": "#/spec/panels/3"
               }
             },
             {
@@ -2336,7 +2320,7 @@
               "width": 12,
               "height": 11,
               "content": {
-                "$ref": "#/spec/panels/1_2"
+                "$ref": "#/spec/panels/4"
               }
             },
             {
@@ -2345,29 +2329,16 @@
               "width": 12,
               "height": 11,
               "content": {
-                "$ref": "#/spec/panels/1_3"
+                "$ref": "#/spec/panels/5"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Query Stats",
-            "collapse": {
-              "open": false
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 30,
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_0"
+                "$ref": "#/spec/panels/6"
               }
             },
             {
@@ -2376,7 +2347,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_1"
+                "$ref": "#/spec/panels/7"
               }
             },
             {
@@ -2385,7 +2356,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_2"
+                "$ref": "#/spec/panels/8"
               }
             },
             {
@@ -2394,7 +2365,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_3"
+                "$ref": "#/spec/panels/9"
               }
             },
             {
@@ -2403,7 +2374,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_4"
+                "$ref": "#/spec/panels/10"
               }
             },
             {
@@ -2412,7 +2383,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_5"
+                "$ref": "#/spec/panels/11"
               }
             },
             {
@@ -2421,29 +2392,16 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_6"
+                "$ref": "#/spec/panels/12"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Query Cache",
-            "collapse": {
-              "open": false
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 4,
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/3_0"
+                "$ref": "#/spec/panels/13"
               }
             },
             {
@@ -2452,7 +2410,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/3_1"
+                "$ref": "#/spec/panels/14"
               }
             },
             {
@@ -2461,7 +2419,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/3_2"
+                "$ref": "#/spec/panels/15"
               }
             },
             {
@@ -2470,7 +2428,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/3_3"
+                "$ref": "#/spec/panels/16"
               }
             },
             {
@@ -2479,7 +2437,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/3_4"
+                "$ref": "#/spec/panels/17"
               }
             },
             {
@@ -2488,29 +2446,16 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/3_5"
+                "$ref": "#/spec/panels/18"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Unexpected Queries",
-            "collapse": {
-              "open": false
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 5,
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/4_0"
+                "$ref": "#/spec/panels/19"
               }
             },
             {
@@ -2519,7 +2464,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/4_1"
+                "$ref": "#/spec/panels/20"
               }
             },
             {
@@ -2528,29 +2473,16 @@
               "width": 24,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/4_2"
+                "$ref": "#/spec/panels/21"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Cluster Synchronization ",
-            "collapse": {
-              "open": false
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 6,
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/5_0"
+                "$ref": "#/spec/panels/22"
               }
             },
             {
@@ -2559,29 +2491,16 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/5_1"
+                "$ref": "#/spec/panels/23"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Connection Pool Stats",
-            "collapse": {
-              "open": false
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 7,
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/6_0"
+                "$ref": "#/spec/panels/24"
               }
             },
             {
@@ -2590,7 +2509,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/6_1"
+                "$ref": "#/spec/panels/25"
               }
             },
             {
@@ -2599,7 +2518,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/6_2"
+                "$ref": "#/spec/panels/26"
               }
             },
             {
@@ -2608,7 +2527,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/6_3"
+                "$ref": "#/spec/panels/27"
               }
             },
             {
@@ -2617,7 +2536,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/6_4"
+                "$ref": "#/spec/panels/28"
               }
             },
             {
@@ -2626,7 +2545,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/6_5"
+                "$ref": "#/spec/panels/29"
               }
             },
             {
@@ -2635,7 +2554,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/6_6"
+                "$ref": "#/spec/panels/30"
               }
             },
             {
@@ -2644,7 +2563,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/6_7"
+                "$ref": "#/spec/panels/31"
               }
             },
             {
@@ -2653,7 +2572,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/6_8"
+                "$ref": "#/spec/panels/32"
               }
             },
             {
@@ -2662,7 +2581,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/6_9"
+                "$ref": "#/spec/panels/33"
               }
             },
             {
@@ -2671,7 +2590,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/6_10"
+                "$ref": "#/spec/panels/34"
               }
             },
             {
@@ -2680,7 +2599,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/6_11"
+                "$ref": "#/spec/panels/35"
               }
             },
             {
@@ -2689,7 +2608,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/6_12"
+                "$ref": "#/spec/panels/36"
               }
             },
             {
@@ -2698,7 +2617,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/6_13"
+                "$ref": "#/spec/panels/37"
               }
             },
             {
@@ -2707,7 +2626,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/6_14"
+                "$ref": "#/spec/panels/38"
               }
             },
             {
@@ -2716,7 +2635,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/6_15"
+                "$ref": "#/spec/panels/39"
               }
             },
             {
@@ -2725,7 +2644,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/6_16"
+                "$ref": "#/spec/panels/40"
               }
             },
             {
@@ -2734,29 +2653,16 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/6_17"
+                "$ref": "#/spec/panels/41"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Myhgm Connection Pool",
-            "collapse": {
-              "open": false
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 8,
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7_0"
+                "$ref": "#/spec/panels/42"
               }
             },
             {
@@ -2765,7 +2671,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7_1"
+                "$ref": "#/spec/panels/43"
               }
             },
             {
@@ -2774,7 +2680,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7_2"
+                "$ref": "#/spec/panels/44"
               }
             },
             {
@@ -2783,7 +2689,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7_3"
+                "$ref": "#/spec/panels/45"
               }
             },
             {
@@ -2792,7 +2698,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7_4"
+                "$ref": "#/spec/panels/46"
               }
             },
             {
@@ -2801,7 +2707,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7_5"
+                "$ref": "#/spec/panels/47"
               }
             },
             {
@@ -2810,29 +2716,16 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7_6"
+                "$ref": "#/spec/panels/48"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Access Denial",
-            "collapse": {
-              "open": false
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 9,
               "width": 10,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/8_0"
+                "$ref": "#/spec/panels/49"
               }
             },
             {
@@ -2841,7 +2734,7 @@
               "width": 7,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/8_1"
+                "$ref": "#/spec/panels/50"
               }
             },
             {
@@ -2850,29 +2743,16 @@
               "width": 7,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/8_2"
+                "$ref": "#/spec/panels/51"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Stack Memory Stats",
-            "collapse": {
-              "open": false
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 18,
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/9_0"
+                "$ref": "#/spec/panels/52"
               }
             },
             {
@@ -2881,7 +2761,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/9_1"
+                "$ref": "#/spec/panels/53"
               }
             },
             {
@@ -2890,29 +2770,16 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/9_2"
+                "$ref": "#/spec/panels/54"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "STMT Stats",
-            "collapse": {
-              "open": false
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 35,
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/10_0"
+                "$ref": "#/spec/panels/55"
               }
             },
             {
@@ -2921,7 +2788,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/10_1"
+                "$ref": "#/spec/panels/56"
               }
             },
             {
@@ -2930,7 +2797,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/10_2"
+                "$ref": "#/spec/panels/57"
               }
             },
             {
@@ -2939,7 +2806,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/10_3"
+                "$ref": "#/spec/panels/58"
               }
             },
             {
@@ -2948,7 +2815,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/10_4"
+                "$ref": "#/spec/panels/59"
               }
             },
             {
@@ -2957,7 +2824,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/10_5"
+                "$ref": "#/spec/panels/60"
               }
             },
             {
@@ -2966,7 +2833,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/10_6"
+                "$ref": "#/spec/panels/61"
               }
             },
             {
@@ -2975,29 +2842,16 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/10_7"
+                "$ref": "#/spec/panels/62"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Firewall Stats",
-            "collapse": {
-              "open": false
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 12,
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/11_0"
+                "$ref": "#/spec/panels/63"
               }
             },
             {
@@ -3006,7 +2860,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/11_1"
+                "$ref": "#/spec/panels/64"
               }
             },
             {
@@ -3015,7 +2869,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/11_2"
+                "$ref": "#/spec/panels/65"
               }
             },
             {
@@ -3024,29 +2878,16 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/11_3"
+                "$ref": "#/spec/panels/66"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Backend Monitoring Stats",
-            "collapse": {
-              "open": false
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 13,
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/12_0"
+                "$ref": "#/spec/panels/67"
               }
             },
             {
@@ -3055,7 +2896,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/12_1"
+                "$ref": "#/spec/panels/68"
               }
             },
             {
@@ -3064,7 +2905,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/12_2"
+                "$ref": "#/spec/panels/69"
               }
             },
             {
@@ -3073,7 +2914,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/12_3"
+                "$ref": "#/spec/panels/70"
               }
             },
             {
@@ -3082,7 +2923,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/12_4"
+                "$ref": "#/spec/panels/71"
               }
             },
             {
@@ -3091,7 +2932,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/12_5"
+                "$ref": "#/spec/panels/72"
               }
             },
             {
@@ -3100,7 +2941,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/12_6"
+                "$ref": "#/spec/panels/73"
               }
             },
             {
@@ -3109,7 +2950,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/12_7"
+                "$ref": "#/spec/panels/74"
               }
             }
           ]

--- a/charts/kubedb-perses-dashboards/dashboards/proxysql/proxysql-pod.json
+++ b/charts/kubedb-perses-dashboards/dashboards/proxysql/proxysql-pod.json
@@ -1,4 +1,5 @@
 {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
 {
   "kind": "Dashboard",
   "metadata": {
@@ -105,7 +106,7 @@
       }
     ],
     "panels": {
-      "0_0": {
+      "0": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -115,9 +116,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": "pod}} ",
               "thresholds": {
                 "steps": [
                   {
@@ -137,7 +140,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "proxysql_uptime_seconds_total{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }} "
                   }
                 }
               }
@@ -145,7 +148,7 @@
           ]
         }
       },
-      "0_1": {
+      "1": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -155,6 +158,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -181,7 +185,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "proxysql_uptime_seconds_total{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -189,268 +193,7 @@
           ]
         }
       },
-      "1_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "CPU Usage"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\", image!=\"\"}[5m])) by (pod)",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "1_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Memory Usage"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "bytes"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "sum(container_memory_working_set_bytes{namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\", image!=\"\"}) by (pod)",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "ProxySQL Connections"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "proxysql_connpool_conns{status=\"used\",namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "proxysql_connpool_conns{status=\"free\",namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "ProxySQL Aborted Connections"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "proxysql_server_connections_total{ status=\"aborted\",namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "ProxySQL Slow Queries"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "proxysql_slow_queries_total{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "4_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "ProxySQL Questions"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_questions_total{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "ProxySQL Network Traffic",
-            "description": "\n\nHere we can see how much network traffic is generated by MySQL. Outbound is network traffic sent from MySQL and Inbound is network traffic MySQL has received."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_connpool_data_bytes_total{traffic_flow=\"recv\",namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_connpool_data_bytes_total{traffic_flow=\"sent\",namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "6_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "ProxySQL Query Cache Memory"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "bytes"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(proxysql_query_cache_memory_bytes{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "6_1": {
+      "10": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -475,7 +218,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_query_cache_count_get_total{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Get-Total - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -488,7 +231,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_query_cache_count_set_total{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Set-Total - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -501,7 +244,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_query_cache_bytes_total{op=\"read\",namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Read - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -514,7 +257,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_query_cache_bytes_total{op=\"written\",namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Write - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -527,7 +270,268 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(proxysql_query_cache_purged_total{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Purged - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\", image!=\"\"}[5m])) by (pod)",
+                    "seriesNameFormat": "{{ `{{container}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Usage"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=~\"$namespace\", pod=~\"$pod\", container!=\"\", image!=\"\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ProxySQL Connections"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "proxysql_connpool_conns{status=\"used\",namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Used Connects - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "proxysql_connpool_conns{status=\"free\",namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Free Connects - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ProxySQL Aborted Connections"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "proxysql_server_connections_total{ status=\"aborted\",namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Aborted Connects - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ProxySQL Slow Queries"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "proxysql_slow_queries_total{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Slow Queries - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ProxySQL Questions"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_questions_total{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Questions - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ProxySQL Network Traffic",
+            "description": "\n\nHere we can see how much network traffic is generated by MySQL. Outbound is network traffic sent from MySQL and Inbound is network traffic MySQL has received."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_connpool_data_bytes_total{traffic_flow=\"recv\",namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Inbound - {{ `{{pod}}` }} from {{ `{{endpoint}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_connpool_data_bytes_total{traffic_flow=\"sent\",namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Outbound - {{ `{{pod}}` }} to {{ `{{endpoint}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ProxySQL Query Cache Memory"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(proxysql_query_cache_memory_bytes{namespace=~\"$namespace\",service=~\"$app\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Query Cache Size - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -541,10 +545,7 @@
         "kind": "Grid",
         "spec": {
           "display": {
-            "title": "MySQL Pod Summary",
-            "collapse": {
-              "open": true
-            }
+            "title": "Panel Group 1"
           },
           "items": [
             {
@@ -553,7 +554,7 @@
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/0_0"
+                "$ref": "#/spec/panels/0"
               }
             },
             {
@@ -562,29 +563,16 @@
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/0_1"
+                "$ref": "#/spec/panels/1"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Pod CPU, Memory and File Descriptor Stats",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 7,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/1_0"
+                "$ref": "#/spec/panels/2"
               }
             },
             {
@@ -593,29 +581,16 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/1_1"
+                "$ref": "#/spec/panels/3"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Connections",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 15,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2_0"
+                "$ref": "#/spec/panels/4"
               }
             },
             {
@@ -624,95 +599,43 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2_1"
+                "$ref": "#/spec/panels/5"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Temporary Objects & Slow Queries",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 23,
               "width": 24,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_0"
+                "$ref": "#/spec/panels/6"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Table Locks and Questions",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 31,
               "width": 24,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/4_0"
+                "$ref": "#/spec/panels/7"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Network",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 39,
               "width": 24,
               "height": 10,
               "content": {
-                "$ref": "#/spec/panels/5_0"
+                "$ref": "#/spec/panels/8"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Query Cache",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 50,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/6_0"
+                "$ref": "#/spec/panels/9"
               }
             },
             {
@@ -721,7 +644,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/6_1"
+                "$ref": "#/spec/panels/10"
               }
             }
           ]

--- a/charts/kubedb-perses-dashboards/dashboards/proxysql/proxysql-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/proxysql/proxysql-summary.json
@@ -1,0 +1,1291 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "VsnOgk2Hnk",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / ProxySQL / Summary"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "proxysql",
+            "hidden": false
+          },
+          "defaultValue": "proxy-server",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kubedb_com_proxysql_status_phase{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Database Status",
+            "description": "Represent database status"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_proxysql_status_phase\n",
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Version",
+            "description": "ProxySQL CR Name"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "mean",
+              "colorMode": "none",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": " version ",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              },
+              "valueFontSize": 50
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_proxysql_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{ version }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage",
+            "description": "CPU Usage by ProxySQL pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Quota",
+            "description": "CPU Quote information in details"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp",
+                  "width": "auto"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Usage",
+            "description": "Memory Usage by ProxySQL pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Quota"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (RSS)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Cache)",
+                  "name": "value #7"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Swap)",
+                  "name": "value #8"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_rss{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_cache{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_swap{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk Usage",
+            "description": "Disk usage by ProxySQL pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk R/W Info",
+            "description": "System Disk Usage Information"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "IOPS (Reads+Writes)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m])))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ThroughPut (Read+Write)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Receive Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Transmit Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Backend Server",
+            "description": "Backend Server Kind and Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "metricLabel": " backend ",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              },
+              "valueFontSize": 25
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_proxysql_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{ backend }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Frontend SSL"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last",
+              "colorMode": "value",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_proxysql_info{namespace=\"$namespace\", app=\"$app\", ssl!~\"^$\"}",
+                    "seriesNameFormat": "{{ `{{ssl}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Nodes",
+            "description": "Total node count of ProxySQL cluster"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_proxysql_replicas{namespace=\"$namespace\",app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Request (Core)",
+            "description": "Initial Requested CPU amount by ProxySQL Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_proxysql_resource_request_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Limit (Core)",
+            "description": "CPU Limit in core by ProxySQL instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_proxysql_resource_limit_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Limit",
+            "description": "KubeDB ProxySQL Total Memory Limit"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_proxysql_resource_limit_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Request",
+            "description": "Initial Requested Memory amount by ProxySQL Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_proxysql_resource_request_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Termination Policy",
+            "description": "KubeDB Database Resource terminationPolicy"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_proxysql_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{terminationPolicy}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 6,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 6,
+              "y": 1,
+              "width": 6,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 12,
+              "y": 1,
+              "width": 6,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 18,
+              "y": 1,
+              "width": 6,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 4,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 8,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 12,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 16,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 20,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 0,
+              "y": 22,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 0,
+              "y": 28,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 0,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 12,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 0,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 12,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            },
+            {
+              "x": 0,
+              "y": 52,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/18"
+              }
+            },
+            {
+              "x": 12,
+              "y": 52,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/19"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/qdrant/qdrant_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/qdrant/qdrant_database_dashboard.json
@@ -1,0 +1,650 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "891d29ac-3a28-4b09-8628-a2559963ed4a",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / Qdrant / Database"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Datasource",
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "default",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Qdrant",
+            "hidden": false
+          },
+          "defaultValue": "qdrant-sample",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "job",
+              "matchers": [
+                "app_info{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cluster Mode",
+            "description": "Shows whether Qdrant is running in standalone or distributed cluster mode"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "format": {
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#5794f2",
+                    "value": 0
+                  },
+                  {
+                    "color": "#5794f2",
+                    "value": 1
+                  }
+                ]
+              },
+              "valueFontSize": 28
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "max(cluster_enabled{namespace=~\"$namespace\", job=~\"$app.*\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Service Status",
+            "description": "Displays the operational status (UP/DOWN) of each Qdrant pod in the database"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": []
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "up{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "gRPC Avg Response Duration",
+            "description": "Average response time for gRPC API requests by endpoint"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg by (endpoint) (\n  grpc_responses_avg_duration_seconds{\n    namespace=~\"$namespace\",\n    pod=~\"$app.*\"\n  }\n)\n",
+                    "seriesNameFormat": "{{ `{{endpoint}}` }} "
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "gRPC Request Rate by Endpoint",
+            "description": "Request rate for gRPC API endpoints showing requests per second by endpoint"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (endpoint) (\n  rate(grpc_responses_total{namespace=~\"$namespace\", pod=~\"$app.*\"}[5m])\n)\n",
+                    "seriesNameFormat": "{{ `{{endpoint}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Service Uptime",
+            "description": "Shows how long each Qdrant pod has been running since its last start"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": []
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "time() - kube_pod_start_time{namespace=~\"$namespace\",pod=~\"$app.*\"}",
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Usage",
+            "description": "Memory usage breakdown showing resident, allocated, and active memory for Qdrant pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memory_resident_bytes{namespace=~\"$namespace\",pod=~\"$app.*\"}",
+                    "seriesNameFormat": "Resident - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memory_allocated_bytes{namespace=~\"$namespace\",pod=~\"$app.*\"}",
+                    "seriesNameFormat": "Allocated - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memory_active_bytes{namespace=~\"$namespace\",pod=~\"$app.*\"}",
+                    "seriesNameFormat": "Active - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage",
+            "description": "CPU Usage by Qdrant pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(sum by(namespace,pod,container)(irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[5m]))* on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}))) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Pending Operations",
+            "description": "Pending Operations"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(\n  cluster_pending_operations_total{\n    namespace=~\"$namespace\",\n    service=~\"$app+-stats\"\n  }\n)\n",
+                    "seriesNameFormat": "Pending Operations"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "REST Success Rate",
+            "description": "Shows the percentage of successful REST API requests over the total requests"
+          },
+          "plugin": {
+            "kind": "GaugeChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "percent-decimal"
+              },
+              "max": 1,
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#f2495c",
+                    "value": 0
+                  },
+                  {
+                    "color": "#ff9830",
+                    "value": 0.95
+                  },
+                  {
+                    "color": "#fade2a",
+                    "value": 0.98
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 0.99
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "1 -\n(\n  sum(rate(rest_responses_fail_total{namespace=~\"$namespace\",pod=~\"$app.*\"}[5m]))\n  /\n  sum(rate(rest_responses_total{namespace=~\"$namespace\",pod=~\"$app.*\"}[5m]))\n)",
+                    "seriesNameFormat": "Success Rate"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "REST Avg Response Duration",
+            "description": "Average response time for REST API requests by endpoint"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg by (endpoint) (\n  rest_responses_avg_duration_seconds{\n    namespace=~\"$namespace\",\n    pod=~\"$app.*\"\n  }\n)",
+                    "seriesNameFormat": "{{ `{{endpoint}}` }} "
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "REST Request Rate by Endpoint",
+            "description": "Request rate for REST API endpoints showing requests per second by endpoint"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (endpoint) (\n  rate(rest_responses_total{namespace=~\"$namespace\", pod=~\"$app.*\"}[5m])\n)",
+                    "seriesNameFormat": "{{ `{{endpoint}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "gRPC Success Rate",
+            "description": "Shows the percentage of successful gRPC API requests over the total requests"
+          },
+          "plugin": {
+            "kind": "GaugeChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "percent-decimal"
+              },
+              "max": 1,
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#f2495c",
+                    "value": 0
+                  },
+                  {
+                    "color": "#ff9830",
+                    "value": 0.95
+                  },
+                  {
+                    "color": "#fade2a",
+                    "value": 0.98
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 0.99
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "1 -\n(\n  sum(rate(grpc_responses_fail_total{namespace=~\"$namespace\",pod=~\"$app.*\"}[5m]))\n  /\n  sum(rate(grpc_responses_total{namespace=~\"$namespace\",pod=~\"$app.*\"}[5m]))\n)",
+                    "seriesNameFormat": "Success Rate"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 12,
+              "y": 1,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 0,
+              "y": 16,
+              "width": 12,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 12,
+              "y": 16,
+              "width": 12,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 0,
+              "y": 26,
+              "width": 12,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 0,
+              "y": 37,
+              "width": 12,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 12,
+              "y": 37,
+              "width": 12,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 0,
+              "y": 47,
+              "width": 12,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 0,
+              "y": 58,
+              "width": 12,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 12,
+              "y": 58,
+              "width": 12,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 0,
+              "y": 68,
+              "width": 12,
+              "height": 10,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/qdrant/qdrant_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/qdrant/qdrant_pod_dashboard.json
@@ -1,0 +1,1128 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "fd868f7d-b1ee-4a46-8cd4-524d08ef710b",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / Qdrant / Pod"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "default",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Qdrant",
+            "hidden": false
+          },
+          "defaultValue": "qdrant-sample",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kubedb_com_qdrant_status_phase{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Pod",
+            "hidden": false
+          },
+          "defaultValue": "qdrant-sample-0",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "pod",
+              "matchers": [
+                "up{service=\"$app-stats\", namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "pod"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Pod Name",
+            "description": "Displays the name of the selected Qdrant pod"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "metricLabel": "pod",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#3274d9",
+                    "value": 0
+                  }
+                ]
+              },
+              "valueFontSize": 24
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "app_info{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Status",
+            "description": "Shows the current operational status of the pod (Up/Down)"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#f2495c",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 0
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 1
+                  }
+                ]
+              },
+              "valueFontSize": 50
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "up{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "REST Avg Response Duration",
+            "description": "Shows the average response time for REST API endpoints"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "mean",
+                  "last-number",
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 2
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "seconds"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (endpoint) (rest_responses_avg_duration_seconds{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"})",
+                    "seriesNameFormat": "{{ `{{endpoint}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "gRPC Request Rate by Endpoint",
+            "description": "Shows the rate of gRPC API requests per endpoint"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "mean",
+                  "last-number",
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 2
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "requests/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(grpc_responses_total{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{endpoint}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "gRPC Request Distribution by Endpoint",
+            "description": "Displays the distribution of gRPC requests across different endpoints"
+          },
+          "plugin": {
+            "kind": "PieChart",
+            "spec": {
+              "calculation": "last-number",
+              "legend": {
+                "mode": "table",
+                "position": "right"
+              },
+              "radius": 50,
+              "showLabels": true
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (endpoint) (rate(grpc_responses_total{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m]))",
+                    "seriesNameFormat": "{{ `{{endpoint}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "gRPC Endpoint Performance Summary",
+            "description": "Table showing gRPC endpoint performance metrics including rate, average duration, and failures"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "format": {
+                    "unit": "requests/sec"
+                  },
+                  "name": "Rate"
+                },
+                {
+                  "format": {
+                    "unit": "seconds"
+                  },
+                  "name": "Avg Duration"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (endpoint) (rate(grpc_responses_total{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (endpoint) (grpc_responses_avg_duration_seconds{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (endpoint) (rate(grpc_responses_fail_total{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "gRPC Success Rate",
+            "description": "Shows the success rate of gRPC API requests as a percentage"
+          },
+          "plugin": {
+            "kind": "GaugeChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "decimalPlaces": 4,
+                "unit": "percent-decimal"
+              },
+              "max": 1,
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#f2495c",
+                    "value": 0
+                  },
+                  {
+                    "color": "#ff9830",
+                    "value": 0.99
+                  },
+                  {
+                    "color": "#fade2a",
+                    "value": 0.995
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 0.999
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "1 - (sum(rate(grpc_responses_fail_total{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])) / sum(rate(grpc_responses_total{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])))",
+                    "seriesNameFormat": "gRPC Success Rate"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "gRPC Total Failed Requests (1h)",
+            "description": "Displays the total number of failed gRPC requests in the last hour"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "sum",
+              "colorMode": "background_solid",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(increase(grpc_responses_fail_total{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[1h]))",
+                    "seriesNameFormat": "Failed Requests (1h)"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "gRPC Avg Response Duration",
+            "description": "Shows the average response time for gRPC API endpoints"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "mean",
+                  "last-number",
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 2
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "seconds"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "grpc_responses_avg_duration_seconds{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{endpoint}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Uptime",
+            "description": "Displays how long the pod has been running since it was started"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "format": {
+                "unit": "seconds"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              },
+              "valueFontSize": 40
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "time() - kube_pod_start_time{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Usage",
+            "description": "Shows memory consumption metrics including Resident, Allocated, and Active memory"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "mean",
+                  "last-number",
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 2
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memory_resident_bytes{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Resident"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memory_allocated_bytes{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Allocated"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memory_active_bytes{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Active"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage by Collection",
+            "description": "Displays CPU usage per collection for the selected pod"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 2
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "collection_hardware_metric_cpu{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{id}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "REST Request Rate by Endpoint",
+            "description": "Shows the rate of REST API requests per endpoint"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "bottom",
+                "values": [
+                  "mean",
+                  "last-number",
+                  "max"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 2
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "requests/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(rest_responses_total{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{endpoint}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "REST Request Distribution by Endpoint",
+            "description": "Displays the distribution of REST requests across different endpoints"
+          },
+          "plugin": {
+            "kind": "PieChart",
+            "spec": {
+              "calculation": "last-number",
+              "legend": {
+                "mode": "table",
+                "position": "right"
+              },
+              "radius": 50,
+              "showLabels": true
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (endpoint) (\n  rate(\n    rest_responses_total{\n      namespace=~\"$namespace\",\n      service=~\"$app+-stats\",\n      pod=~\"$pod\"\n    }[5m]\n  )\n)\n",
+                    "seriesNameFormat": "{{ `{{endpoint}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "REST Endpoint Performance Summary",
+            "description": "Table showing REST endpoint performance metrics including rate, average duration, and failures"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "format": {
+                    "unit": "requests/sec"
+                  },
+                  "name": "Rate"
+                },
+                {
+                  "format": {
+                    "unit": "seconds"
+                  },
+                  "name": "Avg Duration"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (endpoint) (rate(rest_responses_total{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (endpoint) (rest_responses_avg_duration_seconds{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (endpoint) (rate(rest_responses_fail_total{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "REST Success Rate",
+            "description": "Shows the success rate of REST API requests as a percentage"
+          },
+          "plugin": {
+            "kind": "GaugeChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "decimalPlaces": 4,
+                "unit": "percent-decimal"
+              },
+              "max": 1,
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#f2495c",
+                    "value": 0
+                  },
+                  {
+                    "color": "#ff9830",
+                    "value": 0.99
+                  },
+                  {
+                    "color": "#fade2a",
+                    "value": 0.995
+                  },
+                  {
+                    "color": "#73bf69",
+                    "value": 0.999
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "1 - (sum(rate(rest_responses_fail_total{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])) / sum(rate(rest_responses_total{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])))",
+                    "seriesNameFormat": "gRPC Success Rate"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "REST Total Failed Requests (1h)",
+            "description": "Displays the total number of failed REST requests in the last hour"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "sum",
+              "colorMode": "background_solid",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(increase(rest_responses_fail_total{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[1h]))",
+                    "seriesNameFormat": "Failed Requests (1h)"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 8,
+              "y": 1,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 16,
+              "y": 1,
+              "width": 8,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 12,
+              "y": 8,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 0,
+              "y": 17,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 12,
+              "y": 17,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 0,
+              "y": 25,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 0,
+              "y": 33,
+              "width": 6,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 6,
+              "y": 33,
+              "width": 6,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 12,
+              "y": 33,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 0,
+              "y": 42,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 12,
+              "y": 42,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 0,
+              "y": 50,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 0,
+              "y": 58,
+              "width": 6,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 6,
+              "y": 58,
+              "width": 6,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 12,
+              "y": 58,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/qdrant/qdrant_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/qdrant/qdrant_summary_dashboard.json
@@ -1,0 +1,1623 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "60777403-b8d8-45e8-b9ca-0ed3c35b86e7",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / Qdrant / Summary"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "default",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Qdrant",
+            "hidden": false
+          },
+          "defaultValue": "qdrant-sample",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kubedb_com_qdrant_status_phase{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Database Status",
+            "description": "Represents database status"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_qdrant_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Version",
+            "description": "Qdrant Version"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "mean",
+              "colorMode": "none",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": " version ",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              },
+              "valueFontSize": 50
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_qdrant_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{ version }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage",
+            "description": "CPU Usage by Qdrant pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(sum by(namespace,pod,container)(irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[5m]))* on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}))) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Quota",
+            "description": "CPU Quote information in details"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp",
+                  "width": "auto"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                },
+                {
+                  "name": "CPU Limits",
+                  "width": "auto"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(sum by(namespace,pod,container)(irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[5m]))* on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}))) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(sum by(namespace,pod,container)(irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[5m]))* on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}))) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(sum by(namespace,pod,container)(irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[5m]))* on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}))) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-aggregator\\\\d+$|$app-leaf\\\\d+$|$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Usage",
+            "description": "Memory Usage by Qdrant pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app-leaf-\\\\d+$|$app-aggregator-\\\\d+$|$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Quota",
+            "description": "Memory quota information in details"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (RSS)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Cache)",
+                  "name": "value #7"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Swap)",
+                  "name": "value #8"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_rss{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_cache{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_swap{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk Usage",
+            "description": "Disk usage by Qdrant pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk R/W Info",
+            "description": "System Disk Usage Information"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "IOPS (Reads+Writes)",
+            "description": "IOPS (Input/Output Operations Per Second) by Qdrant pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\"}[5m])))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ThroughPut (Read+Write)",
+            "description": "Disk throughput (read and write) by Qdrant pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[5m]))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Current Storage IO",
+            "description": "Current storage I/O operations by Qdrant pods"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads)",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Writes)",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads + Writes)",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read)",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Write)",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read + Write)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_total{container!=\"\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_total{container!=\"\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_bytes_total{container!=\"\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Allocated Storage",
+            "description": "This panel describes allocated persistent storage in a table format\n"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": []
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}\n* on(persistentvolumeclaim, namespace) group_left(pod)\nkube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"^$app.*\", namespace=~\"$namespace\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "TLS Mode",
+            "description": "Qdrant TLS Modes"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "rgb(255, 255, 255)",
+                    "value": 0
+                  },
+                  {
+                    "color": "rgb(255, 255, 255)",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "max(\n  (\n    kubedb_com_qdrant_info{\n      namespace=\"$namespace\",\n      app=\"$app\",\n      tls!=\"\"\n    } * 1\n  )\n  or vector(0)\n)\n",
+                    "seriesNameFormat": "TLS"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "max(\n  (\n    kubedb_com_qdrant_info{\n      namespace=\"$namespace\",\n      app=\"$app\",\n      verify_https_client_certificate=\"true\"\n    } * 1\n  )\n  or vector(0)\n)\n",
+                    "seriesNameFormat": "Client"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "max(\n  (\n    kubedb_com_qdrant_info{\n      namespace=\"$namespace\",\n      app=\"$app\",\n      p2p_tls!=\"\"\n    } * 1\n  )\n  or vector(0)\n)\n",
+                    "seriesNameFormat": "P2P"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage",
+            "description": "This panel shows the persistent volume usage in percentage. "
+          },
+          "plugin": {
+            "kind": "BarChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "percent"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(\n  kubelet_volume_stats_used_bytes{job=\"kubelet\"}\n  * on(persistentvolumeclaim, namespace) group_left(pod)\n  kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"^$app.*\", namespace=~\"$namespace\"}\n)\n/\n(\n  kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}\n  * on(persistentvolumeclaim, namespace) group_left(pod)\n  kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"^$app.*\", namespace=~\"$namespace\"}\n)\n* 100",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage History",
+            "description": "This panel describes the persistent volume usage in a time series. "
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "right",
+                "values": [
+                  "max",
+                  "last-number"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineStyle": "solid",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decbytes"
+                },
+                "max": 5000,
+                "min": 0
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubelet_volume_stats_used_bytes{job=\"kubelet\"}\n* on(persistentvolumeclaim, namespace) group_left(pod)\nkube_pod_spec_volumes_persistentvolumeclaims_info{\n  pod=~\"^$app.*\",\n  namespace=~\"$namespace\"\n}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Receive Bandwidth",
+            "description": "Network receive bandwidth by Qdrant pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Transmit Bandwidth",
+            "description": "Network transmit bandwidth by Qdrant pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Deletion Policy",
+            "description": "KubeDB Database Resource deletionPolicy"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_qdrant_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Nodes",
+            "description": "Total node count of Qdrant cluster"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_qdrant_replicas{namespace=\"$namespace\",app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Request (Core)",
+            "description": "Initial Requested CPU amount by Qdrant Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_qdrant_resource_request_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Limit (Core)",
+            "description": "CPU Limit in core by Qdrant instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_qdrant_resource_limit_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Request",
+            "description": "Initial Requested Memory amount by Qdrant Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_qdrant_resource_request_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Limit",
+            "description": "KubeDB Qdrant Total Memory Limit"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_qdrant_resource_limit_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Storage Request",
+            "description": "Total storage request by Qdrant nodes"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_qdrant_resource_request_storage{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 8,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 16,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 20,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 4,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 8,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 12,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 16,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 20,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 0,
+              "y": 22,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 0,
+              "y": 28,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 0,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 12,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 0,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 12,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            },
+            {
+              "x": 0,
+              "y": 51,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/18"
+              }
+            },
+            {
+              "x": 0,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/19"
+              }
+            },
+            {
+              "x": 12,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/20"
+              }
+            },
+            {
+              "x": 0,
+              "y": 65,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/21"
+              }
+            },
+            {
+              "x": 0,
+              "y": 74,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/22"
+              }
+            },
+            {
+              "x": 12,
+              "y": 74,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/23"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/rabbitmq/rabbitmq-database.json
+++ b/charts/kubedb-perses-dashboards/dashboards/rabbitmq/rabbitmq-database.json
@@ -80,7 +80,7 @@
       }
     ],
     "panels": {
-      "0_0": {
+      "0": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -90,6 +90,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "background_solid",
               "format": {
                 "unit": "decimal"
               },
@@ -120,7 +121,7 @@
           ]
         }
       },
-      "0_1": {
+      "1": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -130,6 +131,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "background_solid",
               "format": {
                 "unit": "decimal"
               },
@@ -160,354 +162,7 @@
           ]
         }
       },
-      "0_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Connections"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "decimal"
-              },
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#fa6400",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "sum(rabbitmq_connections * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Ready messages"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "decimal"
-              },
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#37872D",
-                    "value": 0
-                  },
-                  {
-                    "color": "#1F60C4",
-                    "value": 10000
-                  },
-                  {
-                    "color": "#C4162A",
-                    "value": 100000
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "sum(rabbitmq_queue_messages_ready * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_4": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Incoming messages / s"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "decimal"
-              },
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#C4162A",
-                    "value": 0
-                  },
-                  {
-                    "color": "#37872d",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "sum(rate(rabbitmq_global_messages_received_total[60s]) * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_5": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Nodes"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "decimal"
-              },
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#fa6400",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "sum(rabbitmq_build_info * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_6": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Consumers"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "decimal"
-              },
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#fa6400",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "sum(rabbitmq_consumers * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_7": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Channels"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "decimal"
-              },
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#fa6400",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "sum(rabbitmq_channels * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_8": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Unacknowledged messages"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "decimal"
-              },
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#37872D",
-                    "value": 0
-                  },
-                  {
-                    "color": "#1F60C4",
-                    "value": 100
-                  },
-                  {
-                    "color": "#C4162A",
-                    "value": 500
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "sum(rabbitmq_queue_messages_unacked * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_9": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Outgoing messages / s"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "decimal"
-              },
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#C4162A",
-                    "value": 0
-                  },
-                  {
-                    "color": "#37872d",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "sum(rate(rabbitmq_global_messages_redelivered_total[60s]) * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) +\nsum(rate(rabbitmq_global_messages_delivered_consume_auto_ack_total[60s]) * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) +\nsum(rate(rabbitmq_global_messages_delivered_consume_manual_ack_total[60s]) * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) +\nsum(rate(rabbitmq_global_messages_delivered_get_auto_ack_total[60s]) * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) +\nsum(rate(rabbitmq_global_messages_delivered_get_manual_ack_total[60s]) * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "1_0": {
+      "10": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -518,76 +173,69 @@
             "spec": {
               "columnSettings": [
                 {
-                  "name": "rabbitmq_cluster"
-                },
-                {
-                  "name": "pod"
-                },
-                {
-                  "name": "rabbitmq_node"
-                },
-                {
-                  "name": "container"
-                },
-                {
-                  "name": "service"
-                },
-                {
-                  "name": "instance"
-                },
-                {
-                  "name": "endpoint"
-                },
-                {
-                  "header": "RabbitMQ Version",
-                  "name": "rabbitmq_version"
-                },
-                {
-                  "header": "Prometheus Plugin Version",
-                  "name": "prometheus_plugin_version"
-                },
-                {
-                  "header": "Prometheus client Version",
-                  "name": "prometheus_client_version"
-                },
-                {
-                  "header": "Erlang Version",
-                  "name": "erlang_version"
-                },
-                {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Erlang/OTP",
                   "name": "erlang_version"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "RabbitMQ",
                   "name": "rabbitmq_version"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Host",
                   "name": "instance"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Node name",
                   "name": "rabbitmq_node"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "name": "value"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "name": "job"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Cluster",
                   "name": "rabbitmq_cluster"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "prometheus.erl",
                   "name": "prometheus_client_version"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "rabbitmq_prometheus",
                   "name": "prometheus_plugin_version"
                 },
@@ -602,12 +250,6 @@
                 {
                   "name": "Prometheus client Version",
                   "width": 185
-                }
-              ],
-              "transforms": [
-                {
-                  "kind": "MergeSeries",
-                  "spec": {}
                 }
               ]
             }
@@ -633,7 +275,7 @@
           ]
         }
       },
-      "1_1": {
+      "11": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -674,7 +316,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "(rabbitmq_resident_memory_limit_bytes * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) -\n(rabbitmq_process_resident_memory_bytes * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -682,7 +324,7 @@
           ]
         }
       },
-      "1_2": {
+      "12": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -723,7 +365,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rabbitmq_disk_space_available_bytes * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -731,7 +373,7 @@
           ]
         }
       },
-      "1_3": {
+      "13": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -771,7 +413,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "(rabbitmq_process_max_fds * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) -\n(rabbitmq_process_open_fds * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -779,7 +421,7 @@
           ]
         }
       },
-      "1_4": {
+      "14": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -819,7 +461,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "(rabbitmq_process_max_tcp_sockets * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) -\n(rabbitmq_process_open_tcp_sockets * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -827,7 +469,7 @@
           ]
         }
       },
-      "2_0": {
+      "15": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -869,7 +511,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rabbitmq_queue_messages_ready * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -877,7 +519,7 @@
           ]
         }
       },
-      "2_1": {
+      "16": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -919,7 +561,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rabbitmq_queue_messages_unacked * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -927,7 +569,7 @@
           ]
         }
       },
-      "3_0": {
+      "17": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -969,7 +611,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(rabbitmq_global_messages_received_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -977,7 +619,7 @@
           ]
         }
       },
-      "3_1": {
+      "18": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1019,7 +661,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(rabbitmq_global_messages_confirmed_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -1027,7 +669,7 @@
           ]
         }
       },
-      "3_2": {
+      "19": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1069,6 +711,48 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(rabbitmq_global_messages_routed_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Connections"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#fa6400",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rabbitmq_connections * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})",
                     "seriesNameFormat": ""
                   }
                 }
@@ -1077,7 +761,7 @@
           ]
         }
       },
-      "3_3": {
+      "20": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1119,7 +803,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(rabbitmq_global_messages_received_confirm_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"} - \nrate(rabbitmq_global_messages_confirmed_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}\n) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -1127,7 +811,7 @@
           ]
         }
       },
-      "3_4": {
+      "21": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1146,6 +830,13 @@
                   "min"
                 ]
               },
+              "querySettings": [
+                {
+                  "colorMode": "fixed",
+                  "colorValue": "#C4162A",
+                  "queryIndex": 0
+                }
+              ],
               "visual": {
                 "areaOpacity": 1,
                 "connectNulls": false,
@@ -1168,7 +859,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(rabbitmq_global_messages_unroutable_dropped_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -1176,7 +867,7 @@
           ]
         }
       },
-      "3_5": {
+      "22": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1195,6 +886,13 @@
                   "min"
                 ]
               },
+              "querySettings": [
+                {
+                  "colorMode": "fixed",
+                  "colorValue": "#C4162A",
+                  "queryIndex": 0
+                }
+              ],
               "visual": {
                 "areaOpacity": 1,
                 "connectNulls": false,
@@ -1217,7 +915,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(rabbitmq_global_messages_unroutable_returned_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -1225,7 +923,7 @@
           ]
         }
       },
-      "4_0": {
+      "23": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1267,7 +965,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(\n  (rate(rabbitmq_global_messages_delivered_consume_auto_ack_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) +\n  (rate(rabbitmq_global_messages_delivered_consume_manual_ack_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})\n) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -1275,7 +973,7 @@
           ]
         }
       },
-      "4_1": {
+      "24": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1316,7 +1014,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(rabbitmq_global_messages_redelivered_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -1324,7 +1022,7 @@
           ]
         }
       },
-      "4_2": {
+      "25": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1366,7 +1064,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(rabbitmq_global_messages_delivered_consume_manual_ack_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -1374,7 +1072,7 @@
           ]
         }
       },
-      "4_3": {
+      "26": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1416,7 +1114,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(rabbitmq_global_messages_delivered_consume_auto_ack_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -1424,7 +1122,7 @@
           ]
         }
       },
-      "4_4": {
+      "27": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1466,7 +1164,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(rabbitmq_global_messages_acknowledged_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -1474,7 +1172,7 @@
           ]
         }
       },
-      "4_5": {
+      "28": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1493,6 +1191,13 @@
                   "min"
                 ]
               },
+              "querySettings": [
+                {
+                  "colorMode": "fixed",
+                  "colorValue": "#C4162A",
+                  "queryIndex": 0
+                }
+              ],
               "visual": {
                 "areaOpacity": 1,
                 "connectNulls": false,
@@ -1515,7 +1220,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(rabbitmq_global_messages_delivered_get_auto_ack_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -1523,7 +1228,7 @@
           ]
         }
       },
-      "4_6": {
+      "29": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1542,6 +1247,13 @@
                   "min"
                 ]
               },
+              "querySettings": [
+                {
+                  "colorMode": "fixed",
+                  "colorValue": "#C4162A",
+                  "queryIndex": 0
+                }
+              ],
               "visual": {
                 "areaOpacity": 1,
                 "connectNulls": false,
@@ -1564,6 +1276,56 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(rabbitmq_global_messages_get_empty_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Ready messages"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#37872D",
+                    "value": 0
+                  },
+                  {
+                    "color": "#1F60C4",
+                    "value": 10000
+                  },
+                  {
+                    "color": "#C4162A",
+                    "value": 100000
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rabbitmq_queue_messages_ready * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})",
                     "seriesNameFormat": ""
                   }
                 }
@@ -1572,7 +1334,7 @@
           ]
         }
       },
-      "4_7": {
+      "30": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1591,6 +1353,13 @@
                   "min"
                 ]
               },
+              "querySettings": [
+                {
+                  "colorMode": "fixed",
+                  "colorValue": "#C4162A",
+                  "queryIndex": 0
+                }
+              ],
               "visual": {
                 "areaOpacity": 1,
                 "connectNulls": false,
@@ -1613,7 +1382,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(rabbitmq_global_messages_delivered_get_manual_ack_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -1621,7 +1390,7 @@
           ]
         }
       },
-      "5_0": {
+      "31": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1663,7 +1432,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rabbitmq_queues * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -1671,7 +1440,7 @@
           ]
         }
       },
-      "5_1": {
+      "32": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1712,7 +1481,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(rabbitmq_queues_declared_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -1720,7 +1489,7 @@
           ]
         }
       },
-      "5_2": {
+      "33": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1761,7 +1530,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(rabbitmq_queues_created_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -1769,7 +1538,7 @@
           ]
         }
       },
-      "5_3": {
+      "34": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1810,7 +1579,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(rabbitmq_queues_deleted_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -1818,7 +1587,7 @@
           ]
         }
       },
-      "6_0": {
+      "35": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1859,7 +1628,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(rabbitmq_raft_log_commit_index[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -1867,7 +1636,7 @@
           ]
         }
       },
-      "6_1": {
+      "36": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1882,7 +1651,7 @@
           }
         }
       },
-      "6_2": {
+      "37": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1922,7 +1691,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(\n  (rabbitmq_raft_log_last_written_index * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) -\n  (rabbitmq_raft_log_commit_index * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})\n) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -1930,7 +1699,7 @@
           ]
         }
       },
-      "6_3": {
+      "38": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1971,7 +1740,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(rabbitmq_raft_term_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -1979,7 +1748,7 @@
           ]
         }
       },
-      "6_4": {
+      "39": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2021,6 +1790,52 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(\n  (rabbitmq_raft_log_last_written_index * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) - \n  (rabbitmq_raft_log_snapshot_index * on(instance) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})\n) by(queue, rabbitmq_node)",
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }} {{ `{{queue}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Incoming messages / s"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#C4162A",
+                    "value": 0
+                  },
+                  {
+                    "color": "#37872d",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(rabbitmq_global_messages_received_total[60s]) * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})",
                     "seriesNameFormat": ""
                   }
                 }
@@ -2029,7 +1844,7 @@
           ]
         }
       },
-      "7_0": {
+      "40": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2070,7 +1885,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rabbitmq_channels * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -2078,7 +1893,7 @@
           ]
         }
       },
-      "7_1": {
+      "41": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2119,7 +1934,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(rabbitmq_channels_opened_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -2127,7 +1942,7 @@
           ]
         }
       },
-      "7_2": {
+      "42": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2168,7 +1983,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(rabbitmq_channels_closed_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -2176,7 +1991,7 @@
           ]
         }
       },
-      "8_0": {
+      "43": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2217,7 +2032,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rabbitmq_connections * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -2225,7 +2040,7 @@
           ]
         }
       },
-      "8_1": {
+      "44": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2267,7 +2082,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(rabbitmq_connections_opened_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
                   }
                 }
               }
@@ -2275,7 +2090,7 @@
           ]
         }
       },
-      "8_2": {
+      "45": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2316,6 +2131,223 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sum(rate(rabbitmq_connections_closed_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) by(rabbitmq_node)",
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Nodes"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#fa6400",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "sum(rabbitmq_build_info * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Consumers"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#fa6400",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "sum(rabbitmq_consumers * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Channels"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#fa6400",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "sum(rabbitmq_channels * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Unacknowledged messages"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#37872D",
+                    "value": 0
+                  },
+                  {
+                    "color": "#1F60C4",
+                    "value": 100
+                  },
+                  {
+                    "color": "#C4162A",
+                    "value": 500
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "sum(rabbitmq_queue_messages_unacked * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Outgoing messages / s"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#C4162A",
+                    "value": 0
+                  },
+                  {
+                    "color": "#37872d",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "sum(rate(rabbitmq_global_messages_redelivered_total[60s]) * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) +\nsum(rate(rabbitmq_global_messages_delivered_consume_auto_ack_total[60s]) * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) +\nsum(rate(rabbitmq_global_messages_delivered_consume_manual_ack_total[60s]) * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) +\nsum(rate(rabbitmq_global_messages_delivered_get_auto_ack_total[60s]) * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"}) +\nsum(rate(rabbitmq_global_messages_delivered_get_manual_ack_total[60s]) * on(instance, job) group_left(rabbitmq_cluster) rabbitmq_identity_info{rabbitmq_cluster=\"$app\", namespace=\"$namespace\"})",
                     "seriesNameFormat": ""
                   }
                 }
@@ -2330,10 +2362,7 @@
         "kind": "Grid",
         "spec": {
           "display": {
-            "title": "MESSAGING",
-            "collapse": {
-              "open": true
-            }
+            "title": "Panel Group 1"
           },
           "items": [
             {
@@ -2342,7 +2371,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_0"
+                "$ref": "#/spec/panels/0"
               }
             },
             {
@@ -2351,7 +2380,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_1"
+                "$ref": "#/spec/panels/1"
               }
             },
             {
@@ -2360,7 +2389,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_2"
+                "$ref": "#/spec/panels/2"
               }
             },
             {
@@ -2369,7 +2398,7 @@
               "width": 6,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_3"
+                "$ref": "#/spec/panels/3"
               }
             },
             {
@@ -2378,7 +2407,7 @@
               "width": 6,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_4"
+                "$ref": "#/spec/panels/4"
               }
             },
             {
@@ -2387,7 +2416,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_5"
+                "$ref": "#/spec/panels/5"
               }
             },
             {
@@ -2396,7 +2425,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_6"
+                "$ref": "#/spec/panels/6"
               }
             },
             {
@@ -2405,7 +2434,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_7"
+                "$ref": "#/spec/panels/7"
               }
             },
             {
@@ -2414,7 +2443,7 @@
               "width": 6,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_8"
+                "$ref": "#/spec/panels/8"
               }
             },
             {
@@ -2423,29 +2452,16 @@
               "width": 6,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_9"
+                "$ref": "#/spec/panels/9"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "NODES",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 8,
               "width": 24,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/1_0"
+                "$ref": "#/spec/panels/10"
               }
             },
             {
@@ -2454,7 +2470,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1_1"
+                "$ref": "#/spec/panels/11"
               }
             },
             {
@@ -2463,7 +2479,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1_2"
+                "$ref": "#/spec/panels/12"
               }
             },
             {
@@ -2472,7 +2488,7 @@
               "width": 4,
               "height": 4,
               "content": {
-                "$ref": "#/spec/panels/1_3"
+                "$ref": "#/spec/panels/13"
               }
             },
             {
@@ -2481,29 +2497,16 @@
               "width": 4,
               "height": 4,
               "content": {
-                "$ref": "#/spec/panels/1_4"
+                "$ref": "#/spec/panels/14"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "QUEUED MESSAGES",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 22,
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/2_0"
+                "$ref": "#/spec/panels/15"
               }
             },
             {
@@ -2512,29 +2515,16 @@
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/2_1"
+                "$ref": "#/spec/panels/16"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "INCOMING MESSAGES",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 28,
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/3_0"
+                "$ref": "#/spec/panels/17"
               }
             },
             {
@@ -2543,7 +2533,7 @@
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/3_1"
+                "$ref": "#/spec/panels/18"
               }
             },
             {
@@ -2552,7 +2542,7 @@
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/3_2"
+                "$ref": "#/spec/panels/19"
               }
             },
             {
@@ -2561,7 +2551,7 @@
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/3_3"
+                "$ref": "#/spec/panels/20"
               }
             },
             {
@@ -2570,7 +2560,7 @@
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/3_4"
+                "$ref": "#/spec/panels/21"
               }
             },
             {
@@ -2579,29 +2569,16 @@
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/3_5"
+                "$ref": "#/spec/panels/22"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "OUTGOING MESSAGES",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 44,
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/4_0"
+                "$ref": "#/spec/panels/23"
               }
             },
             {
@@ -2610,7 +2587,7 @@
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/4_1"
+                "$ref": "#/spec/panels/24"
               }
             },
             {
@@ -2619,7 +2596,7 @@
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/4_2"
+                "$ref": "#/spec/panels/25"
               }
             },
             {
@@ -2628,7 +2605,7 @@
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/4_3"
+                "$ref": "#/spec/panels/26"
               }
             },
             {
@@ -2637,7 +2614,7 @@
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/4_4"
+                "$ref": "#/spec/panels/27"
               }
             },
             {
@@ -2646,7 +2623,7 @@
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/4_5"
+                "$ref": "#/spec/panels/28"
               }
             },
             {
@@ -2655,7 +2632,7 @@
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/4_6"
+                "$ref": "#/spec/panels/29"
               }
             },
             {
@@ -2664,29 +2641,16 @@
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/4_7"
+                "$ref": "#/spec/panels/30"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "QUEUES",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 65,
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/5_0"
+                "$ref": "#/spec/panels/31"
               }
             },
             {
@@ -2695,7 +2659,7 @@
               "width": 4,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/5_1"
+                "$ref": "#/spec/panels/32"
               }
             },
             {
@@ -2704,7 +2668,7 @@
               "width": 4,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/5_2"
+                "$ref": "#/spec/panels/33"
               }
             },
             {
@@ -2713,29 +2677,16 @@
               "width": 4,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/5_3"
+                "$ref": "#/spec/panels/34"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "RAFT STATES FOR QUORUM QUEUES",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 71,
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/6_0"
+                "$ref": "#/spec/panels/35"
               }
             },
             {
@@ -2744,7 +2695,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/6_1"
+                "$ref": "#/spec/panels/36"
               }
             },
             {
@@ -2753,7 +2704,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/6_2"
+                "$ref": "#/spec/panels/37"
               }
             },
             {
@@ -2762,7 +2713,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/6_3"
+                "$ref": "#/spec/panels/38"
               }
             },
             {
@@ -2771,29 +2722,16 @@
               "width": 24,
               "height": 10,
               "content": {
-                "$ref": "#/spec/panels/6_4"
+                "$ref": "#/spec/panels/39"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "CHANNELS",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 100,
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/7_0"
+                "$ref": "#/spec/panels/40"
               }
             },
             {
@@ -2802,7 +2740,7 @@
               "width": 6,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/7_1"
+                "$ref": "#/spec/panels/41"
               }
             },
             {
@@ -2811,29 +2749,16 @@
               "width": 6,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/7_2"
+                "$ref": "#/spec/panels/42"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "CONNECTIONS",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 106,
               "width": 12,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/8_0"
+                "$ref": "#/spec/panels/43"
               }
             },
             {
@@ -2842,7 +2767,7 @@
               "width": 6,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/8_1"
+                "$ref": "#/spec/panels/44"
               }
             },
             {
@@ -2851,7 +2776,7 @@
               "width": 6,
               "height": 5,
               "content": {
-                "$ref": "#/spec/panels/8_2"
+                "$ref": "#/spec/panels/45"
               }
             }
           ]

--- a/charts/kubedb-perses-dashboards/dashboards/rabbitmq/rabbitmq-pod.json
+++ b/charts/kubedb-perses-dashboards/dashboards/rabbitmq/rabbitmq-pod.json
@@ -1,0 +1,768 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "FktZiiOnz",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / RabbitMQ / Pod"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Datasource",
+            "hidden": false
+          },
+          "defaultValue": "default",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "rabbit",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "RabbitMQ",
+            "hidden": false
+          },
+          "defaultValue": "rabbit-dev",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kubedb_com_rabbitmq_status_phase{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Pod Name",
+            "hidden": false
+          },
+          "defaultValue": "rabbit-dev-0",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "alphabetical-asc",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "pod",
+              "matchers": [
+                "rabbitmq_build_info{namespace=~\"$namespace\",pod=~\"${app}-.*\"}"
+              ]
+            }
+          },
+          "name": "pod"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Status"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 1,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "rgba(50, 172, 45, 0.97)",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kube_pod_status_phase{pod=~\"$pod\",phase=~\"Running\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Uptime"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "seconds"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "max(max_over_time(rabbitmq_erlang_uptime_seconds{pod=~\"$pod\"}[$__interval]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Messages published / s",
+            "description": "The incoming message rate before any routing rules are applied.\n\nIf this value is lower than the number of messages published to queues, it may indicate that some messages are delivered to more than one queue.\n\nIf this value is higher than the number of messages published to queues, messages cannot be routed and will either be dropped or returned to publishers.\n\n* [Publishers](https://www.rabbitmq.com/publishers.html)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom",
+                "values": [
+                  "last-number",
+                  "max",
+                  "min"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 1,
+                "connectNulls": false,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "decimalPlaces": 0,
+                  "unit": "decimal"
+                },
+                "min": 0
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "sum(rate(rabbitmq_global_messages_received_total[60s]) * on(instance, job) group_left(rabbitmq_cluster, rabbitmq_node) rabbitmq_identity_info{pod=\"$pod\", namespace=\"$namespace\"}) by(rabbitmq_node)",
+                    "seriesNameFormat": "{{ `{{rabbitmq_node}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk Space Available"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rabbitmq_disk_space_available_bytes{pod=~\"$pod\"} / 1024 / 1024",
+                    "seriesNameFormat": "Available memory"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rabbitmq_process_resident_memory_bytes{pod=~\"$pod\"} / 1024 / 1024",
+                    "seriesNameFormat": "used memory"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Memory Used"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{pod=\"$pod\"}) / 1024 / 1024",
+                    "seriesNameFormat": "used memory"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Average CPU Usage",
+            "description": "Average user and system CPU time spent in seconds."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_cpu_usage_seconds_total{pod=~\"$pod\"}[5m])) / count(node_cpu_seconds_total{mode=\"system\"}) * 100",
+                    "seriesNameFormat": "CPU used (%)"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Unreachable Peers"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rabbitmq_unreachable_cluster_peers_count{pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent messages Count"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rabbitmq_queue_messages_persistent{pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Ready and unacknowledged messages stored in memory"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rabbitmq_queue_messages_ram{pod=~\"$pod\"}",
+                    "seriesNameFormat": "messages stored in ram"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Connections"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rabbitmq_connections{pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Size of ready and unacknowledged messages stored in memory"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rabbitmq_queue_messages_ram_bytes{pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Size in bytes of persistent messages"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rabbitmq_queue_messages_persistent{pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Erlang GC runs Frequency"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(rabbitmq_erlang_gc_runs_total{pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Number of total GC runs"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory reclaimed by Erlang GC"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(rabbitmq_erlang_gc_reclaimed_bytes_total{pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 8,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 8,
+              "y": 0,
+              "width": 8,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 16,
+              "y": 0,
+              "width": 8,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 8,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 8,
+              "y": 4,
+              "width": 8,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 16,
+              "y": 4,
+              "width": 8,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 12,
+              "y": 8,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 0,
+              "y": 16,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 12,
+              "y": 16,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 0,
+              "y": 24,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 12,
+              "y": 24,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 0,
+              "y": 33,
+              "width": 12,
+              "height": 11,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 12,
+              "y": 33,
+              "width": 12,
+              "height": 11,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/rabbitmq/rabbitmq-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/rabbitmq/rabbitmq-summary.json
@@ -1,0 +1,1589 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "rAbbItMqSumMaRy",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / RabbitMQ / Summary"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Datasource",
+            "hidden": false
+          },
+          "defaultValue": "default",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "RabbitMQ",
+            "hidden": false
+          },
+          "defaultValue": "rabbitmq",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kubedb_com_rabbitmq_status_phase{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Database Status",
+            "description": "Represent database status"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_rabbitmq_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Version",
+            "description": "RabbitMQ CR Name"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "mean",
+              "colorMode": "none",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": " version ",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              },
+              "valueFontSize": 50
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_rabbitmq_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{ version }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage",
+            "description": "CPU Usage by RabbitMQ pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Quota",
+            "description": "CPU Quote information in details"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp",
+                  "width": "auto"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Usage",
+            "description": "Memory Usage by RabbitMQ pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Quota"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (RSS)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Cache)",
+                  "name": "value #7"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Swap)",
+                  "name": "value #8"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_rss{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_cache{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_swap{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk Usage",
+            "description": "Disk usage by RabbitMQ pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk R/W Info",
+            "description": "System Disk Usage Information"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "IOPS (Reads+Writes)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m])))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ThroughPut (Read+Write)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Current Storage IO"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads)",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Writes)",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads + Writes)",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read)",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Write)",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read + Write)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_total{container!=\"\",pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_bytes_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\",pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Allocated Storage",
+            "description": "This panel describes allocated persistent storage in a table format\n"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": []
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Require Secure Transport",
+            "description": "When this option is enabled, connections attempted using insecure transport will be rejected."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_rabbitmq_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{requireSSL}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage",
+            "description": "This panel shows the persistent volume usage in percentage. "
+          },
+          "plugin": {
+            "kind": "BarChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "percent"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage History",
+            "description": "This panel describes the persistent volume usage in a time series. "
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "right",
+                "values": [
+                  "max",
+                  "last-number"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineStyle": "solid",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decbytes"
+                },
+                "max": 5000,
+                "min": 0
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(kubelet_volume_stats_used_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) ",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Receive Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Transmit Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Deletion Policy",
+            "description": "KubeDB Database Resource deletionPolicy"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_rabbitmq_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Nodes",
+            "description": "Total node count of RabbitMQ cluster"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_rabbitmq_replicas{namespace=\"$namespace\",app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Request (Core)",
+            "description": "Initial Requested CPU amount by RabbitMQ Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_rabbitmq_resource_request_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Limit (Core)",
+            "description": "CPU Limit in core by RabbitMQ instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_rabbitmq_resource_limit_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Request",
+            "description": "Initial Requested Memory amount by RabbitMQ Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_rabbitmq_resource_request_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Limit",
+            "description": "KubeDB RabbitMQ Total Memory Limit"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_rabbitmq_resource_limit_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Storage Request",
+            "description": "Total storage request by RabbitMQ nodes"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_rabbitmq_resource_request_storage{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 8,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 16,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 20,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 4,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 8,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 12,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 16,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 20,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 0,
+              "y": 22,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 0,
+              "y": 28,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 0,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 12,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 0,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 12,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            },
+            {
+              "x": 0,
+              "y": 51,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/18"
+              }
+            },
+            {
+              "x": 0,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/19"
+              }
+            },
+            {
+              "x": 12,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/20"
+              }
+            },
+            {
+              "x": 0,
+              "y": 65,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/21"
+              }
+            },
+            {
+              "x": 0,
+              "y": 74,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/22"
+              }
+            },
+            {
+              "x": 12,
+              "y": 74,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/23"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/redis/redis_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/redis/redis_pod_dashboard.json
@@ -1,0 +1,884 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "fF-N4cH7k",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / Redis / Pod"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "redis_up"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "redis",
+            "hidden": false
+          },
+          "defaultValue": "redis-cluster",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "alphabetical-asc",
+          "plugin": {
+            "kind": "PrometheusPromQLVariable",
+            "spec": {
+              "expr": "kubedb_com_redis_created{namespace=\"$namespace\"}",
+              "labelName": "app"
+            }
+          },
+          "name": "app"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Pod Name",
+            "hidden": false
+          },
+          "defaultValue": "redis-cluster-shard0-0",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "alphabetical-asc",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "pod",
+              "matchers": [
+                "redis_up{namespace=~\"$namespace\",pod=~\"${app}-.*\"}"
+              ]
+            }
+          },
+          "name": "pod"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Status"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 1,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "rgba(50, 172, 45, 0.97)",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "redis_up{pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Role"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 0,
+                "unit": "decimal"
+              },
+              "metricLabel": "role",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "redis_instance_info{pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{role}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Network I/O"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(redis_net_input_bytes_total{pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{ input }}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(redis_net_output_bytes_total{pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{ output }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Command Calls / sec"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "topk(7, irate(redis_commands_total{pod=~\"$pod\"} [1m]))",
+                    "seriesNameFormat": "{{ `{{ cmd }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Redis connected clients"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "redis_connected_clients{pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Memory Usage"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "redis_memory_used_bytes{pod=~\"$pod\"} ",
+                    "seriesNameFormat": "used"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "redis_memory_max_bytes{pod=~\"$pod\"} ",
+                    "seriesNameFormat": "max"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Average CPU Usage",
+            "description": "Average user and system CPU time spent in seconds."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(rate(process_cpu_seconds_total{pod=\"$pod\", namespace=\"$namespace\"}[5m]) * 1000)",
+                    "seriesNameFormat": "used"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Average Memory Usage",
+            "description": "Virtual and Resident memory size in bytes, averages over 5 min interval"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(rate(process_resident_memory_bytes{pod=\"$pod\", namespace=\"$namespace\"}[5m]))",
+                    "seriesNameFormat": "Resident Mem"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(rate(process_virtual_memory_bytes{pod=\"$pod\", namespace=\"$namespace\"}[5m]))",
+                    "seriesNameFormat": "Virtual Mem"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "My Master"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 0,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              },
+              "valueFontSize": 25
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "redis_master_last_io_seconds_ago{pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{master_host}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "My slaves"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 0,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "redis_connected_slaves{pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Connected Clients"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 0,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "redis_connected_clients{pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Go Routines",
+            "description": "Number of goroutines that currently exist"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 0,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              },
+              "valueFontSize": 32
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "go_goroutines{pod=\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Uptime"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "seconds"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "max(max_over_time(redis_uptime_in_seconds{pod=~\"$pod\"}[$__interval]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Usage"
+          },
+          "plugin": {
+            "kind": "GaugeChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "decimalPlaces": 0,
+                "unit": "decbytes"
+              },
+              "max": 100,
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "rgba(50, 172, 45, 0.97)",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "redis_memory_used_bytes{pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Commands Executed / sec"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(redis_commands_processed_total{pod=~\"$pod\"}[1m])",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Hits / Misses per Sec"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "irate(redis_keyspace_hits_total{pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "hits"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "irate(redis_keyspace_misses_total{pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "misses"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 4,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 8,
+              "y": 1,
+              "width": 6,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 14,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 18,
+              "y": 1,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 21,
+              "y": 1,
+              "width": 3,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 4,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 4,
+              "y": 4,
+              "width": 5,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 9,
+              "y": 4,
+              "width": 7,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 16,
+              "y": 4,
+              "width": 8,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 0,
+              "y": 11,
+              "width": 8,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 8,
+              "y": 11,
+              "width": 8,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 16,
+              "y": 11,
+              "width": 8,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 0,
+              "y": 19,
+              "width": 7,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 7,
+              "y": 19,
+              "width": 9,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 16,
+              "y": 19,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/redis/redis_shards_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/redis/redis_shards_dashboard.json
@@ -1,0 +1,499 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "fF-N4cHsh",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / Redis / Shard"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "redis_up"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "redis",
+            "hidden": false
+          },
+          "defaultValue": "redis-cluster",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "alphabetical-asc",
+          "plugin": {
+            "kind": "PrometheusPromQLVariable",
+            "spec": {
+              "expr": "kubedb_com_redis_created{namespace=\"$namespace\"}",
+              "labelName": "app"
+            }
+          },
+          "name": "app"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Pod Name",
+            "hidden": false
+          },
+          "defaultValue": "redis-cluster-shard0-0",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "alphabetical-asc",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "pod",
+              "matchers": [
+                "redis_up{namespace=~\"$namespace\",pod=~\"${app}-shard.*\"}"
+              ]
+            }
+          },
+          "name": "pod"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "StaticListVariable",
+            "spec": {
+              "values": [
+                "grafana",
+                "migration",
+                "not",
+                "supported"
+              ]
+            }
+          },
+          "name": "Filters"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cluster Shard slots"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 1,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "rgba(50, 172, 45, 0.97)",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "redis_cluster_slots_ok{pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cluster nodes"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 0,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "redis_cluster_known_nodes{pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Connected Slaves"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 0,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "redis_connected_slaves{pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "My Slaves"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": []
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "redis_connected_slave_offset_bytes{pod=~\"$pod\"} ",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cluster Shard slots Failed"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 1,
+                "unit": "decimal"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "rgba(50, 172, 45, 0.97)",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "redis_cluster_slots_fail{pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Mode"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 0,
+                "unit": "decimal"
+              },
+              "metricLabel": "redis_mode",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "redis_instance_info{pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{redis_mode}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cluster Masters"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 0,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "redis_cluster_size{pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 3,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 3,
+              "y": 1,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 7,
+              "y": 1,
+              "width": 5,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 12,
+              "y": 1,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 0,
+              "y": 5,
+              "width": 3,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 3,
+              "y": 5,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 7,
+              "y": 5,
+              "width": 5,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/redis/redis_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/redis/redis_summary_dashboard.json
@@ -79,7 +79,7 @@
       }
     ],
     "panels": {
-      "0_0": {
+      "0": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -90,6 +90,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
               "thresholds": {
                 "steps": [
                   {
@@ -109,7 +111,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_redis_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
                   }
                 }
               }
@@ -117,7 +119,7 @@
           ]
         }
       },
-      "0_1": {
+      "1": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -128,9 +130,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": "version",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -155,7 +159,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_redis_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{version}}` }}"
                   }
                 }
               }
@@ -163,7 +167,7 @@
           ]
         }
       },
-      "0_10": {
+      "10": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -174,6 +178,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -205,335 +210,7 @@
           ]
         }
       },
-      "0_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Max Clients",
-            "description": "redis_config_maxclients"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              },
-              "valueFontSize": 25
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "avg(redis_config_maxclients{namespace=\"$namespace\" , pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\"}) ",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "RedisMode",
-            "description": "RedisMode CR Name"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "mean",
-              "format": {
-                "unit": "decimal"
-              },
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#f2495c",
-                    "value": 80
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_redis_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_4": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Deletion Policy",
-            "description": "KubeDB Database Resource deletionPolicy"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#c4162a",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_redis_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_5": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Total Nodes",
-            "description": "Total node count of Redis cluster"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#f2495c",
-                    "value": 80
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_redis_replicas{namespace=\"$namespace\",app=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_6": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "CPU Request (Core)",
-            "description": "Initial Requested CPU amount by Postgres Instance"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_redis_resource_request_cpu{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_7": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "CPU Limit (Core)",
-            "description": "CPU Limit in core by Redis instance"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_redis_resource_limit_cpu{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_8": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Memory Request",
-            "description": "Initial Requested Memory amount by Redis Instance"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "bytes"
-              },
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_redis_resource_request_memory{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_9": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Memory Limit",
-            "description": "KubeDB Redis Total Memory Limit"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "bytes"
-              },
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_redis_resource_limit_memory{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "1_0": {
+      "11": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -559,7 +236,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -567,7 +244,7 @@
           ]
         }
       },
-      "1_1": {
+      "12": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -581,37 +258,49 @@
                 {
                   "header": "Time",
                   "name": "timestamp",
-                  "width": null
+                  "width": "auto"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
-                }
-              ],
-              "transforms": [
-                {
-                  "kind": "MergeSeries",
-                  "spec": {}
                 }
               ]
             }
@@ -685,7 +374,7 @@
           ]
         }
       },
-      "2_0": {
+      "13": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -716,7 +405,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\",container!=\"\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -724,7 +413,7 @@
           ]
         }
       },
-      "2_1": {
+      "14": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -739,46 +428,67 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (RSS)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Cache)",
-                  "name": "Value #G"
+                  "name": "value #7"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Swap)",
-                  "name": "Value #H"
+                  "name": "value #8"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
-                }
-              ],
-              "transforms": [
-                {
-                  "kind": "MergeSeries",
-                  "spec": {}
                 }
               ]
             }
@@ -891,7 +601,7 @@
           ]
         }
       },
-      "3_0": {
+      "15": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -922,7 +632,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -930,7 +640,7 @@
           ]
         }
       },
-      "3_1": {
+      "16": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -961,7 +671,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
                   }
                 }
               }
@@ -974,7 +684,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
                   }
                 }
               }
@@ -982,7 +692,7 @@
           ]
         }
       },
-      "3_2": {
+      "17": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1012,7 +722,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\"}[5m])))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1020,7 +730,7 @@
           ]
         }
       },
-      "3_3": {
+      "18": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1050,7 +760,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\"}[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1058,7 +768,7 @@
           ]
         }
       },
-      "3_4": {
+      "19": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1073,38 +783,53 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads)",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Writes)",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads + Writes)",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read)",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Write)",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read + Write)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
-                }
-              ],
-              "transforms": [
-                {
-                  "kind": "MergeSeries",
-                  "spec": {}
                 }
               ]
             }
@@ -1191,7 +916,47 @@
           ]
         }
       },
-      "4_0": {
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Max Clients",
+            "description": "redis_config_maxclients"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              },
+              "valueFontSize": 25
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(redis_config_maxclients{namespace=\"$namespace\" , pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\"}) ",
+                    "seriesNameFormat": "values"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1201,52 +966,7 @@
           "plugin": {
             "kind": "Table",
             "spec": {
-              "columnSettings": [
-                {
-                  "header": "Volume",
-                  "name": "value"
-                },
-                {
-                  "header": "Pod",
-                  "name": "pod"
-                },
-                {
-                  "hide": true,
-                  "name": "timestamp"
-                },
-                {
-                  "hide": true,
-                  "name": "endpoint"
-                },
-                {
-                  "hide": true,
-                  "name": "instance"
-                },
-                {
-                  "hide": true,
-                  "name": "job"
-                },
-                {
-                  "hide": true,
-                  "name": "metrics_path"
-                },
-                {
-                  "hide": true,
-                  "name": "namespace"
-                },
-                {
-                  "hide": true,
-                  "name": "node"
-                },
-                {
-                  "hide": true,
-                  "name": "persistentvolumeclaim"
-                },
-                {
-                  "hide": true,
-                  "name": "service"
-                }
-              ]
+              "columnSettings": []
             }
           },
           "queries": [
@@ -1266,7 +986,7 @@
           ]
         }
       },
-      "4_1": {
+      "21": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1291,7 +1011,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1299,7 +1019,7 @@
           ]
         }
       },
-      "4_2": {
+      "22": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1326,7 +1046,7 @@
               },
               "yAxis": {
                 "format": {
-                  "unit": "bytes"
+                  "unit": "decbytes"
                 },
                 "max": 5000,
                 "min": 0
@@ -1342,7 +1062,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\",namespace=~\"$namespace\"}) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1350,7 +1070,7 @@
           ]
         }
       },
-      "5_0": {
+      "23": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1380,7 +1100,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1388,7 +1108,7 @@
           ]
         }
       },
-      "5_1": {
+      "24": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1418,7 +1138,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1426,7 +1146,7 @@
           ]
         }
       },
-      "6_0": {
+      "25": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1445,7 +1165,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(redis_db_keys{namespace=\"$namespace\" , pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\"}) by (db)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ db }}` }}"
                   }
                 }
               }
@@ -1453,7 +1173,7 @@
           ]
         }
       },
-      "6_1": {
+      "26": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1493,7 +1213,7 @@
           ]
         }
       },
-      "6_2": {
+      "27": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1532,6 +1252,303 @@
             }
           ]
         }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "RedisMode",
+            "description": "RedisMode CR Name"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "mean",
+              "colorMode": "none",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": "mode",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_redis_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{mode}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Deletion Policy",
+            "description": "KubeDB Database Resource deletionPolicy"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_redis_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Nodes",
+            "description": "Total node count of Redis cluster"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_redis_replicas{namespace=\"$namespace\",app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Request (Core)",
+            "description": "Initial Requested CPU amount by Postgres Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_redis_resource_request_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Limit (Core)",
+            "description": "CPU Limit in core by Redis instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_redis_resource_limit_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Request",
+            "description": "Initial Requested Memory amount by Redis Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_redis_resource_request_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Limit",
+            "description": "KubeDB Redis Total Memory Limit"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_redis_resource_limit_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
       }
     },
     "layouts": [
@@ -1539,10 +1556,7 @@
         "kind": "Grid",
         "spec": {
           "display": {
-            "title": "General",
-            "collapse": {
-              "open": true
-            }
+            "title": "Panel Group 1"
           },
           "items": [
             {
@@ -1551,7 +1565,7 @@
               "width": 8,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_0"
+                "$ref": "#/spec/panels/0"
               }
             },
             {
@@ -1560,7 +1574,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_1"
+                "$ref": "#/spec/panels/1"
               }
             },
             {
@@ -1569,7 +1583,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_2"
+                "$ref": "#/spec/panels/2"
               }
             },
             {
@@ -1578,7 +1592,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_3"
+                "$ref": "#/spec/panels/3"
               }
             },
             {
@@ -1587,7 +1601,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_4"
+                "$ref": "#/spec/panels/4"
               }
             },
             {
@@ -1596,7 +1610,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_5"
+                "$ref": "#/spec/panels/5"
               }
             },
             {
@@ -1605,7 +1619,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_6"
+                "$ref": "#/spec/panels/6"
               }
             },
             {
@@ -1614,7 +1628,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_7"
+                "$ref": "#/spec/panels/7"
               }
             },
             {
@@ -1623,7 +1637,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_8"
+                "$ref": "#/spec/panels/8"
               }
             },
             {
@@ -1632,7 +1646,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_9"
+                "$ref": "#/spec/panels/9"
               }
             },
             {
@@ -1641,29 +1655,16 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_10"
+                "$ref": "#/spec/panels/10"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "CPU Info",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 8,
               "width": 24,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/1_0"
+                "$ref": "#/spec/panels/11"
               }
             },
             {
@@ -1672,29 +1673,16 @@
               "width": 24,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/1_1"
+                "$ref": "#/spec/panels/12"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Memory Info",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 22,
               "width": 24,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/2_0"
+                "$ref": "#/spec/panels/13"
               }
             },
             {
@@ -1703,29 +1691,16 @@
               "width": 24,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/2_1"
+                "$ref": "#/spec/panels/14"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Storage Info",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 35,
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/3_0"
+                "$ref": "#/spec/panels/15"
               }
             },
             {
@@ -1734,7 +1709,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/3_1"
+                "$ref": "#/spec/panels/16"
               }
             },
             {
@@ -1743,7 +1718,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_2"
+                "$ref": "#/spec/panels/17"
               }
             },
             {
@@ -1752,7 +1727,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_3"
+                "$ref": "#/spec/panels/18"
               }
             },
             {
@@ -1761,29 +1736,16 @@
               "width": 24,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_4"
+                "$ref": "#/spec/panels/19"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Persistent Storage Insight",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 59,
               "width": 12,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/4_0"
+                "$ref": "#/spec/panels/20"
               }
             },
             {
@@ -1792,7 +1754,7 @@
               "width": 12,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/4_1"
+                "$ref": "#/spec/panels/21"
               }
             },
             {
@@ -1801,29 +1763,16 @@
               "width": 24,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/4_2"
+                "$ref": "#/spec/panels/22"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Network Info",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 74,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_0"
+                "$ref": "#/spec/panels/23"
               }
             },
             {
@@ -1832,29 +1781,16 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_1"
+                "$ref": "#/spec/panels/24"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Database Cluster Info",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 82,
               "width": 24,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/6_0"
+                "$ref": "#/spec/panels/25"
               }
             },
             {
@@ -1863,7 +1799,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/6_1"
+                "$ref": "#/spec/panels/26"
               }
             },
             {
@@ -1872,7 +1808,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/6_2"
+                "$ref": "#/spec/panels/27"
               }
             }
           ]

--- a/charts/kubedb-perses-dashboards/dashboards/redis/sentinel_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/redis/sentinel_pod_dashboard.json
@@ -1,0 +1,540 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "fF-N4cH7k",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / RedisSentinel / Pod"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "redis_up"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "redissentinel",
+            "hidden": false
+          },
+          "defaultValue": "sentinel",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "alphabetical-asc",
+          "plugin": {
+            "kind": "PrometheusPromQLVariable",
+            "spec": {
+              "expr": "kubedb_com_redissentinel_created{namespace=\"$namespace\"}",
+              "labelName": "app"
+            }
+          },
+          "name": "app"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Pod Name",
+            "hidden": false
+          },
+          "defaultValue": "sentinel-0",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "alphabetical-asc",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "pod",
+              "matchers": [
+                "redis_up{namespace=~\"$namespace\",pod=~\"${app}-.*\"}"
+              ]
+            }
+          },
+          "name": "pod"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Status"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 1,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "rgba(50, 172, 45, 0.97)",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "redis_up{pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Connected Clients"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 0,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "redis_connected_clients{pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Commands Executed / sec"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(redis_commands_processed_total{pod=~\"$pod\"}[1m])",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Uptime"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "seconds"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "max(max_over_time(redis_uptime_in_seconds{pod=~\"$pod\"}[$__interval]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Go Routines",
+            "description": "Number of goroutines that currently exist"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 0,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              },
+              "valueFontSize": 32
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "go_goroutines{pod=\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Network I/O"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(redis_net_input_bytes_total{pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{ input }}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(redis_net_output_bytes_total{pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{ output }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Redis sentinel connected clients"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "redis_connected_clients{pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Average CPU Usage",
+            "description": "Average user and system CPU time spent in seconds."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(rate(process_cpu_seconds_total{pod=\"$pod\", namespace=\"$namespace\"}[5m]) * 1000)",
+                    "seriesNameFormat": "used"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Average Memory Usage",
+            "description": "Virtual and Resident memory size in bytes, averages over 5 min interval"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(rate(process_resident_memory_bytes{pod=\"$pod\", namespace=\"$namespace\"}[5m]))",
+                    "seriesNameFormat": "Resident Mem"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(rate(process_virtual_memory_bytes{pod=\"$pod\", namespace=\"$namespace\"}[5m]))",
+                    "seriesNameFormat": "Virtual Mem"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 8,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 12,
+              "y": 1,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 8,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 8,
+              "y": 4,
+              "width": 4,
+              "height": 4,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 12,
+              "y": 8,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 0,
+              "y": 16,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 12,
+              "y": 16,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/redis/sentinel_summary_dashbaord.json
+++ b/charts/kubedb-perses-dashboards/dashboards/redis/sentinel_summary_dashbaord.json
@@ -79,7 +79,7 @@
       }
     ],
     "panels": {
-      "0_0": {
+      "0": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -90,6 +90,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
               "thresholds": {
                 "steps": [
                   {
@@ -109,7 +111,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_redissentinel_status_phase{namespace=\"$namespace\", redissentinel=\"$app\"} == 1\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
                   }
                 }
               }
@@ -117,7 +119,7 @@
           ]
         }
       },
-      "0_1": {
+      "1": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -128,9 +130,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": "version",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -155,7 +159,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_redissentinel_info{namespace=\"$namespace\", redissentinel=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{version}}` }}"
                   }
                 }
               }
@@ -163,7 +167,7 @@
           ]
         }
       },
-      "0_10": {
+      "10": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -174,6 +178,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -205,335 +210,7 @@
           ]
         }
       },
-      "0_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Blocked Clients",
-            "description": "Sentinel Blocked Clients"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              },
-              "valueFontSize": 25
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "avg(redis_blocked_clients{namespace=\"$namespace\" , pod=~\"$app-\\\\d+$\"}) ",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Sentinel Storage Type",
-            "description": "Sentinel Storage Type"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "mean",
-              "format": {
-                "unit": "decimal"
-              },
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#f2495c",
-                    "value": 80
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_redissentinel_info{namespace=\"$namespace\", redissentinel=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_4": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Deletion Policy",
-            "description": "KubeDB Database Resource deletionPolicy"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#c4162a",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_redissentinel_info{namespace=\"$namespace\", redissentinel=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_5": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Total Nodes",
-            "description": "Total node count of RedisSentinel cluster"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#f2495c",
-                    "value": 80
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_redissentinel_replicas{namespace=\"$namespace\",redissentinel=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_6": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "CPU Request (Core)",
-            "description": "Initial Requested CPU amount by Postgres Instance"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_redissentinel_resource_request_cpu{namespace=\"$namespace\", redissentinel=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_7": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "CPU Limit (Core)",
-            "description": "CPU Limit in core by RedisSentinel instance"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_redissentinel_resource_limit_cpu{namespace=\"$namespace\", redissentinel=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_8": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Memory Request",
-            "description": "Initial Requested Memory amount by RedisSentinel Instance"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "bytes"
-              },
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_redissentinel_resource_request_memory{namespace=\"$namespace\", redissentinel=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_9": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Memory Limit",
-            "description": "KubeDB RedisSentinel Total Memory Limit"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "bytes"
-              },
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_redissentinel_resource_limit_memory{namespace=\"$namespace\", redissentinel=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "1_0": {
+      "11": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -559,7 +236,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -567,7 +244,7 @@
           ]
         }
       },
-      "1_1": {
+      "12": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -581,37 +258,49 @@
                 {
                   "header": "Time",
                   "name": "timestamp",
-                  "width": null
+                  "width": "auto"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
-                }
-              ],
-              "transforms": [
-                {
-                  "kind": "MergeSeries",
-                  "spec": {}
                 }
               ]
             }
@@ -685,7 +374,7 @@
           ]
         }
       },
-      "2_0": {
+      "13": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -716,7 +405,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -724,7 +413,7 @@
           ]
         }
       },
-      "2_1": {
+      "14": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -739,46 +428,67 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (RSS)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Cache)",
-                  "name": "Value #G"
+                  "name": "value #7"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Swap)",
-                  "name": "Value #H"
+                  "name": "value #8"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
-                }
-              ],
-              "transforms": [
-                {
-                  "kind": "MergeSeries",
-                  "spec": {}
                 }
               ]
             }
@@ -891,7 +601,7 @@
           ]
         }
       },
-      "3_0": {
+      "15": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -922,7 +632,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -930,7 +640,7 @@
           ]
         }
       },
-      "3_1": {
+      "16": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -961,7 +671,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
                   }
                 }
               }
@@ -974,7 +684,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
                   }
                 }
               }
@@ -982,7 +692,7 @@
           ]
         }
       },
-      "3_2": {
+      "17": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1012,7 +722,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m])))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1020,7 +730,7 @@
           ]
         }
       },
-      "3_3": {
+      "18": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1050,7 +760,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1058,7 +768,7 @@
           ]
         }
       },
-      "3_4": {
+      "19": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1073,38 +783,53 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads)",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Writes)",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads + Writes)",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read)",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Write)",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read + Write)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
-                }
-              ],
-              "transforms": [
-                {
-                  "kind": "MergeSeries",
-                  "spec": {}
                 }
               ]
             }
@@ -1191,7 +916,47 @@
           ]
         }
       },
-      "4_0": {
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Blocked Clients",
+            "description": "Sentinel Blocked Clients"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              },
+              "valueFontSize": 25
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(redis_blocked_clients{namespace=\"$namespace\" , pod=~\"$app-\\\\d+$\"}) ",
+                    "seriesNameFormat": "values"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1201,52 +966,7 @@
           "plugin": {
             "kind": "Table",
             "spec": {
-              "columnSettings": [
-                {
-                  "header": "Volume",
-                  "name": "value"
-                },
-                {
-                  "header": "Pod",
-                  "name": "pod"
-                },
-                {
-                  "hide": true,
-                  "name": "timestamp"
-                },
-                {
-                  "hide": true,
-                  "name": "endpoint"
-                },
-                {
-                  "hide": true,
-                  "name": "instance"
-                },
-                {
-                  "hide": true,
-                  "name": "job"
-                },
-                {
-                  "hide": true,
-                  "name": "metrics_path"
-                },
-                {
-                  "hide": true,
-                  "name": "namespace"
-                },
-                {
-                  "hide": true,
-                  "name": "node"
-                },
-                {
-                  "hide": true,
-                  "name": "persistentvolumeclaim"
-                },
-                {
-                  "hide": true,
-                  "name": "service"
-                }
-              ]
+              "columnSettings": []
             }
           },
           "queries": [
@@ -1266,7 +986,7 @@
           ]
         }
       },
-      "4_1": {
+      "21": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1291,7 +1011,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1299,7 +1019,7 @@
           ]
         }
       },
-      "4_2": {
+      "22": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1326,7 +1046,7 @@
               },
               "yAxis": {
                 "format": {
-                  "unit": "bytes"
+                  "unit": "decbytes"
                 },
                 "max": 5000,
                 "min": 0
@@ -1342,7 +1062,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1350,7 +1070,7 @@
           ]
         }
       },
-      "5_0": {
+      "23": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1380,7 +1100,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1388,7 +1108,7 @@
           ]
         }
       },
-      "5_1": {
+      "24": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1418,6 +1138,303 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Sentinel Storage Type",
+            "description": "Sentinel Storage Type"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "mean",
+              "colorMode": "none",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": "storageType",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_redissentinel_info{namespace=\"$namespace\", redissentinel=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{storageType}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Deletion Policy",
+            "description": "KubeDB Database Resource deletionPolicy"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_redissentinel_info{namespace=\"$namespace\", redissentinel=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Nodes",
+            "description": "Total node count of RedisSentinel cluster"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_redissentinel_replicas{namespace=\"$namespace\",redissentinel=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Request (Core)",
+            "description": "Initial Requested CPU amount by Postgres Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_redissentinel_resource_request_cpu{namespace=\"$namespace\", redissentinel=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Limit (Core)",
+            "description": "CPU Limit in core by RedisSentinel instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_redissentinel_resource_limit_cpu{namespace=\"$namespace\", redissentinel=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Request",
+            "description": "Initial Requested Memory amount by RedisSentinel Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_redissentinel_resource_request_memory{namespace=\"$namespace\", redissentinel=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Limit",
+            "description": "KubeDB RedisSentinel Total Memory Limit"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_redissentinel_resource_limit_memory{namespace=\"$namespace\", redissentinel=\"$app\"}",
                     "seriesNameFormat": ""
                   }
                 }
@@ -1432,10 +1449,7 @@
         "kind": "Grid",
         "spec": {
           "display": {
-            "title": "General",
-            "collapse": {
-              "open": true
-            }
+            "title": "Panel Group 1"
           },
           "items": [
             {
@@ -1444,7 +1458,7 @@
               "width": 8,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_0"
+                "$ref": "#/spec/panels/0"
               }
             },
             {
@@ -1453,7 +1467,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_1"
+                "$ref": "#/spec/panels/1"
               }
             },
             {
@@ -1462,7 +1476,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_2"
+                "$ref": "#/spec/panels/2"
               }
             },
             {
@@ -1471,7 +1485,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_3"
+                "$ref": "#/spec/panels/3"
               }
             },
             {
@@ -1480,7 +1494,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_4"
+                "$ref": "#/spec/panels/4"
               }
             },
             {
@@ -1489,7 +1503,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_5"
+                "$ref": "#/spec/panels/5"
               }
             },
             {
@@ -1498,7 +1512,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_6"
+                "$ref": "#/spec/panels/6"
               }
             },
             {
@@ -1507,7 +1521,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_7"
+                "$ref": "#/spec/panels/7"
               }
             },
             {
@@ -1516,7 +1530,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_8"
+                "$ref": "#/spec/panels/8"
               }
             },
             {
@@ -1525,7 +1539,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_9"
+                "$ref": "#/spec/panels/9"
               }
             },
             {
@@ -1534,29 +1548,16 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_10"
+                "$ref": "#/spec/panels/10"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "CPU Info",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 8,
               "width": 24,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/1_0"
+                "$ref": "#/spec/panels/11"
               }
             },
             {
@@ -1565,29 +1566,16 @@
               "width": 24,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/1_1"
+                "$ref": "#/spec/panels/12"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Memory Info",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 22,
               "width": 24,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/2_0"
+                "$ref": "#/spec/panels/13"
               }
             },
             {
@@ -1596,29 +1584,16 @@
               "width": 24,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/2_1"
+                "$ref": "#/spec/panels/14"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Storage Info",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 35,
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/3_0"
+                "$ref": "#/spec/panels/15"
               }
             },
             {
@@ -1627,7 +1602,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/3_1"
+                "$ref": "#/spec/panels/16"
               }
             },
             {
@@ -1636,7 +1611,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_2"
+                "$ref": "#/spec/panels/17"
               }
             },
             {
@@ -1645,7 +1620,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_3"
+                "$ref": "#/spec/panels/18"
               }
             },
             {
@@ -1654,29 +1629,16 @@
               "width": 24,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_4"
+                "$ref": "#/spec/panels/19"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Persistent Storage Insight",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 59,
               "width": 12,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/4_0"
+                "$ref": "#/spec/panels/20"
               }
             },
             {
@@ -1685,7 +1647,7 @@
               "width": 12,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/4_1"
+                "$ref": "#/spec/panels/21"
               }
             },
             {
@@ -1694,29 +1656,16 @@
               "width": 24,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/4_2"
+                "$ref": "#/spec/panels/22"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Network Info",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 74,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_0"
+                "$ref": "#/spec/panels/23"
               }
             },
             {
@@ -1725,7 +1674,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_1"
+                "$ref": "#/spec/panels/24"
               }
             }
           ]

--- a/charts/kubedb-perses-dashboards/dashboards/singlestore/singlestore_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/singlestore/singlestore_database_dashboard.json
@@ -90,26 +90,6 @@
           "plugin": {
             "kind": "Table",
             "spec": {
-              "cellSettings": [
-                {
-                  "condition": {
-                    "kind": "Value",
-                    "spec": {
-                      "value": "0"
-                    }
-                  },
-                  "text": "DOWN"
-                },
-                {
-                  "condition": {
-                    "kind": "Value",
-                    "spec": {
-                      "value": "1"
-                    }
-                  },
-                  "text": "UP"
-                }
-              ],
               "columnSettings": []
             }
           },
@@ -122,7 +102,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "memsql_up{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -151,7 +131,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "memsql_status_uptime{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -178,7 +158,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(memsql_status_queries{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -205,7 +185,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "memsql_status_max_used_connections{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Current - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -218,7 +198,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "memsql_variable_max_connections{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Max - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -245,7 +225,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "memsql_variable_load_data_read_size{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "reads - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -258,7 +238,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "memsql_variable_load_data_write_size{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "write - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -285,7 +265,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(memsql_status_bytes_received{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "received - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -298,7 +278,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(memsql_status_bytes_sent{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "sent - {{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -331,7 +311,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "memsql_status_alloc_databases_list_entry{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }} = '{{ `{{ command }}` }}'"
                   }
                 }
               }
@@ -349,6 +329,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -373,7 +354,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "memsql_variable_default_partitions_per_leaf{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod }}` }}"
                   }
                 }
               }
@@ -391,6 +372,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -415,7 +397,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "memsql_distributed_partitions_total{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ database_name }}` }}"
                   }
                 }
               }
@@ -433,6 +415,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -460,7 +443,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "memsql_distributed_partitions_offline{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ database_name }}` }}"
                   }
                 }
               }

--- a/charts/kubedb-perses-dashboards/dashboards/singlestore/singlestore_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/singlestore/singlestore_pod_dashboard.json
@@ -1,4 +1,5 @@
 {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
 {
   "kind": "Dashboard",
   "metadata": {
@@ -105,7 +106,7 @@
       }
     ],
     "panels": {
-      "0_0": {
+      "0": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -115,9 +116,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
+              "metricLabel": "pod",
               "thresholds": {
                 "steps": [
                   {
@@ -137,7 +140,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "memsql_up{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -145,7 +148,7 @@
           ]
         }
       },
-      "0_1": {
+      "1": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -155,6 +158,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -181,7 +185,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "memsql_status_uptime{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{ pod}}` }}"
                   }
                 }
               }
@@ -189,7 +193,446 @@
           ]
         }
       },
-      "0_2": {
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Singlestore Client Thread Activity"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_status_threads_connected{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Threads Connected - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_status_threads_running{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Threads Running - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Singlestore Thread Cache"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_variable_thread_cache_size{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Thread Cache Size - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_status_threads_cached{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Threads Cached - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_status_threads_created{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Threads Created - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Singlestore Failed Queries"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_status_failed_write_queries{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "failed write queries -{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_status_failed_read_queries{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "failed read queries -{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Singlestore Queries"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_status_queries{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Queries - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Singlestore Total Disk Size MB"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_status_disk_total_size_mb{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Total Disk Size MB - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Singlestore Memory Summary Variables"
+          },
+          "plugin": {
+            "kind": "BarChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "decimal"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_status_total_server_memory{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Total Server Memory - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_status_alloc_table_memory{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Alloc Table Memory - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_status_buffer_manager_memory{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Buffer Manager Memory - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_status_alloc_query_execution{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Alloc Query Execution - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_status_alloc_variable{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Alloc variable - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Singlestore Locks"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_status_row_lock_wait_time{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "row lock wait time - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_variable_lock_wait_timeout{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "variable lock wait timeout - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_variable_distributed_commit_lock_timeout{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "variable distributes commit lock timeout - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Singlestore Questions"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(memsql_status_questions{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Questions - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Singlestore Network Traffic",
+            "description": "\n\nHere we can see how much network traffic is generated by Singlestore. Outbound is network traffic sent from Singlestore and Inbound is network traffic Singlestore has received."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(memsql_status_bytes_received{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Inbound - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(memsql_status_bytes_sent{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "Outbound - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Singlestore Network Usage Hourly",
+            "description": "\n\nHere we can see how much network traffic is generated by Singlestore. Outbound is network traffic sent from Singlestore and Inbound is network traffic Singlestore has received."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "1h",
+                    "query": "increase(memsql_status_bytes_received{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[1h])",
+                    "seriesNameFormat": "Received - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "1h",
+                    "query": "increase(memsql_status_bytes_sent{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[1h])",
+                    "seriesNameFormat": "Sent - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -199,6 +642,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "format": {
                 "unit": "decimal"
               },
@@ -225,7 +669,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "memsql_variable_memsql_version{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{version}}` }}"
                   }
                 }
               }
@@ -233,26 +677,18 @@
           ]
         }
       },
-      "0_3": {
+      "20": {
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "Current QPS"
+            "name": "Singlestore Row store variables"
           },
           "plugin": {
-            "kind": "StatChart",
+            "kind": "BarChart",
             "spec": {
               "calculation": "last-number",
               "format": {
                 "unit": "decimal"
-              },
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#8ab8ff",
-                    "value": 0
-                  }
-                ]
               }
             }
           },
@@ -264,8 +700,47 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "minStep": "",
-                    "query": "rate(memsql_status_queries{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
+                    "query": "memsql_status_alloc_skiplist_tower{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Alloc Skiplist Tower - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_status_alloc_table_primary{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Alloc Table Primary - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_status_alloc_deleted_version{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Alloc Delete Version - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_status_alloc_hash_buckets{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Alloc Hash Buckets - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -273,27 +748,24 @@
           ]
         }
       },
-      "0_4": {
+      "21": {
         "kind": "Panel",
         "spec": {
           "display": {
-            "name": "Transaction Buffer"
+            "name": "Singlestore Pipelines"
           },
           "plugin": {
-            "kind": "StatChart",
+            "kind": "GaugeChart",
             "spec": {
               "calculation": "last-number",
-              "format": {
-                "unit": "decimal"
-              },
               "thresholds": {
                 "steps": [
                   {
-                    "color": "#e02f44",
+                    "color": "#73bf69",
                     "value": 0
                   },
                   {
-                    "color": "#8ab8ff",
+                    "color": "#f2495c",
                     "value": 80
                   }
                 ]
@@ -308,8 +780,47 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "minStep": "",
-                    "query": "memsql_variable_transaction_buffer{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "query": "memsql_variable_pipelines_max_concurrent{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Max Concurrent - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_variable_pipelines_cdc_java_heap_size{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "CDC Java Heap Size - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_variable_pipelines_pooled_extractor_batches{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Pooled Extractor Batches- {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_variable_pipelines_offsets_gc_skew_time_minutes{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Offsets GC skew Time Minutes - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -317,7 +828,89 @@
           ]
         }
       },
-      "10_0": {
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Singlestore SSL Session"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "list",
+                "position": "bottom"
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_status_ssl_session_cache_hits{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": " Session Cache Hit - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_status_ssl_session_cache_misses{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Session Cache Misses - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_status_ssl_session_cache_size{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Session Cache Size - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_status_ssl_session_cache_overflows{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Session Cache Overflows - {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -360,7 +953,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "memsql_status_ssl_session_cache_overflows{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Query Cache Size - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -368,7 +961,7 @@
           ]
         }
       },
-      "10_1": {
+      "24": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -389,7 +982,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "memsql_variable_disk_plan_expiration_minutes{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Disk Plan Expiration Minutes - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -402,7 +995,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "memsql_variable_enable_disk_plan_expiration{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Disk_plan_expiration - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -415,7 +1008,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "memsql_variable_plan_expiration_minutes{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Plan Expiration Minutes - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -423,7 +1016,93 @@
           ]
         }
       },
-      "1_0": {
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Current QPS"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "format": {
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#8ab8ff",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(memsql_status_queries{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Transaction Buffer"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "value",
+              "format": {
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#e02f44",
+                    "value": 0
+                  },
+                  {
+                    "color": "#8ab8ff",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "memsql_variable_transaction_buffer{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -448,7 +1127,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", pod=~\"$pod\", container!=\"\", image!=\"\"}[5m])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{container}}` }}"
                   }
                 }
               }
@@ -456,7 +1135,7 @@
           ]
         }
       },
-      "1_1": {
+      "6": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -481,7 +1160,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$pod\", container!=\"\", image!=\"\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -489,7 +1168,7 @@
           ]
         }
       },
-      "1_2": {
+      "7": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -515,7 +1194,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(process_open_fds{pod=~\"$pod\", namespace=\"$namespace\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -523,7 +1202,7 @@
           ]
         }
       },
-      "2_0": {
+      "8": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -542,7 +1221,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "memsql_variable_max_connection_threads{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Max Connection Threads - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -555,7 +1234,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "memsql_variable_max_connections{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Max Connection - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -563,7 +1242,7 @@
           ]
         }
       },
-      "2_1": {
+      "9": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -582,7 +1261,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "memsql_status_aborted_connects{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Aborted Connects - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -595,680 +1274,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "memsql_status_aborted_clients{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Singlestore Client Thread Activity"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_threads_connected{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_threads_running{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Singlestore Thread Cache"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_variable_thread_cache_size{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_threads_cached{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_threads_created{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "4_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Singlestore Failed Queries"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_failed_write_queries{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_failed_read_queries{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "4_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Singlestore Queries"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_queries{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Singlestore Total Disk Size MB"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_disk_total_size_mb{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Singlestore Memory Summary Variables"
-          },
-          "plugin": {
-            "kind": "BarChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "decimal"
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_total_server_memory{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_alloc_table_memory{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_buffer_manager_memory{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_alloc_query_execution{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_alloc_variable{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "6_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Singlestore Locks"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_row_lock_wait_time{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_variable_lock_wait_timeout{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_variable_distributed_commit_lock_timeout{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "6_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Singlestore Questions"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(memsql_status_questions{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "7_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Singlestore Network Traffic",
-            "description": "\n\nHere we can see how much network traffic is generated by Singlestore. Outbound is network traffic sent from Singlestore and Inbound is network traffic Singlestore has received."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(memsql_status_bytes_received{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "rate(memsql_status_bytes_sent{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[5m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "7_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Singlestore Network Usage Hourly",
-            "description": "\n\nHere we can see how much network traffic is generated by Singlestore. Outbound is network traffic sent from Singlestore and Inbound is network traffic Singlestore has received."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "1h",
-                    "query": "increase(memsql_status_bytes_received{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[1h])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "1h",
-                    "query": "increase(memsql_status_bytes_sent{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}[1h])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "8_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Singlestore Row store variables"
-          },
-          "plugin": {
-            "kind": "BarChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "decimal"
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_alloc_skiplist_tower{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_alloc_table_primary{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_alloc_deleted_version{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_alloc_hash_buckets{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "8_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Singlestore Pipelines"
-          },
-          "plugin": {
-            "kind": "GaugeChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#f2495c",
-                    "value": 80
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_variable_pipelines_max_concurrent{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_variable_pipelines_cdc_java_heap_size{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_variable_pipelines_pooled_extractor_batches{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_variable_pipelines_offsets_gc_skew_time_minutes{namespace=\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "9_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Singlestore SSL Session"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {
-              "legend": {
-                "mode": "list",
-                "position": "bottom",
-                "values": []
-              },
-              "visual": {
-                "areaOpacity": 0.1,
-                "connectNulls": true,
-                "display": "line",
-                "lineWidth": 1
-              },
-              "yAxis": {
-                "format": {
-                  "unit": "decimal"
-                }
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_ssl_session_cache_hits{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_ssl_session_cache_misses{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_ssl_session_cache_size{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "memsql_status_ssl_session_cache_overflows{namespace=~\"$namespace\",service=~\"$app+-stats\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "Aborted Clients - {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1282,10 +1288,7 @@
         "kind": "Grid",
         "spec": {
           "display": {
-            "title": "Singlestore Pod Summary",
-            "collapse": {
-              "open": true
-            }
+            "title": "Panel Group 1"
           },
           "items": [
             {
@@ -1294,7 +1297,7 @@
               "width": 5,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_0"
+                "$ref": "#/spec/panels/0"
               }
             },
             {
@@ -1303,7 +1306,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_1"
+                "$ref": "#/spec/panels/1"
               }
             },
             {
@@ -1312,7 +1315,7 @@
               "width": 6,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_2"
+                "$ref": "#/spec/panels/2"
               }
             },
             {
@@ -1321,7 +1324,7 @@
               "width": 5,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_3"
+                "$ref": "#/spec/panels/3"
               }
             },
             {
@@ -1330,29 +1333,16 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_4"
+                "$ref": "#/spec/panels/4"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Pod CPU, Memory and File Descriptor Stats",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 5,
               "width": 8,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/1_0"
+                "$ref": "#/spec/panels/5"
               }
             },
             {
@@ -1361,7 +1351,7 @@
               "width": 8,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/1_1"
+                "$ref": "#/spec/panels/6"
               }
             },
             {
@@ -1370,29 +1360,16 @@
               "width": 8,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/1_2"
+                "$ref": "#/spec/panels/7"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Connections",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 13,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2_0"
+                "$ref": "#/spec/panels/8"
               }
             },
             {
@@ -1401,29 +1378,16 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2_1"
+                "$ref": "#/spec/panels/9"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Client Threads",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 21,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_0"
+                "$ref": "#/spec/panels/10"
               }
             },
             {
@@ -1432,29 +1396,16 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_1"
+                "$ref": "#/spec/panels/11"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Queries, Failed Queries",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 29,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/4_0"
+                "$ref": "#/spec/panels/12"
               }
             },
             {
@@ -1463,29 +1414,16 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/4_1"
+                "$ref": "#/spec/panels/13"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Total Disk Size MB, Memory Summary Variables",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 37,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_0"
+                "$ref": "#/spec/panels/14"
               }
             },
             {
@@ -1494,29 +1432,16 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_1"
+                "$ref": "#/spec/panels/15"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Locks and Questions",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 45,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/6_0"
+                "$ref": "#/spec/panels/16"
               }
             },
             {
@@ -1525,29 +1450,16 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/6_1"
+                "$ref": "#/spec/panels/17"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Network",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 53,
               "width": 24,
               "height": 10,
               "content": {
-                "$ref": "#/spec/panels/7_0"
+                "$ref": "#/spec/panels/18"
               }
             },
             {
@@ -1556,29 +1468,16 @@
               "width": 24,
               "height": 10,
               "content": {
-                "$ref": "#/spec/panels/7_1"
+                "$ref": "#/spec/panels/19"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Row Store, Pipeline",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 74,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/8_0"
+                "$ref": "#/spec/panels/20"
               }
             },
             {
@@ -1587,51 +1486,25 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/8_1"
+                "$ref": "#/spec/panels/21"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "SSL Session",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 82,
               "width": 24,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/9_0"
+                "$ref": "#/spec/panels/22"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Free IO Pool Memory, PlanCache Memory ",
-            "collapse": {
-              "open": false
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 91,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/10_0"
+                "$ref": "#/spec/panels/23"
               }
             },
             {
@@ -1640,7 +1513,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/10_1"
+                "$ref": "#/spec/panels/24"
               }
             }
           ]

--- a/charts/kubedb-perses-dashboards/dashboards/singlestore/singlestore_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/singlestore/singlestore_summary_dashboard.json
@@ -1,0 +1,1588 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "qDMhbh0Iz",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / Singlestore / Summary"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "singlestore",
+            "hidden": false
+          },
+          "defaultValue": "singlestore-standalone",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "app",
+              "matchers": [
+                "kubedb_com_singlestore_status_phase{namespace=~\"$namespace\"}"
+              ]
+            }
+          },
+          "name": "app"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Database Status",
+            "description": "Represent database status"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_singlestore_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Version",
+            "description": "Singlestore CR Name"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "mean",
+              "colorMode": "none",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": " version ",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              },
+              "valueFontSize": 50
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_singlestore_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{ version }}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage",
+            "description": "CPU Usage by Singlestore pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(sum by(namespace,pod,container)(irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[5m]))* on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}))) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Quota",
+            "description": "CPU Quote information in details"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp",
+                  "width": "auto"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "CPU Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "CPU Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(sum by(namespace,pod,container)(irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[5m]))* on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}))) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(sum by(namespace,pod,container)(irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[5m]))* on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}))) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests{namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(sum by(namespace,pod,container)(irate(container_cpu_usage_seconds_total{image!=\"\",job=\"kubelet\",metrics_path=\"/metrics/cadvisor\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[5m]))* on (namespace, pod) group_left (node) topk by (namespace, pod) (1, max by (namespace, pod, node) (kube_pod_info{node!=\"\",namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}))) by (pod) / sum(cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-aggregator\\\\d+$|$app-leaf\\\\d+$|$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Usage",
+            "description": "Memory Usage by Singlestore pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app-leaf-\\\\d+$|$app-aggregator-\\\\d+$|$app-\\\\d+$\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Quota"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Requests",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Requests %",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Limits",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
+                  "header": "Memory Limits %",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (RSS)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Cache)",
+                  "name": "value #7"
+                },
+                {
+                  "format": {
+                    "unit": "bytes"
+                  },
+                  "header": "Memory Usage (Swap)",
+                  "name": "value #8"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_requests{namespace=\"$namespace\",pod=~\"$app-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",container!=\"\", image!=\"\"}) by (pod) / sum(cluster:namespace:pod_memory:active:kube_pod_container_resource_limits{namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_rss{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_cache{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(container_memory_swap{namespace=\"$namespace\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\",container!=\"\"}) by (pod)",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk Usage",
+            "description": "Disk usage by Singlestore pods"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\"}) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk R/W Info",
+            "description": "System Disk Usage Information"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\"}[5m]))by(pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "IOPS (Reads+Writes)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+\"}[5m])))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ThroughPut (Read+Write)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[5m]))",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Current Storage IO"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": [
+                {
+                  "header": "Time",
+                  "name": "timestamp"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads)",
+                  "name": "value #1"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Writes)",
+                  "name": "value #2"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "IOPS(Reads + Writes)",
+                  "name": "value #3"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read)",
+                  "name": "value #4"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Write)",
+                  "name": "value #5"
+                },
+                {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
+                  "header": "Throughput(Read + Write)",
+                  "name": "value #6"
+                },
+                {
+                  "format": {
+                    "unit": "decimal"
+                  },
+                  "header": "Pod",
+                  "name": "pod"
+                }
+              ]
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_total{container!=\"\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_total{container!=\"\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_total{container!=\"\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_writes_bytes_total{container!=\"\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\",pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}[5m]))",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Allocated Storage",
+            "description": "This panel describes allocated persistent storage in a table format\n"
+          },
+          "plugin": {
+            "kind": "Table",
+            "spec": {
+              "columnSettings": []
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Require Secure Transport",
+            "description": "When this option is enabled, connections attempted using insecure transport will be rejected."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_singlestore_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{requireSSL}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage",
+            "description": "This panel shows the persistent volume usage in percentage. "
+          },
+          "plugin": {
+            "kind": "BarChart",
+            "spec": {
+              "calculation": "last-number",
+              "format": {
+                "unit": "percent"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Persistent Volume Usage History",
+            "description": "This panel describes the persistent volume usage in a time series. "
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "mode": "table",
+                "position": "right",
+                "values": [
+                  "max",
+                  "last-number"
+                ]
+              },
+              "visual": {
+                "areaOpacity": 0.1,
+                "connectNulls": true,
+                "display": "line",
+                "lineStyle": "solid",
+                "lineWidth": 1
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decbytes"
+                },
+                "max": 5000,
+                "min": 0
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "(kubelet_volume_stats_used_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}) ",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Receive Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Transmit Bandwidth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Deletion Policy",
+            "description": "KubeDB Database Resource deletionPolicy"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_singlestore_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Nodes",
+            "description": "Total node count of Singlestore cluster"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_singlestore_replicas{namespace=\"$namespace\",app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Request (Core)",
+            "description": "Initial Requested CPU amount by Singlestore Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_singlestore_resource_request_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Limit (Core)",
+            "description": "CPU Limit in core by Singlestore instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_singlestore_resource_limit_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Request",
+            "description": "Initial Requested Memory amount by Singlestore Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_singlestore_resource_request_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Limit",
+            "description": "KubeDB Singlestore Total Memory Limit"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_singlestore_resource_limit_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Storage Request",
+            "description": "Total storage request by Singlestore nodes"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_singlestore_resource_request_storage{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 8,
+              "y": 1,
+              "width": 8,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 16,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 20,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 4,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 8,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 12,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 16,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 20,
+              "y": 4,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 0,
+              "y": 15,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 0,
+              "y": 22,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 0,
+              "y": 28,
+              "width": 24,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 0,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 12,
+              "y": 35,
+              "width": 12,
+              "height": 9,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 0,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 12,
+              "y": 44,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            },
+            {
+              "x": 0,
+              "y": 51,
+              "width": 24,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/18"
+              }
+            },
+            {
+              "x": 0,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/19"
+              }
+            },
+            {
+              "x": 12,
+              "y": 59,
+              "width": 12,
+              "height": 6,
+              "content": {
+                "$ref": "#/spec/panels/20"
+              }
+            },
+            {
+              "x": 0,
+              "y": 65,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/21"
+              }
+            },
+            {
+              "x": 0,
+              "y": 74,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/22"
+              }
+            },
+            {
+              "x": 12,
+              "y": 74,
+              "width": 12,
+              "height": 7,
+              "content": {
+                "$ref": "#/spec/panels/23"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/solr/solr-database.json
+++ b/charts/kubedb-perses-dashboards/dashboards/solr/solr-database.json
@@ -126,7 +126,7 @@
       }
     ],
     "panels": {
-      "0_0": {
+      "0": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -137,6 +137,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -168,7 +169,7 @@
           ]
         }
       },
-      "0_1": {
+      "1": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -179,6 +180,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -210,7 +212,7 @@
           ]
         }
       },
-      "0_10": {
+      "10": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -221,6 +223,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -252,7 +255,7 @@
           ]
         }
       },
-      "0_11": {
+      "11": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -272,7 +275,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "1 - max by (core, state) (solr_collections_replica_state{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",})",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{core}}` }} = {{ `{{state}}` }}"
                   }
                 }
               }
@@ -280,7 +283,231 @@
           ]
         }
       },
-      "0_2": {
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total QPS (by collection)",
+            "description": "Distributed QPS 1-min rate  aggregated by collection, roughly the current QPS across all nodes per "
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (collection) (solr_metrics_core_query_1minRate{namespace=~\"$namespace\",service=~\"$app-stats\"})",
+                    "seriesNameFormat": "{{ `{{collection}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total QPS (by node)",
+            "description": "Distributed QPS 1-min rate aggregated by base_url (Solr node)"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (collection) (solr_metrics_core_query_1minRate{namespace=~\"$namespace\",service=~\"$app-stats\"})",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Buffers",
+            "description": "Total number of jvm buffers"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_jvm_buffers{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{pool}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Buffer Size",
+            "description": "Size of buffer in bytes"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_jvm_buffers_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{pool}}` }} {{ `{{item}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "GC Count",
+            "description": "Total number of garbage collection"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_jvm_gc_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{item}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "GC Time Seconds",
+            "description": "Total time of garbage collection"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_jvm_gc_seconds_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{item}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Heap Size",
+            "description": "Total heap size in bytes"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_jvm_memory_heap_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{item}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Non-heap size",
+            "description": "Size of non heap memory"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_jvm_memory_non_heap_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{item}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -300,6 +527,230 @@
                   "spec": {
                     "minStep": "",
                     "query": "max by (core,replica, shard, collection) (solr_collections_shard_leader{namespace=~\"$namespace\",service=~\"$app-stats\"})",
+                    "seriesNameFormat": "{{ `{{core}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Pool size",
+            "description": "Pool size in bytes"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_jvm_memory_pools_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{space}}` }} {{ `{{item}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory size",
+            "description": "Memory size in bytes"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_jvm_memory_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{item}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Thread size",
+            "description": "Total thread size"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_jvm_threads{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{item}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Request",
+            "description": "Total number of requests"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_node_requests_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{handler}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "24": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Request time",
+            "description": "Total request time in seconds"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_node_time_seconds_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}{{ `{{handler}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "25": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Client Errors",
+            "description": "Total number of node client errors"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_node_client_errors_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}{{ `{{handler}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "26": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Server errors",
+            "description": "Total number of client server errors"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_node_server_errors_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}{{ `{{handler}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "27": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors",
+            "description": "Total node errors"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_node_errors_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}[1m])",
                     "seriesNameFormat": ""
                   }
                 }
@@ -308,7 +759,63 @@
           ]
         }
       },
-      "0_3": {
+      "28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Timeout",
+            "description": "Total node timeout"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_node_timeouts_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}{{ `{{handler}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "29": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cores",
+            "description": "Total node cores."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_node_cores{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{item}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -319,6 +826,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -350,7 +858,175 @@
           ]
         }
       },
-      "0_4": {
+      "30": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Core Root File System",
+            "description": "Total memory consumed by core root file system."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_node_core_root_fs_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{item}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "31": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Thread pool completed",
+            "description": "Total thread pool completed."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_node_thread_pool_completed_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{handler}}` }} {{ `{{executor}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "32": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Thread pool submitted",
+            "description": "Total thread pool submitted."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_node_thread_pool_submitted_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{handler}}` }} {{ `{{executor}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "33": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Thread pool running",
+            "description": "Total number of node thread pool"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_node_thread_pool_running{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{handler}}` }} {{ `{{executor}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "34": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Connections",
+            "description": "Total number of node connections"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_node_connections{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{handler}}` }} {{ `{{item}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "35": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Leader Count(by node)",
+            "description": "Total number of leaders by node."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (base_url) (max by (core) (solr_collections_shard_leader{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}))",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -361,6 +1037,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -392,7 +1069,7 @@
           ]
         }
       },
-      "0_5": {
+      "5": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -403,6 +1080,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -434,7 +1112,7 @@
           ]
         }
       },
-      "0_6": {
+      "6": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -445,6 +1123,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -476,7 +1155,7 @@
           ]
         }
       },
-      "0_7": {
+      "7": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -487,6 +1166,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -518,7 +1198,7 @@
           ]
         }
       },
-      "0_8": {
+      "8": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -529,6 +1209,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -560,7 +1241,7 @@
           ]
         }
       },
-      "0_9": {
+      "9": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -571,6 +1252,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "value",
               "thresholds": {
                 "steps": [
                   {
@@ -601,678 +1283,6 @@
             }
           ]
         }
-      },
-      "1_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Total QPS (by collection)",
-            "description": "Distributed QPS 1-min rate  aggregated by collection, roughly the current QPS across all nodes per "
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "sum by (collection) (solr_metrics_core_query_1minRate{namespace=~\"$namespace\",service=~\"$app-stats\"})",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "1_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Total QPS (by node)",
-            "description": "Distributed QPS 1-min rate aggregated by base_url (Solr node)"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "sum by (collection) (solr_metrics_core_query_1minRate{namespace=~\"$namespace\",service=~\"$app-stats\"})",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Buffers",
-            "description": "Total number of jvm buffers"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_jvm_buffers{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Buffer Size",
-            "description": "Size of buffer in bytes"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_jvm_buffers_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "GC Count",
-            "description": "Total number of garbage collection"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_jvm_gc_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "GC Time Seconds",
-            "description": "Total time of garbage collection"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_jvm_gc_seconds_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_4": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Heap Size",
-            "description": "Total heap size in bytes"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_jvm_memory_heap_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_5": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Non-heap size",
-            "description": "Size of non heap memory"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_jvm_memory_non_heap_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_6": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Pool size",
-            "description": "Pool size in bytes"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_jvm_memory_pools_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_7": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Memory size",
-            "description": "Memory size in bytes"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_jvm_memory_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_8": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Thread size",
-            "description": "Total thread size"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_jvm_threads{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Request",
-            "description": "Total number of requests"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_node_requests_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Request time",
-            "description": "Total request time in seconds"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_node_time_seconds_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_10": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Thread pool running",
-            "description": "Total number of node thread pool"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_node_thread_pool_running{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_11": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Connections",
-            "description": "Total number of node connections"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_node_connections{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_12": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Leader Count(by node)",
-            "description": "Total number of leaders by node."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "sum by (base_url) (max by (core) (solr_collections_shard_leader{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}))",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Client Errors",
-            "description": "Total number of node client errors"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_node_client_errors_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Server errors",
-            "description": "Total number of client server errors"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_node_server_errors_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_4": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Errors",
-            "description": "Total node errors"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_node_errors_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_5": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Timeout",
-            "description": "Total node timeout"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_node_timeouts_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_6": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Cores",
-            "description": "Total node cores."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_node_cores{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_7": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Core Root File System",
-            "description": "Total memory consumed by core root file system."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_node_core_root_fs_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_8": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Thread pool completed",
-            "description": "Total thread pool completed."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_node_thread_pool_completed_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_9": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Thread pool submitted",
-            "description": "Total thread pool submitted."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_node_thread_pool_submitted_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
       }
     },
     "layouts": [
@@ -1280,10 +1290,7 @@
         "kind": "Grid",
         "spec": {
           "display": {
-            "title": "Solr Cluster",
-            "collapse": {
-              "open": true
-            }
+            "title": "Panel Group 1"
           },
           "items": [
             {
@@ -1292,7 +1299,7 @@
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/0_0"
+                "$ref": "#/spec/panels/0"
               }
             },
             {
@@ -1301,7 +1308,7 @@
               "width": 6,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/0_1"
+                "$ref": "#/spec/panels/1"
               }
             },
             {
@@ -1310,7 +1317,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/0_2"
+                "$ref": "#/spec/panels/2"
               }
             },
             {
@@ -1319,7 +1326,7 @@
               "width": 4,
               "height": 4,
               "content": {
-                "$ref": "#/spec/panels/0_3"
+                "$ref": "#/spec/panels/3"
               }
             },
             {
@@ -1328,7 +1335,7 @@
               "width": 4,
               "height": 4,
               "content": {
-                "$ref": "#/spec/panels/0_4"
+                "$ref": "#/spec/panels/4"
               }
             },
             {
@@ -1337,7 +1344,7 @@
               "width": 4,
               "height": 4,
               "content": {
-                "$ref": "#/spec/panels/0_5"
+                "$ref": "#/spec/panels/5"
               }
             },
             {
@@ -1346,7 +1353,7 @@
               "width": 4,
               "height": 4,
               "content": {
-                "$ref": "#/spec/panels/0_6"
+                "$ref": "#/spec/panels/6"
               }
             },
             {
@@ -1355,7 +1362,7 @@
               "width": 4,
               "height": 4,
               "content": {
-                "$ref": "#/spec/panels/0_7"
+                "$ref": "#/spec/panels/7"
               }
             },
             {
@@ -1364,7 +1371,7 @@
               "width": 4,
               "height": 4,
               "content": {
-                "$ref": "#/spec/panels/0_8"
+                "$ref": "#/spec/panels/8"
               }
             },
             {
@@ -1373,7 +1380,7 @@
               "width": 6,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/0_9"
+                "$ref": "#/spec/panels/9"
               }
             },
             {
@@ -1382,7 +1389,7 @@
               "width": 6,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/0_10"
+                "$ref": "#/spec/panels/10"
               }
             },
             {
@@ -1391,29 +1398,16 @@
               "width": 12,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/0_11"
+                "$ref": "#/spec/panels/11"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Query Metrics",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 19,
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1_0"
+                "$ref": "#/spec/panels/12"
               }
             },
             {
@@ -1422,29 +1416,16 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1_1"
+                "$ref": "#/spec/panels/13"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "JVM Metics",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 28,
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_0"
+                "$ref": "#/spec/panels/14"
               }
             },
             {
@@ -1453,7 +1434,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_1"
+                "$ref": "#/spec/panels/15"
               }
             },
             {
@@ -1462,7 +1443,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_2"
+                "$ref": "#/spec/panels/16"
               }
             },
             {
@@ -1471,7 +1452,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_3"
+                "$ref": "#/spec/panels/17"
               }
             },
             {
@@ -1480,7 +1461,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_4"
+                "$ref": "#/spec/panels/18"
               }
             },
             {
@@ -1489,7 +1470,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_5"
+                "$ref": "#/spec/panels/19"
               }
             },
             {
@@ -1498,7 +1479,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_6"
+                "$ref": "#/spec/panels/20"
               }
             },
             {
@@ -1507,7 +1488,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_7"
+                "$ref": "#/spec/panels/21"
               }
             },
             {
@@ -1516,29 +1497,16 @@
               "width": 24,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_8"
+                "$ref": "#/spec/panels/22"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Node Metrics",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 69,
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_0"
+                "$ref": "#/spec/panels/23"
               }
             },
             {
@@ -1547,7 +1515,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_1"
+                "$ref": "#/spec/panels/24"
               }
             },
             {
@@ -1556,7 +1524,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_2"
+                "$ref": "#/spec/panels/25"
               }
             },
             {
@@ -1565,7 +1533,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_3"
+                "$ref": "#/spec/panels/26"
               }
             },
             {
@@ -1574,7 +1542,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_4"
+                "$ref": "#/spec/panels/27"
               }
             },
             {
@@ -1583,7 +1551,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_5"
+                "$ref": "#/spec/panels/28"
               }
             },
             {
@@ -1592,7 +1560,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_6"
+                "$ref": "#/spec/panels/29"
               }
             },
             {
@@ -1601,7 +1569,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_7"
+                "$ref": "#/spec/panels/30"
               }
             },
             {
@@ -1610,7 +1578,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_8"
+                "$ref": "#/spec/panels/31"
               }
             },
             {
@@ -1619,7 +1587,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_9"
+                "$ref": "#/spec/panels/32"
               }
             },
             {
@@ -1628,7 +1596,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_10"
+                "$ref": "#/spec/panels/33"
               }
             },
             {
@@ -1637,7 +1605,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_11"
+                "$ref": "#/spec/panels/34"
               }
             },
             {
@@ -1646,7 +1614,7 @@
               "width": 24,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_12"
+                "$ref": "#/spec/panels/35"
               }
             }
           ]

--- a/charts/kubedb-perses-dashboards/dashboards/solr/solr-pod.json
+++ b/charts/kubedb-perses-dashboards/dashboards/solr/solr-pod.json
@@ -1,4 +1,5 @@
 {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
 {
   "kind": "Dashboard",
   "metadata": {
@@ -269,7 +270,7 @@
       }
     ],
     "panels": {
-      "0_0": {
+      "0": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -295,7 +296,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by (collection) (solr_metrics_core_query_1minRate{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\",searchHandler=~\"$searchHandler\"})\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -303,7 +304,7 @@
           ]
         }
       },
-      "0_1": {
+      "1": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -329,7 +330,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by (base_url) (solr_metrics_core_query_1minRate{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\",searchHandler=~\"$searchHandler\"})",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{base_url}}` }}"
                   }
                 }
               }
@@ -337,7 +338,286 @@
           ]
         }
       },
-      "0_2": {
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Dispatches",
+            "description": "Implies query dispatches"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_jetty_dispatches_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Buffers",
+            "description": "Implies jvm buffers."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_jvm_buffers{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{pool}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Buffer Size",
+            "description": "Implies jvm buffer size in bytes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_jvm_buffers_bytes{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{pool}}` }} {{ `{{item}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "GC Count",
+            "description": "Implies garbage collection count."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_jvm_gc_total{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{item}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "GC Time Seconds",
+            "description": "Implies garbage collection time in seconds."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_jvm_gc_seconds_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{item}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Heap Size"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_jvm_memory_heap_bytes{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{item}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Non-Heap Size",
+            "description": "Implies non-heap size."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_jvm_memory_non_heap_bytes{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{item}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Pool Size",
+            "description": "Implies pool size."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_jvm_memory_pools_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{space}}` }} {{ `{{pod}}` }} {{ `{{item}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Size",
+            "description": "Implies memory size."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_jvm_memory_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{item}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Threads",
+            "description": "Implies number of threads"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_jvm_threads{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{item}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -363,7 +643,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "solr_metrics_core_query_p95_ms{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\",searchHandler=~\"$searchHandler\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{base_url}}` }}  {{ `{{core}}` }}  {{ `{{searchHandler}}` }}"
                   }
                 }
               }
@@ -371,7 +651,287 @@
           ]
         }
       },
-      "0_3": {
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Size",
+            "description": "Implies memory size of jvm os."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_jvm_os_memory_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{item}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "File Descriptors",
+            "description": "Implies jvm os file descriptor."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_jvm_os_file_descriptors{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{item}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Load",
+            "description": "Imples jvm os cpu load."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_jvm_os_cpu_load{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{item}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Time",
+            "description": "Implies jvm os cpu time."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_jvm_os_cpu_time_seconds{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{item}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "24": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Load Average",
+            "description": "Implies jvm os load average."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_jvm_os_load_average{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{item}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "25": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Requests",
+            "description": "Implies total node request for solr."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_node_requests_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{handler}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "26": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Request Time",
+            "description": "Implies total node request time in seconds."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_node_time_seconds_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}{{ `{{handler}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "27": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Client Errors",
+            "description": "Solr node client error."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_node_client_errors_total{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}{{ `{{handler}}` }}{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Server Errors",
+            "description": "Solr node server error."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_node_server_errors_total{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}{{ `{{handler}}` }}{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "29": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors",
+            "description": "total node error in solr"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_node_errors_total{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}{{ `{{handler}}` }}{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -397,7 +957,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "solr_metrics_core_query_p99_ms{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\",searchHandler=~\"$searchHandler\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{base_url}}` }}  {{ `{{core}}` }}  {{ `{{searchHandler}}` }} {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -405,7 +965,287 @@
           ]
         }
       },
-      "0_4": {
+      "30": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Timeouts",
+            "description": "total node timeouts."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_node_timeouts_total{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}{{ `{{handler}}` }}{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "31": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Cores",
+            "description": "total node cores."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_node_cores{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{item}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "32": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Core Root File System",
+            "description": "memory occupied by core root fs in bytes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_node_core_root_fs_bytes{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{item}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "33": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Thread Pool Completed",
+            "description": "total thread pool completed."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_node_thread_pool_completed_total{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{handler}}` }} {{ `{{executor}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "34": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Thread Pool Submitted",
+            "description": "Total thread pool submitted."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_node_thread_pool_submitted_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{handler}}` }} {{ `{{executor}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "35": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Thread Pool Running",
+            "description": "Total thread pool running."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_node_thread_pool_running{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{handler}}` }} {{ `{{executor}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "36": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Connections",
+            "description": "solr node connections."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_node_connections{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{handler}}` }} {{ `{{item}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "37": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Leader Count (by node)",
+            "description": "Number of leaders on each node"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "sum by (base_url) (max by (core) (solr_collections_shard_leader{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}))",
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "38": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Requests",
+            "description": "Total core request."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_core_requests_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\",searchHandler=~\"$searchHandler\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }}{{ `{{handler}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "39": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Request Time",
+            "description": "Total core time in seconds."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_core_time_seconds_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }}{{ `{{handler}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -431,7 +1271,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "solr_metrics_core_query_5minRate{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\",searchHandler=~\"$searchHandler\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{base_url}}` }}  {{ `{{core}}` }} {{ `{{pod}}` }} {{ `{{searchHandler}}` }}"
                   }
                 }
               }
@@ -439,7 +1279,286 @@
           ]
         }
       },
-      "0_5": {
+      "40": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Client Errors",
+            "description": "Total core client error."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_core_client_errors_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }}{{ `{{handler}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "41": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Server Errors"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_core_server_errors_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }}{{ `{{handler}}` }}{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "42": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Errors",
+            "description": "total core errors"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_core_errors_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }}{{ `{{handler}}` }}{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "43": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Timeouts",
+            "description": "Total core timeout."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_core_timeouts_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }}{{ `{{handler}}` }}{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "44": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Searcher Cache Hit Ratio",
+            "description": "Core searcher cache hit ratio."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_core_searcher_cache_ratio{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }} {{ `{{type}}` }} {{ `{{item}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "45": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Searcher Cache",
+            "description": "Core searcher cache."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_core_searcher_cache{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }} {{ `{{type}}` }} {{ `{{item}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "46": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Searcher Warm Up Time",
+            "description": "Core searcher warm up time."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_core_searcher_warmup_time_seconds{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }} {{ `{{type}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "47": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Searcher Cumulative Cache",
+            "description": "Core searcher cumulative cache."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_core_searcher_cumulative_cache_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }} {{ `{{type}}` }} {{ `{{item}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "48": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "File System",
+            "description": "Core file system size in bytes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_core_fs_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "49": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Index Size",
+            "description": "Core index size in bytes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_core_index_size_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -465,7 +1584,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "solr_metrics_core_query_1minRate{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\",searchHandler=~\"$searchHandler\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{base_url}}` }}  {{ `{{core}}` }}  {{ `{{pod}}` }} {{ `{{searchHandler}}` }}"
                   }
                 }
               }
@@ -473,7 +1592,286 @@
           ]
         }
       },
-      "0_6": {
+      "50": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Searcher Documents"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_core_searcher_documents{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }} {{ `{{item}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "51": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Update Handler Adds (cumulative)",
+            "description": "Cumulative core update handler."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_core_update_handler_adds_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "52": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Pending Docs",
+            "description": "Core update handler pending doc."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "solr_metrics_core_update_handler_pending_docs{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }}{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "53": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Update Handler Deletes By ID",
+            "description": "Number of core update handler delete by ID."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_core_update_handler_deletes_by_id_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "54": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Update Handler Deletes By Query",
+            "description": "Number of core update handler deleted by query"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_core_update_handler_deletes_by_query_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "55": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Update Handler Expunge Deletes",
+            "description": "Total number of update handler expunge deletes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_core_update_handler_expunge_deletes_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "56": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Update Handler Merges",
+            "description": "Total number of update handler merges."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_core_update_handler_merges_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "57": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Update Handler Splits",
+            "description": "Total number of update handler splits."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_core_update_handler_splits_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "58": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Update Handler Rollbacks",
+            "description": "Total number of update handler rollbacks."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_core_update_handler_rollbacks_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "59": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Update Handler Optimizes",
+            "description": "Total number of update handle optimizes."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_core_update_handler_optimizes_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -499,7 +1897,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "solr_metrics_core_query_p75_ms{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\",searchHandler=~\"$searchHandler\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{base_url}}` }}  {{ `{{core}}` }} {{ `{{pod}}` }} {{ `{{searchHandler}}` }}"
                   }
                 }
               }
@@ -507,7 +1905,119 @@
           ]
         }
       },
-      "0_7": {
+      "60": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Update Handler Auto Commits",
+            "description": "Total number of update handler auto commits."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_core_update_handler_auto_commits_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "61": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Update Handler Soft Auto Commits",
+            "description": "Total number of soft auto commits for update handler."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_core_update_handler_soft_auto_commits_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "62": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Update Handler Commits",
+            "description": "Total number of update handler commits."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_core_update_handler_commits_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "63": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Update Handler Errors",
+            "description": "Total number of update handler error"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "increase(solr_metrics_core_update_handler_errors_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
+                    "seriesNameFormat": "{{ `{{base_url}}` }}/{{ `{{core}}` }} {{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -535,7 +2045,7 @@
           ]
         }
       },
-      "1_0": {
+      "8": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -555,7 +2065,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "increase(solr_metrics_jetty_requests_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{method}}` }} {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -563,7 +2073,7 @@
           ]
         }
       },
-      "1_1": {
+      "9": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -583,1516 +2093,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "increase(solr_metrics_jetty_response_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "1_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Dispatches",
-            "description": "Implies query dispatches"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_jetty_dispatches_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Buffers",
-            "description": "Implies jvm buffers."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_jvm_buffers{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Buffer Size",
-            "description": "Implies jvm buffer size in bytes."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_jvm_buffers_bytes{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "GC Count",
-            "description": "Implies garbage collection count."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_jvm_gc_total{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "GC Time Seconds",
-            "description": "Implies garbage collection time in seconds."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_jvm_gc_seconds_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_4": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Heap Size"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_jvm_memory_heap_bytes{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_5": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Non-Heap Size",
-            "description": "Implies non-heap size."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_jvm_memory_non_heap_bytes{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_6": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Pool Size",
-            "description": "Implies pool size."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_jvm_memory_pools_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_7": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Memory Size",
-            "description": "Implies memory size."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_jvm_memory_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "2_8": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Threads",
-            "description": "Implies number of threads"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_jvm_threads{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Memory Size",
-            "description": "Implies memory size of jvm os."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_jvm_os_memory_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "File Descriptors",
-            "description": "Implies jvm os file descriptor."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_jvm_os_file_descriptors{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "CPU Load",
-            "description": "Imples jvm os cpu load."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_jvm_os_cpu_load{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "CPU Time",
-            "description": "Implies jvm os cpu time."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_jvm_os_cpu_time_seconds{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "3_4": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Load Average",
-            "description": "Implies jvm os load average."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_jvm_os_load_average{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "4_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Requests",
-            "description": "Implies total node request for solr."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_node_requests_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "4_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Request Time",
-            "description": "Implies total node request time in seconds."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_node_time_seconds_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "4_10": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Thread Pool Running",
-            "description": "Total thread pool running."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_node_thread_pool_running{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "4_11": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Connections",
-            "description": "solr node connections."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_node_connections{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "4_12": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Leader Count (by node)",
-            "description": "Number of leaders on each node"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "sum by (base_url) (max by (core) (solr_collections_shard_leader{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}))",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "4_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Client Errors",
-            "description": "Solr node client error."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_node_client_errors_total{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "4_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Server Errors",
-            "description": "Solr node server error."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_node_server_errors_total{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "4_4": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Errors",
-            "description": "total node error in solr"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_node_errors_total{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "4_5": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Timeouts",
-            "description": "total node timeouts."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_node_timeouts_total{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "4_6": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Cores",
-            "description": "total node cores."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_node_cores{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "4_7": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Core Root File System",
-            "description": "memory occupied by core root fs in bytes."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_node_core_root_fs_bytes{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "4_8": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Thread Pool Completed",
-            "description": "total thread pool completed."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_node_thread_pool_completed_total{namespace=\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "4_9": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Thread Pool Submitted",
-            "description": "Total thread pool submitted."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_node_thread_pool_submitted_total{namespace=~\"$namespace\",service=~\"$app-stats\",base_url=~\"$base_url\",pod=~\"$pod\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Requests",
-            "description": "Total core request."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_core_requests_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\",searchHandler=~\"$searchHandler\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Request Time",
-            "description": "Total core time in seconds."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_core_time_seconds_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_10": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "File System",
-            "description": "Core file system size in bytes."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_core_fs_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_11": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Index Size",
-            "description": "Core index size in bytes."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_core_index_size_bytes{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_12": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Searcher Documents"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_core_searcher_documents{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_13": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Update Handler Adds (cumulative)",
-            "description": "Cumulative core update handler."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_core_update_handler_adds_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_14": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Pending Docs",
-            "description": "Core update handler pending doc."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_core_update_handler_pending_docs{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_15": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Update Handler Deletes By ID",
-            "description": "Number of core update handler delete by ID."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_core_update_handler_deletes_by_id_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_16": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Update Handler Deletes By Query",
-            "description": "Number of core update handler deleted by query"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_core_update_handler_deletes_by_query_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_17": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Update Handler Expunge Deletes",
-            "description": "Total number of update handler expunge deletes."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_core_update_handler_expunge_deletes_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_18": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Update Handler Merges",
-            "description": "Total number of update handler merges."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_core_update_handler_merges_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_19": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Update Handler Splits",
-            "description": "Total number of update handler splits."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_core_update_handler_splits_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Client Errors",
-            "description": "Total core client error."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_core_client_errors_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_20": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Update Handler Rollbacks",
-            "description": "Total number of update handler rollbacks."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_core_update_handler_rollbacks_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_21": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Update Handler Optimizes",
-            "description": "Total number of update handle optimizes."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_core_update_handler_optimizes_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_22": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Update Handler Auto Commits",
-            "description": "Total number of update handler auto commits."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_core_update_handler_auto_commits_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_23": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Update Handler Soft Auto Commits",
-            "description": "Total number of soft auto commits for update handler."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_core_update_handler_soft_auto_commits_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_24": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Update Handler Commits",
-            "description": "Total number of update handler commits."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_core_update_handler_commits_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_25": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Update Handler Errors",
-            "description": "Total number of update handler error"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_core_update_handler_errors_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Server Errors"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_core_server_errors_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_4": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Errors",
-            "description": "total core errors"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_core_errors_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_5": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Timeouts",
-            "description": "Total core timeout."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_core_timeouts_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_6": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Searcher Cache Hit Ratio",
-            "description": "Core searcher cache hit ratio."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_core_searcher_cache_ratio{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_7": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Searcher Cache",
-            "description": "Core searcher cache."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_core_searcher_cache{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_8": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Searcher Warm Up Time",
-            "description": "Core searcher warm up time."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "solr_metrics_core_searcher_warmup_time_seconds{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "5_9": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Searcher Cumulative Cache",
-            "description": "Core searcher cumulative cache."
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "increase(solr_metrics_core_searcher_cumulative_cache_total{namespace=~\"$namespace\",service=~\"$app-stats\",pod=~\"$pod\",base_url=~\"$base_url\",collection=~\"$collection\",shard=~\"$shard\",replica=~\"$replica\",core=~\"$core\"}[1m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{base_url}}` }} {{ `{{status}}` }} {{ `{{pod}}` }}"
                   }
                 }
               }
@@ -2106,10 +2107,7 @@
         "kind": "Grid",
         "spec": {
           "display": {
-            "title": "Query Metrics",
-            "collapse": {
-              "open": true
-            }
+            "title": "Panel Group 1"
           },
           "items": [
             {
@@ -2118,7 +2116,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/0_0"
+                "$ref": "#/spec/panels/0"
               }
             },
             {
@@ -2127,7 +2125,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/0_1"
+                "$ref": "#/spec/panels/1"
               }
             },
             {
@@ -2136,7 +2134,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/0_2"
+                "$ref": "#/spec/panels/2"
               }
             },
             {
@@ -2145,7 +2143,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/0_3"
+                "$ref": "#/spec/panels/3"
               }
             },
             {
@@ -2154,7 +2152,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/0_4"
+                "$ref": "#/spec/panels/4"
               }
             },
             {
@@ -2163,7 +2161,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/0_5"
+                "$ref": "#/spec/panels/5"
               }
             },
             {
@@ -2172,7 +2170,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/0_6"
+                "$ref": "#/spec/panels/6"
               }
             },
             {
@@ -2181,29 +2179,16 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/0_7"
+                "$ref": "#/spec/panels/7"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Jetty Metrics",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 30,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/1_0"
+                "$ref": "#/spec/panels/8"
               }
             },
             {
@@ -2212,7 +2197,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/1_1"
+                "$ref": "#/spec/panels/9"
               }
             },
             {
@@ -2221,29 +2206,16 @@
               "width": 24,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/1_2"
+                "$ref": "#/spec/panels/10"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "JVM Metrics",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 45,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2_0"
+                "$ref": "#/spec/panels/11"
               }
             },
             {
@@ -2252,7 +2224,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2_1"
+                "$ref": "#/spec/panels/12"
               }
             },
             {
@@ -2261,7 +2233,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2_2"
+                "$ref": "#/spec/panels/13"
               }
             },
             {
@@ -2270,7 +2242,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2_3"
+                "$ref": "#/spec/panels/14"
               }
             },
             {
@@ -2279,7 +2251,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2_4"
+                "$ref": "#/spec/panels/15"
               }
             },
             {
@@ -2288,7 +2260,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2_5"
+                "$ref": "#/spec/panels/16"
               }
             },
             {
@@ -2297,7 +2269,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2_6"
+                "$ref": "#/spec/panels/17"
               }
             },
             {
@@ -2306,7 +2278,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2_7"
+                "$ref": "#/spec/panels/18"
               }
             },
             {
@@ -2315,29 +2287,16 @@
               "width": 24,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/2_8"
+                "$ref": "#/spec/panels/19"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "OS Metrics.",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 81,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_0"
+                "$ref": "#/spec/panels/20"
               }
             },
             {
@@ -2346,7 +2305,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_1"
+                "$ref": "#/spec/panels/21"
               }
             },
             {
@@ -2355,7 +2314,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_2"
+                "$ref": "#/spec/panels/22"
               }
             },
             {
@@ -2364,7 +2323,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_3"
+                "$ref": "#/spec/panels/23"
               }
             },
             {
@@ -2373,29 +2332,16 @@
               "width": 24,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_4"
+                "$ref": "#/spec/panels/24"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Node Metrics",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 103,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/4_0"
+                "$ref": "#/spec/panels/25"
               }
             },
             {
@@ -2404,7 +2350,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/4_1"
+                "$ref": "#/spec/panels/26"
               }
             },
             {
@@ -2413,7 +2359,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/4_2"
+                "$ref": "#/spec/panels/27"
               }
             },
             {
@@ -2422,7 +2368,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/4_3"
+                "$ref": "#/spec/panels/28"
               }
             },
             {
@@ -2431,7 +2377,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/4_4"
+                "$ref": "#/spec/panels/29"
               }
             },
             {
@@ -2440,7 +2386,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/4_5"
+                "$ref": "#/spec/panels/30"
               }
             },
             {
@@ -2449,7 +2395,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/4_6"
+                "$ref": "#/spec/panels/31"
               }
             },
             {
@@ -2458,7 +2404,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/4_7"
+                "$ref": "#/spec/panels/32"
               }
             },
             {
@@ -2467,7 +2413,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/4_8"
+                "$ref": "#/spec/panels/33"
               }
             },
             {
@@ -2476,7 +2422,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/4_9"
+                "$ref": "#/spec/panels/34"
               }
             },
             {
@@ -2485,7 +2431,7 @@
               "width": 24,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/4_10"
+                "$ref": "#/spec/panels/35"
               }
             },
             {
@@ -2494,7 +2440,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/4_11"
+                "$ref": "#/spec/panels/36"
               }
             },
             {
@@ -2503,29 +2449,16 @@
               "width": 12,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/4_12"
+                "$ref": "#/spec/panels/37"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Core Metrics",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 153,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_0"
+                "$ref": "#/spec/panels/38"
               }
             },
             {
@@ -2534,7 +2467,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_1"
+                "$ref": "#/spec/panels/39"
               }
             },
             {
@@ -2543,7 +2476,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_2"
+                "$ref": "#/spec/panels/40"
               }
             },
             {
@@ -2552,7 +2485,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_3"
+                "$ref": "#/spec/panels/41"
               }
             },
             {
@@ -2561,7 +2494,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_4"
+                "$ref": "#/spec/panels/42"
               }
             },
             {
@@ -2570,7 +2503,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_5"
+                "$ref": "#/spec/panels/43"
               }
             },
             {
@@ -2579,7 +2512,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_6"
+                "$ref": "#/spec/panels/44"
               }
             },
             {
@@ -2588,7 +2521,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_7"
+                "$ref": "#/spec/panels/45"
               }
             },
             {
@@ -2597,7 +2530,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_8"
+                "$ref": "#/spec/panels/46"
               }
             },
             {
@@ -2606,7 +2539,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_9"
+                "$ref": "#/spec/panels/47"
               }
             },
             {
@@ -2615,7 +2548,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_10"
+                "$ref": "#/spec/panels/48"
               }
             },
             {
@@ -2624,7 +2557,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_11"
+                "$ref": "#/spec/panels/49"
               }
             },
             {
@@ -2633,7 +2566,7 @@
               "width": 24,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_12"
+                "$ref": "#/spec/panels/50"
               }
             },
             {
@@ -2642,7 +2575,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_13"
+                "$ref": "#/spec/panels/51"
               }
             },
             {
@@ -2651,7 +2584,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_14"
+                "$ref": "#/spec/panels/52"
               }
             },
             {
@@ -2660,7 +2593,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_15"
+                "$ref": "#/spec/panels/53"
               }
             },
             {
@@ -2669,7 +2602,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_16"
+                "$ref": "#/spec/panels/54"
               }
             },
             {
@@ -2678,7 +2611,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_17"
+                "$ref": "#/spec/panels/55"
               }
             },
             {
@@ -2687,7 +2620,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_18"
+                "$ref": "#/spec/panels/56"
               }
             },
             {
@@ -2696,7 +2629,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_19"
+                "$ref": "#/spec/panels/57"
               }
             },
             {
@@ -2705,7 +2638,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_20"
+                "$ref": "#/spec/panels/58"
               }
             },
             {
@@ -2714,7 +2647,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_21"
+                "$ref": "#/spec/panels/59"
               }
             },
             {
@@ -2723,7 +2656,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_22"
+                "$ref": "#/spec/panels/60"
               }
             },
             {
@@ -2732,7 +2665,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_23"
+                "$ref": "#/spec/panels/61"
               }
             },
             {
@@ -2741,7 +2674,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_24"
+                "$ref": "#/spec/panels/62"
               }
             },
             {
@@ -2750,7 +2683,7 @@
               "width": 24,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/5_25"
+                "$ref": "#/spec/panels/63"
               }
             }
           ]

--- a/charts/kubedb-perses-dashboards/dashboards/solr/solr-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/solr/solr-summary.json
@@ -81,7 +81,7 @@
       }
     ],
     "panels": {
-      "0_0": {
+      "0": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -92,6 +92,8 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
+              "metricLabel": "phase",
               "thresholds": {
                 "steps": [
                   {
@@ -111,7 +113,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_solr_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
                   }
                 }
               }
@@ -119,7 +121,7 @@
           ]
         }
       },
-      "0_1": {
+      "1": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -130,6 +132,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "seconds"
               },
@@ -161,338 +164,7 @@
           ]
         }
       },
-      "0_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "CPU Limit (Core)",
-            "description": "CPU Limit in core by Solr instance"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_solr_resource_limit_cpu{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Memory Limit",
-            "description": "KubeDB Solr Total Memory Limit"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "bytes"
-              },
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_solr_resource_limit_memory{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_4": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Storage Request",
-            "description": "Total storage request by Solr nodes"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "bytes"
-              },
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_solr_resource_request_storage{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_5": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Version",
-            "description": "Solr version Name"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "mean",
-              "format": {
-                "unit": "decimal"
-              },
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#f2495c",
-                    "value": 80
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_solr_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_6": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Total Nodes",
-            "description": "Total node count of Solr cluster"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#f2495c",
-                    "value": 80
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_solr_replicas{namespace=\"$namespace\",app=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_7": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "CPU Request (Core)",
-            "description": "Initial Requested CPU amount by Solr Instance"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_solr_resource_request_cpu{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_8": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Memory Request",
-            "description": "Initial Requested Memory amount by Solr Instance"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "bytes"
-              },
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_solr_resource_request_memory{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_9": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Deletion Policy",
-            "description": "KubeDB Database Resource deletionPolicy"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#c4162a",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_solr_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "1_0": {
+      "10": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -518,7 +190,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -526,7 +198,7 @@
           ]
         }
       },
-      "1_1": {
+      "11": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -540,37 +212,49 @@
                 {
                   "header": "Time",
                   "name": "timestamp",
-                  "width": null
+                  "width": "auto"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
-                }
-              ],
-              "transforms": [
-                {
-                  "kind": "MergeSeries",
-                  "spec": {}
                 }
               ]
             }
@@ -644,7 +328,7 @@
           ]
         }
       },
-      "2_0": {
+      "12": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -670,7 +354,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\",pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\",container!=\"\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -678,7 +362,7 @@
           ]
         }
       },
-      "2_1": {
+      "13": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -694,46 +378,67 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (RSS)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Cache)",
-                  "name": "Value #G"
+                  "name": "value #7"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Swap)",
-                  "name": "Value #H"
+                  "name": "value #8"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
-                }
-              ],
-              "transforms": [
-                {
-                  "kind": "MergeSeries",
-                  "spec": {}
                 }
               ]
             }
@@ -846,7 +551,7 @@
           ]
         }
       },
-      "3_0": {
+      "14": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -877,7 +582,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -885,7 +590,7 @@
           ]
         }
       },
-      "3_1": {
+      "15": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -916,7 +621,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
                   }
                 }
               }
@@ -929,7 +634,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
                   }
                 }
               }
@@ -937,7 +642,7 @@
           ]
         }
       },
-      "3_2": {
+      "16": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -968,7 +673,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\"}[5m])))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -976,7 +681,7 @@
           ]
         }
       },
-      "3_3": {
+      "17": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1007,7 +712,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\"}[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1015,7 +720,7 @@
           ]
         }
       },
-      "3_4": {
+      "18": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1031,38 +736,53 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads)",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Writes)",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads + Writes)",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read)",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Write)",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read + Write)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
-                }
-              ],
-              "transforms": [
-                {
-                  "kind": "MergeSeries",
-                  "spec": {}
                 }
               ]
             }
@@ -1149,7 +869,7 @@
           ]
         }
       },
-      "4_0": {
+      "19": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1159,52 +879,7 @@
           "plugin": {
             "kind": "Table",
             "spec": {
-              "columnSettings": [
-                {
-                  "header": "Volume",
-                  "name": "value"
-                },
-                {
-                  "header": "Pod",
-                  "name": "pod"
-                },
-                {
-                  "hide": true,
-                  "name": "timestamp"
-                },
-                {
-                  "hide": true,
-                  "name": "endpoint"
-                },
-                {
-                  "hide": true,
-                  "name": "instance"
-                },
-                {
-                  "hide": true,
-                  "name": "job"
-                },
-                {
-                  "hide": true,
-                  "name": "metrics_path"
-                },
-                {
-                  "hide": true,
-                  "name": "namespace"
-                },
-                {
-                  "hide": true,
-                  "name": "node"
-                },
-                {
-                  "hide": true,
-                  "name": "persistentvolumeclaim"
-                },
-                {
-                  "hide": true,
-                  "name": "service"
-                }
-              ]
+              "columnSettings": []
             }
           },
           "queries": [
@@ -1224,7 +899,47 @@
           ]
         }
       },
-      "4_1": {
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Limit (Core)",
+            "description": "CPU Limit in core by Solr instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_solr_resource_limit_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1249,7 +964,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1257,7 +972,7 @@
           ]
         }
       },
-      "4_2": {
+      "21": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1284,7 +999,7 @@
               },
               "yAxis": {
                 "format": {
-                  "unit": "bytes"
+                  "unit": "decbytes"
                 },
                 "max": 5000,
                 "min": 0
@@ -1300,7 +1015,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1308,7 +1023,7 @@
           ]
         }
       },
-      "5_0": {
+      "22": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1339,7 +1054,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1347,7 +1062,7 @@
           ]
         }
       },
-      "5_1": {
+      "23": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1378,7 +1093,307 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Limit",
+            "description": "KubeDB Solr Total Memory Limit"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_solr_resource_limit_memory{namespace=\"$namespace\", app=\"$app\"}",
                     "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Storage Request",
+            "description": "Total storage request by Solr nodes"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_solr_resource_request_storage{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Version",
+            "description": "Solr version Name"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "mean",
+              "colorMode": "none",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": "version",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_solr_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{version}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Nodes",
+            "description": "Total node count of Solr cluster"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_solr_replicas{namespace=\"$namespace\",app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Request (Core)",
+            "description": "Initial Requested CPU amount by Solr Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_solr_resource_request_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Request",
+            "description": "Initial Requested Memory amount by Solr Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_solr_resource_request_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Deletion Policy",
+            "description": "KubeDB Database Resource deletionPolicy"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_solr_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
                   }
                 }
               }
@@ -1392,10 +1407,7 @@
         "kind": "Grid",
         "spec": {
           "display": {
-            "title": "General Info",
-            "collapse": {
-              "open": true
-            }
+            "title": "Panel Group 1"
           },
           "items": [
             {
@@ -1404,7 +1416,7 @@
               "width": 8,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_0"
+                "$ref": "#/spec/panels/0"
               }
             },
             {
@@ -1413,7 +1425,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_1"
+                "$ref": "#/spec/panels/1"
               }
             },
             {
@@ -1422,7 +1434,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_2"
+                "$ref": "#/spec/panels/2"
               }
             },
             {
@@ -1431,7 +1443,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_3"
+                "$ref": "#/spec/panels/3"
               }
             },
             {
@@ -1440,7 +1452,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_4"
+                "$ref": "#/spec/panels/4"
               }
             },
             {
@@ -1449,7 +1461,7 @@
               "width": 8,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_5"
+                "$ref": "#/spec/panels/5"
               }
             },
             {
@@ -1458,7 +1470,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_6"
+                "$ref": "#/spec/panels/6"
               }
             },
             {
@@ -1467,7 +1479,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_7"
+                "$ref": "#/spec/panels/7"
               }
             },
             {
@@ -1476,7 +1488,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_8"
+                "$ref": "#/spec/panels/8"
               }
             },
             {
@@ -1485,29 +1497,16 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_9"
+                "$ref": "#/spec/panels/9"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "CPU Info",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 8,
               "width": 24,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/1_0"
+                "$ref": "#/spec/panels/10"
               }
             },
             {
@@ -1516,29 +1515,16 @@
               "width": 24,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/1_1"
+                "$ref": "#/spec/panels/11"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Memory Info",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 22,
               "width": 24,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/2_0"
+                "$ref": "#/spec/panels/12"
               }
             },
             {
@@ -1547,29 +1533,16 @@
               "width": 24,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/2_1"
+                "$ref": "#/spec/panels/13"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Storage Info",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 35,
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/3_0"
+                "$ref": "#/spec/panels/14"
               }
             },
             {
@@ -1578,7 +1551,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/3_1"
+                "$ref": "#/spec/panels/15"
               }
             },
             {
@@ -1587,7 +1560,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_2"
+                "$ref": "#/spec/panels/16"
               }
             },
             {
@@ -1596,7 +1569,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_3"
+                "$ref": "#/spec/panels/17"
               }
             },
             {
@@ -1605,29 +1578,16 @@
               "width": 24,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_4"
+                "$ref": "#/spec/panels/18"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Persistent Storage Insight",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 59,
               "width": 12,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/4_0"
+                "$ref": "#/spec/panels/19"
               }
             },
             {
@@ -1636,7 +1596,7 @@
               "width": 12,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/4_1"
+                "$ref": "#/spec/panels/20"
               }
             },
             {
@@ -1645,29 +1605,16 @@
               "width": 24,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/4_2"
+                "$ref": "#/spec/panels/21"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Network Info",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 74,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_0"
+                "$ref": "#/spec/panels/22"
               }
             },
             {
@@ -1676,7 +1623,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_1"
+                "$ref": "#/spec/panels/23"
               }
             }
           ]

--- a/charts/kubedb-perses-dashboards/dashboards/zookeeper/zookeeper_ensemble_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/zookeeper/zookeeper_ensemble_dashboard.json
@@ -1,4 +1,5 @@
 {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
 {
   "kind": "Dashboard",
   "metadata": {
@@ -80,7 +81,7 @@
       }
     ],
     "panels": {
-      "0_0": {
+      "0": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -99,7 +100,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "znode_count{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{instance}}` }} znode_count"
                   }
                 }
               }
@@ -112,7 +113,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "ephemerals_count{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{instance}}` }} ephemerals"
                   }
                 }
               }
@@ -120,7 +121,7 @@
           ]
         }
       },
-      "0_1": {
+      "1": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -139,7 +140,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(znode_count{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{instance}}` }} znode_count_rate"
                   }
                 }
               }
@@ -152,7 +153,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "rate(ephemerals_count{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{instance}}` }} ephemerals_rate"
                   }
                 }
               }
@@ -160,7 +161,7 @@
           ]
         }
       },
-      "0_10": {
+      "10": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -178,7 +179,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "unrecoverable_error_count{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{instance}}` }} unrecoverable_error_count"
                   }
                 }
               }
@@ -186,7 +187,7 @@
           ]
         }
       },
-      "0_11": {
+      "11": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -204,7 +205,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "digest_mismatches_count{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{instance}}` }} digest_mismatches_count"
                   }
                 }
               }
@@ -212,7 +213,7 @@
           ]
         }
       },
-      "0_12": {
+      "12": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -230,7 +231,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "startup_snap_load_time",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{instance}}` }} startup_snap_load_time-{{ `{{quantile}}` }}"
                   }
                 }
               }
@@ -242,7 +243,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "startup_snap_load_time_count",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{instance}}` }} startup_snap_load_time_count"
                   }
                 }
               }
@@ -254,7 +255,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "startup_snap_load_time_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{instance}}` }} startup_snap_load_time"
                   }
                 }
               }
@@ -262,7 +263,7 @@
           ]
         }
       },
-      "0_13": {
+      "13": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -280,7 +281,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "startup_txns_loaded",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{instance}}` }} startup_txns_loaded-{{ `{{quantile}}` }}"
                   }
                 }
               }
@@ -292,7 +293,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "startup_txns_loaded_count",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{instance}}` }} startup_txns_loaded_count"
                   }
                 }
               }
@@ -304,7 +305,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "startup_txns_loaded_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{instance}}` }} startup_txns_loaded"
                   }
                 }
               }
@@ -312,7 +313,7 @@
           ]
         }
       },
-      "0_14": {
+      "14": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -330,7 +331,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "dbinittime",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} dbinittime-{{ "{{" }}quantile{{ "}}" }}"
+                    "seriesNameFormat": "{{ `{{instance}}` }} dbinittime-{{ `{{quantile}}` }}"
                   }
                 }
               }
@@ -342,8 +343,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "dbinittime_count",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} dbinittime_count"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} dbinittime_count"
                   }
                 }
               }
@@ -355,8 +355,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "dbinittime_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} db_init_time"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} db_init_time"
                   }
                 }
               }
@@ -364,630 +363,7 @@
           ]
         }
       },
-      "0_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "global_sessions"
-          },
-          "plugin": {
-            "kind": "BarChart",
-            "spec": {
-              "calculation": "last",
-              "format": {
-                "unit": "decimal"
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "global_sessions{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }}"
-
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "local_sessions "
-          },
-          "plugin": {
-            "kind": "BarChart",
-            "spec": {
-              "calculation": "last",
-              "format": {
-                "unit": "decimal"
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "local_sessions{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }}"
-
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_4": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "write_per_namespace"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "write_per_namespace_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} write_per_namespace:{{ "{{" }}key{{ "}}" }}"
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_5": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "read_per_namespace"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "read_per_namespace_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} read_per_namespace:{{ "{{" }}key{{ "}}" }}"
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_6": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "approximate_data_size"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "approximate_data_size{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} approximate_data_size"
-
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_7": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "packets_received"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "packets_received{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} packets_received"
-
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_8": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "packets_sent"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "packets_sent{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} packets_sent"
-
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_9": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "response_packet_cache"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "response_packet_cache_misses{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} response_packet_cache_misses"
-
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "response_packet_cache_hits{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} response_packet_cache_hits"
-
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "response_packet_get_children_cache_misses{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} response_packet_get_children_cache_misses"
-
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "response_packet_get_children_cache_hits{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} response_packet_get_children_cache_hits"
-
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "10_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "tls_handshake"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "tls_handshake_exceeded{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} tls_handshake_exceeded"
-
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "outstanding_tls_handshake{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} outstanding_tls_handshake"
-
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "10_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "ensemble_auth"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "ensemble_auth_fail{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} ensemble_auth_fail"
-
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "ensemble_auth_success{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} ensemble_auth_success"
-
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "ensemble_auth_skip{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} ensemble_auth_skip"
-
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "11_0": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "jvm_classes_loaded"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "decimal"
-              },
-              "mappings": [
-                {
-                  "kind": "Misc",
-                  "spec": {
-                    "result": {
-                      "value": "N/A"
-                    },
-                    "value": "null"
-                  }
-                }
-              ],
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#f2495c",
-                    "value": 80
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "max(jvm_classes_loaded{namespace=~\"$namespace\",service=~\"$app+-stats\"})",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "11_1": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "jvm_threads_current"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "decimal"
-              },
-              "mappings": [
-                {
-                  "kind": "Misc",
-                  "spec": {
-                    "result": {
-                      "value": "N/A"
-                    },
-                    "value": "null"
-                  }
-                }
-              ],
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#f2495c",
-                    "value": 80
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "max(jvm_threads_current{namespace=~\"$namespace\",service=~\"$app+-stats\"})",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "11_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "jvm_threads_deadlocked"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "decimal"
-              },
-              "mappings": [
-                {
-                  "kind": "Misc",
-                  "spec": {
-                    "result": {
-                      "value": "N/A"
-                    },
-                    "value": "null"
-                  }
-                }
-              ],
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#f2495c",
-                    "value": 80
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "max(jvm_threads_deadlocked{namespace=~\"$namespace\",service=~\"$app+-stats\"})",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "11_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "jvm_pause_time_ms"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "rate(jvm_pause_time_ms_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} jvm_pause_time_ms"
-
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "11_4": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "jvm_gc_collection_seconds"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "rate(jvm_gc_collection_seconds_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} gc:{{ "{{" }}gc{{ "}}" }}"
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "11_5": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "jvm_threads_state"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "jvm_threads_state{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} state:{{ "{{" }}state{{ "}}" }}"
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "11_6": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "jvm_memory_pool_bytes_used"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "jvm_memory_pool_bytes_used{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} pool:{{ "{{" }}pool{{ "}}" }}"
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "1_0": {
+      "15": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -997,20 +373,10 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "background_solid",
               "format": {
                 "unit": "decimal"
               },
-              "mappings": [
-                {
-                  "kind": "Misc",
-                  "spec": {
-                    "result": {
-                      "value": "N/A"
-                    },
-                    "value": "null"
-                  }
-                }
-              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1038,7 +404,6 @@
                   "spec": {
                     "query": "max(quorum_size{namespace=~\"$namespace\",service=~\"$app+-stats\"})",
                     "seriesNameFormat": "quorum_size"
-
                   }
                 }
               }
@@ -1046,7 +411,7 @@
           ]
         }
       },
-      "1_1": {
+      "16": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1056,20 +421,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "background_solid",
               "format": {
                 "unit": "milliseconds"
               },
-              "mappings": [
-                {
-                  "kind": "Misc",
-                  "spec": {
-                    "result": {
-                      "value": "N/A"
-                    },
-                    "value": "null"
-                  }
-                }
-              ],
+              "metricLabel": "instance",
               "thresholds": {
                 "steps": [
                   {
@@ -1093,8 +449,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "leader_uptime{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }}"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }}"
                   }
                 }
               }
@@ -1102,127 +457,7 @@
           ]
         }
       },
-      "1_10": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "follower_sync_time"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "rate(follower_sync_time_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[1m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} follower_sync_time"
-
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "1_11": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "learner_handler_qp_size"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "learner_handler_qp_size_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} learner_handler_qp_size_sum sid:{{ "{{" }}key{{ "}}" }}"
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "1_12": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "quit_leading_due_to_disloyal_voter"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "quit_leading_due_to_disloyal_voter{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} quit_leading_due_to_disloyal_voter"
-
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "1_13": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Observer Master"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "rate(om_commit_process_time_ms_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} om_commit_process_time"
-
-                  }
-                }
-              }
-            },
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "rate(om_proposal_process_time_ms_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} om_proposal_process_time"
-
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "1_2": {
+      "17": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1232,20 +467,10 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "background_solid",
               "format": {
                 "unit": "milliseconds"
               },
-              "mappings": [
-                {
-                  "kind": "Misc",
-                  "spec": {
-                    "result": {
-                      "value": "N/A"
-                    },
-                    "value": "null"
-                  }
-                }
-              ],
               "thresholds": {
                 "steps": [
                   {
@@ -1268,8 +493,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "leader_uptime{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} leader_uptime"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} leader_uptime"
                   }
                 }
               }
@@ -1277,7 +501,7 @@
           ]
         }
       },
-      "1_3": {
+      "18": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1298,7 +522,6 @@
                   "spec": {
                     "query": "max(learners{namespace=~\"$namespace\",service=~\"$app+-stats\"})",
                     "seriesNameFormat": "learners"
-
                   }
                 }
               }
@@ -1311,7 +534,6 @@
                   "spec": {
                     "query": "max(synced_non_voting_followers{namespace=~\"$namespace\",service=~\"$app+-stats\"})",
                     "seriesNameFormat": "synced_non_voting_followers"
-
                   }
                 }
               }
@@ -1324,7 +546,6 @@
                   "spec": {
                     "query": "max(synced_observers{namespace=~\"$namespace\",service=~\"$app+-stats\"})",
                     "seriesNameFormat": "synced_observers"
-
                   }
                 }
               }
@@ -1332,7 +553,7 @@
           ]
         }
       },
-      "1_4": {
+      "19": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1350,8 +571,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "commit_count{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} commit_count"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} commit_count"
                   }
                 }
               }
@@ -1359,7 +579,38 @@
           ]
         }
       },
-      "1_5": {
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "global_sessions"
+          },
+          "plugin": {
+            "kind": "BarChart",
+            "spec": {
+              "calculation": "last",
+              "format": {
+                "unit": "decimal"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "global_sessions{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1377,8 +628,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "snap_count{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} snap_count"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} snap_count"
                   }
                 }
               }
@@ -1386,7 +636,7 @@
           ]
         }
       },
-      "1_6": {
+      "21": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1404,8 +654,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "diff_count{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} diff_count"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} diff_count"
                   }
                 }
               }
@@ -1413,7 +662,7 @@
           ]
         }
       },
-      "1_7": {
+      "22": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1431,8 +680,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "looking_count{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} looking_count"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} looking_count"
                   }
                 }
               }
@@ -1440,7 +688,7 @@
           ]
         }
       },
-      "1_8": {
+      "23": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1458,8 +706,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "proposal_count{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} proposal_count"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} proposal_count"
                   }
                 }
               }
@@ -1467,7 +714,7 @@
           ]
         }
       },
-      "1_9": {
+      "24": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1485,8 +732,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "last_proposal_size{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} last_proposal_size"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} last_proposal_size"
                   }
                 }
               }
@@ -1498,8 +744,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "max_proposal_size{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} max_proposal_size"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} max_proposal_size"
                   }
                 }
               }
@@ -1511,8 +756,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "min_proposal_size{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} min_proposal_size"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} min_proposal_size"
                   }
                 }
               }
@@ -1520,7 +764,123 @@
           ]
         }
       },
-      "2_0": {
+      "25": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "follower_sync_time"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(follower_sync_time_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[1m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} follower_sync_time"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "26": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "learner_handler_qp_size"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "learner_handler_qp_size_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} learner_handler_qp_size_sum sid:{{ `{{key}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "27": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "quit_leading_due_to_disloyal_voter"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "quit_leading_due_to_disloyal_voter{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} quit_leading_due_to_disloyal_voter"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Observer Master"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(om_commit_process_time_ms_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} om_commit_process_time"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(om_proposal_process_time_ms_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} om_proposal_process_time"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "29": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1538,8 +898,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "watch_count{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} watch_count"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} watch_count"
                   }
                 }
               }
@@ -1547,7 +906,38 @@
           ]
         }
       },
-      "2_1": {
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "local_sessions "
+          },
+          "plugin": {
+            "kind": "BarChart",
+            "spec": {
+              "calculation": "last",
+              "format": {
+                "unit": "decimal"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "local_sessions{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "30": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1565,8 +955,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "node_changed_watch_count_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} node_changed_watch_count"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} node_changed_watch_count"
                   }
                 }
               }
@@ -1574,7 +963,7 @@
           ]
         }
       },
-      "2_2": {
+      "31": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1592,8 +981,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "node_children_watch_count_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} node_children_watch_count"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} node_children_watch_count"
                   }
                 }
               }
@@ -1601,7 +989,7 @@
           ]
         }
       },
-      "2_3": {
+      "32": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1619,8 +1007,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "node_deleted_watch_count_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} node_deleted_watch_count"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} node_deleted_watch_count"
                   }
                 }
               }
@@ -1628,7 +1015,7 @@
           ]
         }
       },
-      "2_4": {
+      "33": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1646,8 +1033,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "node_created_watch_count_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} node_created_watch_count"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} node_created_watch_count"
                   }
                 }
               }
@@ -1655,7 +1041,7 @@
           ]
         }
       },
-      "2_5": {
+      "34": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1673,8 +1059,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "revalidate_count{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} revalidate_count"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} revalidate_count"
                   }
                 }
               }
@@ -1682,7 +1067,7 @@
           ]
         }
       },
-      "2_6": {
+      "35": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1700,8 +1085,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "stale_sessions_expired{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} stale_sessions_expired"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} stale_sessions_expired"
                   }
                 }
               }
@@ -1709,7 +1093,7 @@
           ]
         }
       },
-      "2_7": {
+      "36": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1727,8 +1111,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "dead_watchers_cleared{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} dead_watchers_cleared"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} dead_watchers_cleared"
                   }
                 }
               }
@@ -1740,8 +1123,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "dead_watchers_queued{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} dead_watchers_queued"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} dead_watchers_queued"
                   }
                 }
               }
@@ -1753,8 +1135,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(dead_watchers_cleaner_latency_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} dead_watchers_cleaner_latency"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} dead_watchers_cleaner_latency"
                   }
                 }
               }
@@ -1762,7 +1143,7 @@
           ]
         }
       },
-      "2_8": {
+      "37": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1780,8 +1161,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "add_dead_watcher_stall_time{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} add_dead_watcher_stall_time"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} add_dead_watcher_stall_time"
                   }
                 }
               }
@@ -1789,7 +1169,7 @@
           ]
         }
       },
-      "3_0": {
+      "38": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1807,8 +1187,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "outstanding_requests{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} outstanding_requests"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} outstanding_requests"
                   }
                 }
               }
@@ -1816,7 +1195,7 @@
           ]
         }
       },
-      "3_1": {
+      "39": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1834,8 +1213,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "last_client_response_size{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} last_client_response_size"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} last_client_response_size"
                   }
                 }
               }
@@ -1847,8 +1225,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "min_client_response_size{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} min_client_response_size"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} min_client_response_size"
                   }
                 }
               }
@@ -1860,8 +1237,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "max_client_response_size{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} max_client_response_size"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} max_client_response_size"
                   }
                 }
               }
@@ -1869,7 +1245,33 @@
           ]
         }
       },
-      "3_2": {
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "write_per_namespace"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "write_per_namespace_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} write_per_namespace:{{ `{{key}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "40": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1887,8 +1289,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "bytes_received_count{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} bytes_received_count"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} bytes_received_count"
                   }
                 }
               }
@@ -1896,7 +1297,7 @@
           ]
         }
       },
-      "3_3": {
+      "41": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1914,8 +1315,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "connection_request_count{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} connection_request_count"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} connection_request_count"
                   }
                 }
               }
@@ -1923,7 +1323,7 @@
           ]
         }
       },
-      "3_4": {
+      "42": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1941,8 +1341,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "num_alive_connections{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} num_alive_connections"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} num_alive_connections"
                   }
                 }
               }
@@ -1950,7 +1349,7 @@
           ]
         }
       },
-      "3_5": {
+      "43": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1968,8 +1367,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "connection_rejected{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} connection_rejected"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} connection_rejected"
                   }
                 }
               }
@@ -1977,7 +1375,7 @@
           ]
         }
       },
-      "3_6": {
+      "44": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1995,8 +1393,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "connection_drop_count{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} connection_drop_count"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} connection_drop_count"
                   }
                 }
               }
@@ -2004,7 +1401,7 @@
           ]
         }
       },
-      "3_7": {
+      "45": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2022,8 +1419,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "connection_drop_probability{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} connection_drop_probability"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} connection_drop_probability"
                   }
                 }
               }
@@ -2031,7 +1427,7 @@
           ]
         }
       },
-      "3_8": {
+      "46": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2049,8 +1445,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sessionless_connections_expired{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} sessionless_connections_expired"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} sessionless_connections_expired"
                   }
                 }
               }
@@ -2058,7 +1453,7 @@
           ]
         }
       },
-      "3_9": {
+      "47": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2076,8 +1471,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(connection_token_deficit_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} connection_token_deficit"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} connection_token_deficit"
                   }
                 }
               }
@@ -2085,7 +1479,7 @@
           ]
         }
       },
-      "4_0": {
+      "48": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2121,8 +1515,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "open_file_descriptor_count{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }}"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }}"
                   }
                 }
               }
@@ -2130,7 +1523,7 @@
           ]
         }
       },
-      "4_1": {
+      "49": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2148,8 +1541,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "fsynctime{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} fsynctime"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} fsynctime"
                   }
                 }
               }
@@ -2162,8 +1554,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "fsynctime_count{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} fsynctime_count"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} fsynctime_count"
                   }
                 }
               }
@@ -2175,8 +1566,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "fsynctime_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} fsynctime_sum(ms)"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} fsynctime_sum(ms)"
                   }
                 }
               }
@@ -2188,8 +1578,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "fsynctime_sum * 1000 /fsynctime_count{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} fsynctime_avg(\u03bcs)"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} fsynctime_avg(μs)"
                   }
                 }
               }
@@ -2201,8 +1590,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "irate(fsynctime_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[1m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} fsynctime_rate"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} fsynctime_rate"
                   }
                 }
               }
@@ -2210,7 +1598,33 @@
           ]
         }
       },
-      "4_2": {
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "read_per_namespace"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "read_per_namespace_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} read_per_namespace:{{ `{{key}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "50": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2228,8 +1642,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(snapshottime_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} snapshot_time_rate"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} snapshot_time_rate"
                   }
                 }
               }
@@ -2241,8 +1654,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "snapshottime_count{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} snapshottime_count"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} snapshottime_count"
                   }
                 }
               }
@@ -2254,8 +1666,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "snapshottime_sum / snapshottime_count{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} snapshottime_avg(ms)"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} snapshottime_avg(ms)"
                   }
                 }
               }
@@ -2263,7 +1674,7 @@
           ]
         }
       },
-      "5_0": {
+      "51": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2281,8 +1692,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(prep_process_time_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} prep_process_time"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} prep_process_time"
                   }
                 }
               }
@@ -2290,7 +1700,7 @@
           ]
         }
       },
-      "5_1": {
+      "52": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2308,8 +1718,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(prep_processor_queue_time_ms_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} prep_processor_queue_time_ms"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} prep_processor_queue_time_ms"
                   }
                 }
               }
@@ -2317,7 +1726,7 @@
           ]
         }
       },
-      "5_2": {
+      "53": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2335,8 +1744,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(prep_processor_queue_size_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} prep_processor_queue_size"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} prep_processor_queue_size"
                   }
                 }
               }
@@ -2344,7 +1752,7 @@
           ]
         }
       },
-      "5_3": {
+      "54": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2362,8 +1770,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "prep_processor_request_queued{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} prep_processor_request_queued"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} prep_processor_request_queued"
                   }
                 }
               }
@@ -2371,7 +1778,7 @@
           ]
         }
       },
-      "5_4": {
+      "55": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2389,8 +1796,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "outstanding_changes_queued{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} outstanding_changes_queued"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} outstanding_changes_queued"
                   }
                 }
               }
@@ -2402,8 +1808,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "outstanding_changes_removed{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} outstanding_changes_removed"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} outstanding_changes_removed"
                   }
                 }
               }
@@ -2411,7 +1816,7 @@
           ]
         }
       },
-      "5_5": {
+      "56": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2429,8 +1834,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(close_session_prep_time_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} close_session_prep_time"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} close_session_prep_time"
                   }
                 }
               }
@@ -2438,7 +1842,7 @@
           ]
         }
       },
-      "6_0": {
+      "57": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2456,8 +1860,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(sync_process_time_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} sync_process_time"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} sync_process_time"
                   }
                 }
               }
@@ -2465,7 +1868,7 @@
           ]
         }
       },
-      "6_1": {
+      "58": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2483,8 +1886,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(sync_processor_queue_flush_time_ms_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} sync_processor_queue_flush_time"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} sync_processor_queue_flush_time"
                   }
                 }
               }
@@ -2492,7 +1894,7 @@
           ]
         }
       },
-      "6_2": {
+      "59": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2510,8 +1912,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(sync_processor_queue_size_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} sync_processor_queue_size"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} sync_processor_queue_size"
                   }
                 }
               }
@@ -2519,7 +1920,33 @@
           ]
         }
       },
-      "6_3": {
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "approximate_data_size"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "approximate_data_size{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} approximate_data_size"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "60": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2537,8 +1964,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "sync_processor_request_queued{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} sync_processor_request_queued"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} sync_processor_request_queued"
                   }
                 }
               }
@@ -2546,7 +1972,7 @@
           ]
         }
       },
-      "6_4": {
+      "61": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2564,8 +1990,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(sync_processor_batch_size_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} sync_processor_batch_size"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} sync_processor_batch_size"
                   }
                 }
               }
@@ -2573,7 +1998,7 @@
           ]
         }
       },
-      "7_0": {
+      "62": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2591,8 +2016,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(commit_process_time_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} commit_process_time"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} commit_process_time"
                   }
                 }
               }
@@ -2604,8 +2028,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(read_commitproc_time_ms_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} read_commitproc_time"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} read_commitproc_time"
                   }
                 }
               }
@@ -2617,8 +2040,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(write_commitproc_time_ms_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} write_commitproc_time"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} write_commitproc_time"
                   }
                 }
               }
@@ -2626,7 +2048,7 @@
           ]
         }
       },
-      "7_1": {
+      "63": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2644,8 +2066,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(write_commit_proc_req_queued_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} write_commit_proc_req_queued"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} write_commit_proc_req_queued"
                   }
                 }
               }
@@ -2657,8 +2078,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(read_commit_proc_req_queued_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} read_commit_proc_req_queued"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} read_commit_proc_req_queued"
                   }
                 }
               }
@@ -2670,8 +2090,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(commit_commit_proc_req_queued_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} commit_commit_proc_req_queued"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} commit_commit_proc_req_queued"
                   }
                 }
               }
@@ -2679,115 +2098,7 @@
           ]
         }
       },
-      "7_10": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "reads_after_write_in_session_queue"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "rate(reads_after_write_in_session_queue_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} reads_after_write_in_session_queue"
-
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "7_11": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "session_queues_drained"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "rate(session_queues_drained_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} session_queues_drained"
-
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "7_12": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "reads_issued_from_session_queue"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "rate(reads_issued_from_session_queue_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} reads_issued_from_session_queue"
-
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "7_13": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "request_commit_queued"
-          },
-          "plugin": {
-            "kind": "TimeSeriesChart",
-            "spec": {}
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "query": "request_commit_queued{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} request_commit_queued"
-
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "7_2": {
+      "64": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2805,8 +2116,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(requests_in_session_queue_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} requests_in_session_queue"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} requests_in_session_queue"
                   }
                 }
               }
@@ -2814,7 +2124,7 @@
           ]
         }
       },
-      "7_3": {
+      "65": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2832,8 +2142,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(read_commit_proc_issued_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} read_commit_proc_issued"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} read_commit_proc_issued"
                   }
                 }
               }
@@ -2845,8 +2154,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(write_commit_proc_issued_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} write_commit_proc_issued"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} write_commit_proc_issued"
                   }
                 }
               }
@@ -2854,7 +2162,7 @@
           ]
         }
       },
-      "7_4": {
+      "66": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2872,8 +2180,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(concurrent_request_processing_in_commit_processor_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} concurrent_request_processing_in_commit_processor"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} concurrent_request_processing_in_commit_processor"
                   }
                 }
               }
@@ -2881,7 +2188,7 @@
           ]
         }
       },
-      "7_5": {
+      "67": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2899,8 +2206,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(time_waiting_empty_pool_in_commit_processor_read_ms_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} time_waiting_empty_pool_in_commit_processor_read"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} time_waiting_empty_pool_in_commit_processor_read"
                   }
                 }
               }
@@ -2908,7 +2214,7 @@
           ]
         }
       },
-      "7_6": {
+      "68": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2926,8 +2232,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(pending_session_queue_size_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} pending_session_queue_size"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} pending_session_queue_size"
                   }
                 }
               }
@@ -2935,7 +2240,7 @@
           ]
         }
       },
-      "7_7": {
+      "69": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2953,8 +2258,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(local_write_committed_time_ms_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} local_write_committed_time_ms"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} local_write_committed_time_ms"
                   }
                 }
               }
@@ -2962,7 +2266,33 @@
           ]
         }
       },
-      "7_8": {
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "packets_received"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "packets_received{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} packets_received"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "70": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -2980,8 +2310,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(server_write_committed_time_ms_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} server_write_committed_time"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} server_write_committed_time"
                   }
                 }
               }
@@ -2989,7 +2318,7 @@
           ]
         }
       },
-      "7_9": {
+      "71": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -3007,8 +2336,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(write_batch_time_in_commit_processor_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} write_batch_time_in_commit_processor"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} write_batch_time_in_commit_processor"
                   }
                 }
               }
@@ -3016,7 +2344,111 @@
           ]
         }
       },
-      "8_0": {
+      "72": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "reads_after_write_in_session_queue"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(reads_after_write_in_session_queue_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} reads_after_write_in_session_queue"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "73": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "session_queues_drained"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(session_queues_drained_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} session_queues_drained"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "74": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "reads_issued_from_session_queue"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(reads_issued_from_session_queue_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} reads_issued_from_session_queue"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "75": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "request_commit_queued"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "request_commit_queued{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} request_commit_queued"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "76": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -3034,8 +2466,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(write_final_proc_time_ms_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} write_final_proc_time_ms"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} write_final_proc_time_ms"
                   }
                 }
               }
@@ -3043,7 +2474,7 @@
           ]
         }
       },
-      "8_1": {
+      "77": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -3061,8 +2492,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(read_final_proc_time_ms_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} read_final_proc_time_ms"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} read_final_proc_time_ms"
                   }
                 }
               }
@@ -3070,7 +2500,7 @@
           ]
         }
       },
-      "9_0": {
+      "78": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -3088,8 +2518,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(readlatency_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} readlatency"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} readlatency"
                   }
                 }
               }
@@ -3097,7 +2526,7 @@
           ]
         }
       },
-      "9_1": {
+      "79": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -3115,8 +2544,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(updatelatency_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} updatelatency"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} updatelatency"
                   }
                 }
               }
@@ -3124,7 +2552,33 @@
           ]
         }
       },
-      "9_2": {
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "packets_sent"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "packets_sent{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} packets_sent"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "80": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -3142,8 +2596,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "max_latency{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} max_latency"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} max_latency"
                   }
                 }
               }
@@ -3156,8 +2609,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "min_latency{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} min_latency"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} min_latency"
                   }
                 }
               }
@@ -3169,8 +2621,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "avg_latency{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} avg_latency"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} avg_latency"
                   }
                 }
               }
@@ -3178,7 +2629,7 @@
           ]
         }
       },
-      "9_3": {
+      "81": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -3196,8 +2647,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(proposal_latency_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} proposal_latency"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} proposal_latency"
                   }
                 }
               }
@@ -3205,7 +2655,7 @@
           ]
         }
       },
-      "9_4": {
+      "82": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -3223,8 +2673,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(quorum_ack_latency_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} quorum_ack_latency"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} quorum_ack_latency"
                   }
                 }
               }
@@ -3232,7 +2681,7 @@
           ]
         }
       },
-      "9_5": {
+      "83": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -3250,7 +2699,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "proposal_ack_creation_latency{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} proposal_ack_creation_latency-{{ "{{" }}quantile{{ "}}" }}"
+                    "seriesNameFormat": "{{ `{{instance}}` }} proposal_ack_creation_latency-{{ `{{quantile}}` }}"
                   }
                 }
               }
@@ -3258,7 +2707,7 @@
           ]
         }
       },
-      "9_6": {
+      "84": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -3276,8 +2725,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(propagation_latency_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} propagation_latency"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} propagation_latency"
                   }
                 }
               }
@@ -3285,7 +2733,7 @@
           ]
         }
       },
-      "9_7": {
+      "85": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -3303,8 +2751,393 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "query": "rate(commit_propagation_latency_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }} commit_propagation_latency"
-
+                    "seriesNameFormat": "{{ `{{instance}}` }} commit_propagation_latency"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "86": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "tls_handshake"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "tls_handshake_exceeded{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} tls_handshake_exceeded"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "outstanding_tls_handshake{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} outstanding_tls_handshake"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "87": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ensemble_auth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "ensemble_auth_fail{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} ensemble_auth_fail"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "ensemble_auth_success{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} ensemble_auth_success"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "ensemble_auth_skip{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} ensemble_auth_skip"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "88": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "jvm_classes_loaded"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "max(jvm_classes_loaded{namespace=~\"$namespace\",service=~\"$app+-stats\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "89": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "jvm_threads_current"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "max(jvm_threads_current{namespace=~\"$namespace\",service=~\"$app+-stats\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "response_packet_cache"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "response_packet_cache_misses{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} response_packet_cache_misses"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "response_packet_cache_hits{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} response_packet_cache_hits"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "response_packet_get_children_cache_misses{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} response_packet_get_children_cache_misses"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "response_packet_get_children_cache_hits{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} response_packet_get_children_cache_hits"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "90": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "jvm_threads_deadlocked"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "max(jvm_threads_deadlocked{namespace=~\"$namespace\",service=~\"$app+-stats\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "91": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "jvm_pause_time_ms"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(jvm_pause_time_ms_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} jvm_pause_time_ms"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "92": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "jvm_gc_collection_seconds"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(jvm_gc_collection_seconds_sum{namespace=~\"$namespace\",service=~\"$app+-stats\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} gc:{{ `{{gc}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "93": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "jvm_threads_state"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "jvm_threads_state{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} state:{{ `{{state}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "94": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "jvm_memory_pool_bytes_used"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "jvm_memory_pool_bytes_used{namespace=~\"$namespace\",service=~\"$app+-stats\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} pool:{{ `{{pool}}` }}"
                   }
                 }
               }
@@ -3318,10 +3151,7 @@
         "kind": "Grid",
         "spec": {
           "display": {
-            "title": "Overall",
-            "collapse": {
-              "open": true
-            }
+            "title": "Panel Group 1"
           },
           "items": [
             {
@@ -3330,7 +3160,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_0"
+                "$ref": "#/spec/panels/0"
               }
             },
             {
@@ -3339,7 +3169,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_1"
+                "$ref": "#/spec/panels/1"
               }
             },
             {
@@ -3348,7 +3178,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_2"
+                "$ref": "#/spec/panels/2"
               }
             },
             {
@@ -3357,7 +3187,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_3"
+                "$ref": "#/spec/panels/3"
               }
             },
             {
@@ -3366,7 +3196,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_4"
+                "$ref": "#/spec/panels/4"
               }
             },
             {
@@ -3375,7 +3205,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_5"
+                "$ref": "#/spec/panels/5"
               }
             },
             {
@@ -3384,7 +3214,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_6"
+                "$ref": "#/spec/panels/6"
               }
             },
             {
@@ -3393,7 +3223,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_7"
+                "$ref": "#/spec/panels/7"
               }
             },
             {
@@ -3402,7 +3232,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_8"
+                "$ref": "#/spec/panels/8"
               }
             },
             {
@@ -3411,7 +3241,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_9"
+                "$ref": "#/spec/panels/9"
               }
             },
             {
@@ -3420,7 +3250,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_10"
+                "$ref": "#/spec/panels/10"
               }
             },
             {
@@ -3429,7 +3259,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_11"
+                "$ref": "#/spec/panels/11"
               }
             },
             {
@@ -3438,7 +3268,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_12"
+                "$ref": "#/spec/panels/12"
               }
             },
             {
@@ -3447,7 +3277,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_13"
+                "$ref": "#/spec/panels/13"
               }
             },
             {
@@ -3456,29 +3286,16 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/0_14"
+                "$ref": "#/spec/panels/14"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Quorum/Leader Election",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 50,
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1_0"
+                "$ref": "#/spec/panels/15"
               }
             },
             {
@@ -3487,7 +3304,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1_1"
+                "$ref": "#/spec/panels/16"
               }
             },
             {
@@ -3496,7 +3313,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1_2"
+                "$ref": "#/spec/panels/17"
               }
             },
             {
@@ -3505,7 +3322,7 @@
               "width": 24,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1_3"
+                "$ref": "#/spec/panels/18"
               }
             },
             {
@@ -3514,7 +3331,7 @@
               "width": 6,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1_4"
+                "$ref": "#/spec/panels/19"
               }
             },
             {
@@ -3523,7 +3340,7 @@
               "width": 6,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1_5"
+                "$ref": "#/spec/panels/20"
               }
             },
             {
@@ -3532,7 +3349,7 @@
               "width": 6,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1_6"
+                "$ref": "#/spec/panels/21"
               }
             },
             {
@@ -3541,7 +3358,7 @@
               "width": 6,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1_7"
+                "$ref": "#/spec/panels/22"
               }
             },
             {
@@ -3550,7 +3367,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1_8"
+                "$ref": "#/spec/panels/23"
               }
             },
             {
@@ -3559,7 +3376,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1_9"
+                "$ref": "#/spec/panels/24"
               }
             },
             {
@@ -3568,7 +3385,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1_10"
+                "$ref": "#/spec/panels/25"
               }
             },
             {
@@ -3577,7 +3394,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1_11"
+                "$ref": "#/spec/panels/26"
               }
             },
             {
@@ -3586,7 +3403,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1_12"
+                "$ref": "#/spec/panels/27"
               }
             },
             {
@@ -3595,29 +3412,16 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/1_13"
+                "$ref": "#/spec/panels/28"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Session/Watch",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 91,
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_0"
+                "$ref": "#/spec/panels/29"
               }
             },
             {
@@ -3626,7 +3430,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_1"
+                "$ref": "#/spec/panels/30"
               }
             },
             {
@@ -3635,7 +3439,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_2"
+                "$ref": "#/spec/panels/31"
               }
             },
             {
@@ -3644,7 +3448,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_3"
+                "$ref": "#/spec/panels/32"
               }
             },
             {
@@ -3653,7 +3457,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_4"
+                "$ref": "#/spec/panels/33"
               }
             },
             {
@@ -3662,7 +3466,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_5"
+                "$ref": "#/spec/panels/34"
               }
             },
             {
@@ -3671,7 +3475,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_6"
+                "$ref": "#/spec/panels/35"
               }
             },
             {
@@ -3680,7 +3484,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_7"
+                "$ref": "#/spec/panels/36"
               }
             },
             {
@@ -3689,29 +3493,16 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/2_8"
+                "$ref": "#/spec/panels/37"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Client/Connection",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 116,
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_0"
+                "$ref": "#/spec/panels/38"
               }
             },
             {
@@ -3720,7 +3511,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_1"
+                "$ref": "#/spec/panels/39"
               }
             },
             {
@@ -3729,7 +3520,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_2"
+                "$ref": "#/spec/panels/40"
               }
             },
             {
@@ -3738,7 +3529,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_3"
+                "$ref": "#/spec/panels/41"
               }
             },
             {
@@ -3747,7 +3538,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_4"
+                "$ref": "#/spec/panels/42"
               }
             },
             {
@@ -3756,7 +3547,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_5"
+                "$ref": "#/spec/panels/43"
               }
             },
             {
@@ -3765,7 +3556,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_6"
+                "$ref": "#/spec/panels/44"
               }
             },
             {
@@ -3774,7 +3565,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_7"
+                "$ref": "#/spec/panels/45"
               }
             },
             {
@@ -3783,7 +3574,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_8"
+                "$ref": "#/spec/panels/46"
               }
             },
             {
@@ -3792,29 +3583,16 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/3_9"
+                "$ref": "#/spec/panels/47"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Disk/Snapshot",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 149,
               "width": 24,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/4_0"
+                "$ref": "#/spec/panels/48"
               }
             },
             {
@@ -3823,7 +3601,7 @@
               "width": 24,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/4_1"
+                "$ref": "#/spec/panels/49"
               }
             },
             {
@@ -3832,29 +3610,16 @@
               "width": 24,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/4_2"
+                "$ref": "#/spec/panels/50"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Prep_Processor",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 174,
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/5_0"
+                "$ref": "#/spec/panels/51"
               }
             },
             {
@@ -3863,7 +3628,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/5_1"
+                "$ref": "#/spec/panels/52"
               }
             },
             {
@@ -3872,7 +3637,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/5_2"
+                "$ref": "#/spec/panels/53"
               }
             },
             {
@@ -3881,7 +3646,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/5_3"
+                "$ref": "#/spec/panels/54"
               }
             },
             {
@@ -3890,7 +3655,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/5_4"
+                "$ref": "#/spec/panels/55"
               }
             },
             {
@@ -3899,29 +3664,16 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/5_5"
+                "$ref": "#/spec/panels/56"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Sync_Processor",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 191,
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/6_0"
+                "$ref": "#/spec/panels/57"
               }
             },
             {
@@ -3930,7 +3682,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/6_1"
+                "$ref": "#/spec/panels/58"
               }
             },
             {
@@ -3939,7 +3691,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/6_2"
+                "$ref": "#/spec/panels/59"
               }
             },
             {
@@ -3948,7 +3700,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/6_3"
+                "$ref": "#/spec/panels/60"
               }
             },
             {
@@ -3957,29 +3709,16 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/6_4"
+                "$ref": "#/spec/panels/61"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Commit_Processor",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 208,
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7_0"
+                "$ref": "#/spec/panels/62"
               }
             },
             {
@@ -3988,7 +3727,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7_1"
+                "$ref": "#/spec/panels/63"
               }
             },
             {
@@ -3997,7 +3736,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7_2"
+                "$ref": "#/spec/panels/64"
               }
             },
             {
@@ -4006,7 +3745,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7_3"
+                "$ref": "#/spec/panels/65"
               }
             },
             {
@@ -4015,7 +3754,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7_4"
+                "$ref": "#/spec/panels/66"
               }
             },
             {
@@ -4024,7 +3763,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7_5"
+                "$ref": "#/spec/panels/67"
               }
             },
             {
@@ -4033,7 +3772,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7_6"
+                "$ref": "#/spec/panels/68"
               }
             },
             {
@@ -4042,7 +3781,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7_7"
+                "$ref": "#/spec/panels/69"
               }
             },
             {
@@ -4051,7 +3790,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7_8"
+                "$ref": "#/spec/panels/70"
               }
             },
             {
@@ -4060,7 +3799,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7_9"
+                "$ref": "#/spec/panels/71"
               }
             },
             {
@@ -4069,7 +3808,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7_10"
+                "$ref": "#/spec/panels/72"
               }
             },
             {
@@ -4078,7 +3817,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7_11"
+                "$ref": "#/spec/panels/73"
               }
             },
             {
@@ -4087,7 +3826,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7_12"
+                "$ref": "#/spec/panels/74"
               }
             },
             {
@@ -4096,29 +3835,16 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/7_13"
+                "$ref": "#/spec/panels/75"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Final_Processor",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 249,
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/8_0"
+                "$ref": "#/spec/panels/76"
               }
             },
             {
@@ -4127,29 +3853,16 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/8_1"
+                "$ref": "#/spec/panels/77"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Latency",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 258,
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/9_0"
+                "$ref": "#/spec/panels/78"
               }
             },
             {
@@ -4158,7 +3871,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/9_1"
+                "$ref": "#/spec/panels/79"
               }
             },
             {
@@ -4167,7 +3880,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/9_2"
+                "$ref": "#/spec/panels/80"
               }
             },
             {
@@ -4176,7 +3889,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/9_3"
+                "$ref": "#/spec/panels/81"
               }
             },
             {
@@ -4185,7 +3898,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/9_4"
+                "$ref": "#/spec/panels/82"
               }
             },
             {
@@ -4194,7 +3907,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/9_5"
+                "$ref": "#/spec/panels/83"
               }
             },
             {
@@ -4203,7 +3916,7 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/9_6"
+                "$ref": "#/spec/panels/84"
               }
             },
             {
@@ -4212,29 +3925,16 @@
               "width": 12,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/9_7"
+                "$ref": "#/spec/panels/85"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Security",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 291,
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/10_0"
+                "$ref": "#/spec/panels/86"
               }
             },
             {
@@ -4243,29 +3943,16 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/10_1"
+                "$ref": "#/spec/panels/87"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "JVM",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 300,
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/11_0"
+                "$ref": "#/spec/panels/88"
               }
             },
             {
@@ -4274,7 +3961,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/11_1"
+                "$ref": "#/spec/panels/89"
               }
             },
             {
@@ -4283,7 +3970,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/11_2"
+                "$ref": "#/spec/panels/90"
               }
             },
             {
@@ -4292,7 +3979,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/11_3"
+                "$ref": "#/spec/panels/91"
               }
             },
             {
@@ -4301,7 +3988,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/11_4"
+                "$ref": "#/spec/panels/92"
               }
             },
             {
@@ -4310,7 +3997,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/11_5"
+                "$ref": "#/spec/panels/93"
               }
             },
             {
@@ -4319,7 +4006,7 @@
               "width": 8,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/11_6"
+                "$ref": "#/spec/panels/94"
               }
             }
           ]

--- a/charts/kubedb-perses-dashboards/dashboards/zookeeper/zookeeper_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/zookeeper/zookeeper_pod_dashboard.json
@@ -1,0 +1,4364 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+{
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "NBKKAJAIz",
+    "createdAt": "0001-01-01T00:00:00Z",
+    "updatedAt": "0001-01-01T00:00:00Z",
+    "version": 0,
+    "project": "pp"
+  },
+  "spec": {
+    "display": {
+      "name": "KubeDB / ZooKeeper / Pod"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Datasource",
+            "hidden": false
+          },
+          "defaultValue": "Prometheus",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "DatasourceVariable",
+            "spec": {
+              "datasourcePluginKind": "PrometheusDatasource"
+            }
+          },
+          "name": "datasource"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Namespace",
+            "hidden": false
+          },
+          "defaultValue": "demo",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "none",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "namespace",
+              "matchers": [
+                "kube_namespace_status_phase{phase=\"Active\"}"
+              ]
+            }
+          },
+          "name": "namespace"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "ZooKeeper",
+            "hidden": false
+          },
+          "defaultValue": "zk-cluster",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "alphabetical-asc",
+          "plugin": {
+            "kind": "PrometheusPromQLVariable",
+            "spec": {
+              "expr": "kubedb_com_zookeeper_created{namespace=\"$namespace\"}",
+              "labelName": "app"
+            }
+          },
+          "name": "app"
+        }
+      },
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "Pod Name",
+            "hidden": false
+          },
+          "defaultValue": "zk-cluster-2",
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "sort": "alphabetical-asc",
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "labelName": "pod",
+              "matchers": [
+                "up{namespace=~\"$namespace\",pod=~\"${app}-.*\"}"
+              ]
+            }
+          },
+          "name": "pod"
+        }
+      }
+    ],
+    "panels": {
+      "0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Status"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 1,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "rgba(50, 172, 45, 0.97)",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "up{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Role"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "mean",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "milliseconds"
+              },
+              "metricLabel": "Leader",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "leader_uptime{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "Leader"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "10": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "write_per_namespace"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "write_per_namespace_sum{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} write_per_namespace:{{ `{{key}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "100": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "jvm_memory_pool_bytes_used"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "jvm_memory_pool_bytes_used{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} pool:{{ `{{pool}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "11": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "read_per_namespace"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "read_per_namespace_sum{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} read_per_namespace:{{ `{{key}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "12": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "approximate_data_size"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "approximate_data_size{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} approximate_data_size"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "13": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "packets_received"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "packets_received{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} packets_received"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "14": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "packets_sent"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "packets_sent{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} packets_sent"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "15": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "response_packet_cache"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "response_packet_cache_misses{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} response_packet_cache_misses"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "response_packet_cache_hits{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} response_packet_cache_hits"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "response_packet_get_children_cache_misses{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} response_packet_get_children_cache_misses"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "response_packet_get_children_cache_hits{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} response_packet_get_children_cache_hits"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "16": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "unrecoverable_error_count"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "unrecoverable_error_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} unrecoverable_error_count"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "17": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "digest_mismatches_count"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "digest_mismatches_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} digest_mismatches_count"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "18": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "startup_snap_load_time"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "startup_snap_load_time",
+                    "seriesNameFormat": "{{ `{{instance}}` }} startup_snap_load_time-{{ `{{quantile}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "startup_snap_load_time_count",
+                    "seriesNameFormat": "{{ `{{instance}}` }} startup_snap_load_time_count"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "startup_snap_load_time_sum{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} startup_snap_load_time"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "19": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "startup_txns_loaded"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "startup_txns_loaded",
+                    "seriesNameFormat": "{{ `{{instance}}` }} startup_txns_loaded-{{ `{{quantile}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "startup_txns_loaded_count",
+                    "seriesNameFormat": "{{ `{{instance}}` }} startup_txns_loaded_count"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "startup_txns_loaded_sum{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} startup_txns_loaded"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Uptime"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "milliseconds"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "uptime{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} leader_uptime"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "db_init_time"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "dbinittime",
+                    "seriesNameFormat": "{{ `{{instance}}` }} dbinittime-{{ `{{quantile}}` }}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "dbinittime_count",
+                    "seriesNameFormat": "{{ `{{instance}}` }} dbinittime_count"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "dbinittime_sum{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} db_init_time"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "21": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "quorum_size"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73BF69",
+                    "value": 0
+                  },
+                  {
+                    "color": "rgba(237, 129, 40, 0.89)",
+                    "value": 50
+                  },
+                  {
+                    "color": "#d44a3a",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "max(quorum_size{namespace=~\"$namespace\",pod=~\"$pod\"})",
+                    "seriesNameFormat": "quorum_size"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "22": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "leader"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "mean",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "milliseconds"
+              },
+              "metricLabel": "instance",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "leader_uptime{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "23": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "leader_uptime"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "milliseconds"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "leader_uptime{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} leader_uptime"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "24": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "learner/observer"
+          },
+          "plugin": {
+            "kind": "BarChart",
+            "spec": {
+              "calculation": "last"
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "max(learners{namespace=~\"$namespace\",pod=~\"$pod\"})",
+                    "seriesNameFormat": "learners"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "max(synced_non_voting_followers{namespace=~\"$namespace\",pod=~\"$pod\"})",
+                    "seriesNameFormat": "synced_non_voting_followers"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "max(synced_observers{namespace=~\"$namespace\",pod=~\"$pod\"})",
+                    "seriesNameFormat": "synced_observers"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "25": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "commit_count"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "commit_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} commit_count"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "26": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "snap_count"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "snap_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} snap_count"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "27": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "diff_count"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "diff_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} diff_count"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "28": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "looking_count"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "looking_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} looking_count"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "29": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "proposal_count"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "proposal_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} proposal_count"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Snap Count"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 0,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "snap_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "30": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "proposal_size"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "last_proposal_size{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} last_proposal_size"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "max_proposal_size{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} max_proposal_size"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "min_proposal_size{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} min_proposal_size"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "31": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "follower_sync_time"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(follower_sync_time_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[1m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} follower_sync_time"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "32": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "learner_handler_qp_size"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "learner_handler_qp_size_sum{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} learner_handler_qp_size_sum sid:{{ `{{key}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "33": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "quit_leading_due_to_disloyal_voter"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "quit_leading_due_to_disloyal_voter{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} quit_leading_due_to_disloyal_voter"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "34": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Observer Master"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(om_commit_process_time_ms_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} om_commit_process_time"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(om_proposal_process_time_ms_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} om_proposal_process_time"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "35": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "watch_count"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "watch_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} watch_count"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "36": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "node_changed_watch_count"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "node_changed_watch_count_sum{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} node_changed_watch_count"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "37": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "node_children_watch_count"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "node_children_watch_count_sum{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} node_children_watch_count"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "38": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "node_deleted_watch_count"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "node_deleted_watch_count_sum{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} node_deleted_watch_count"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "39": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "node_created_watch_count"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "node_created_watch_count_sum{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} node_created_watch_count"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Commit Count"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 0,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "commit_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "40": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "revalidate_count"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "revalidate_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} revalidate_count"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "41": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "stale_sessions_expired"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "stale_sessions_expired{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} stale_sessions_expired"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "42": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "dead_watchers"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "dead_watchers_cleared{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} dead_watchers_cleared"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "dead_watchers_queued{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} dead_watchers_queued"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(dead_watchers_cleaner_latency_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} dead_watchers_cleaner_latency"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "43": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "add_dead_watcher_stall_time"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "add_dead_watcher_stall_time{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} add_dead_watcher_stall_time"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "44": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "outstanding_requests"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "outstanding_requests{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} outstanding_requests"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "45": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "client_response_size"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "last_client_response_size{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} last_client_response_size"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "min_client_response_size{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} min_client_response_size"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "max_client_response_size{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} max_client_response_size"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "46": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "bytes_received_count"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "bytes_received_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} bytes_received_count"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "47": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "connection_request_count"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "connection_request_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} connection_request_count"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "48": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "num_alive_connections"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "num_alive_connections{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} num_alive_connections"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "49": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "connection_rejected"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "connection_rejected{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} connection_rejected"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Looking Count"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "decimalPlaces": 0,
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "looking_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "50": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "connection_drop_count"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "connection_drop_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} connection_drop_count"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "51": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "connection_drop_probability"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "connection_drop_probability{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} connection_drop_probability"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "52": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "sessionless_connections_expired"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "sessionless_connections_expired{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} sessionless_connections_expired"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "53": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "connection_token_deficit"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(connection_token_deficit_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} connection_token_deficit"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "54": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "open_file_descriptor"
+          },
+          "plugin": {
+            "kind": "GaugeChart",
+            "spec": {
+              "calculation": "last",
+              "format": {
+                "unit": "decimal"
+              },
+              "max": 1024,
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 800
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "open_file_descriptor_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "55": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "fsync_time"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "fsynctime{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} fsynctime"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "fsynctime_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} fsynctime_count"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "fsynctime_sum{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} fsynctime_sum(ms)"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "fsynctime_sum * 1000 /fsynctime_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} fsynctime_avg(μs)"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "irate(fsynctime_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[1m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} fsynctime_rate"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "56": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "snapshot_time"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(snapshottime_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} snapshot_time_rate"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "snapshottime_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} snapshottime_count"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "snapshottime_sum / snapshottime_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} snapshottime_avg(ms)"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "57": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "prep_process_time"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(prep_process_time_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} prep_process_time"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "58": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "prep_processor_queue_time"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(prep_processor_queue_time_ms_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} prep_processor_queue_time_ms"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "59": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "prep_processor_queue_size"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(prep_processor_queue_size_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} prep_processor_queue_size"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "znode_count"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "znode_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} znode_count"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "ephemerals_count{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} ephemerals"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "60": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "prep_processor_request_queued"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "prep_processor_request_queued{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} prep_processor_request_queued"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "61": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "outstanding_changes_queued"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "outstanding_changes_queued{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} outstanding_changes_queued"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "outstanding_changes_removed{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} outstanding_changes_removed"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "62": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "close_session_prep_time"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(close_session_prep_time_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} close_session_prep_time"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "63": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "sync_process_time"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(sync_process_time_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} sync_process_time"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "64": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "sync_processor_queue_flush_time"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(sync_processor_queue_flush_time_ms_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} sync_processor_queue_flush_time"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "65": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "sync_processor_queue_size"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(sync_processor_queue_size_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} sync_processor_queue_size"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "66": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "sync_processor_request_queued"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "sync_processor_request_queued{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} sync_processor_request_queued"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "67": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "sync_processor_batch_size"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(sync_processor_batch_size_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} sync_processor_batch_size"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "68": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "commit_process_time"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(commit_process_time_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} commit_process_time"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(read_commitproc_time_ms_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} read_commitproc_time"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(write_commitproc_time_ms_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} write_commitproc_time"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "69": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "commit_proc_req_queued"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(write_commit_proc_req_queued_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} write_commit_proc_req_queued"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(read_commit_proc_req_queued_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} read_commit_proc_req_queued"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(commit_commit_proc_req_queued_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} commit_commit_proc_req_queued"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "znode_count_rate"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(znode_count{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} znode_count_rate"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "rate(ephemerals_count{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} ephemerals_rate"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "70": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "requests_in_session_queue"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(requests_in_session_queue_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} requests_in_session_queue"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "71": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "commit_proc_issued"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(read_commit_proc_issued_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} read_commit_proc_issued"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(write_commit_proc_issued_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} write_commit_proc_issued"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "72": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "concurrent_request_processing_in_commit_processor"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(concurrent_request_processing_in_commit_processor_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} concurrent_request_processing_in_commit_processor"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "73": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "time_waiting_empty_pool_in_commit_processor_read"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(time_waiting_empty_pool_in_commit_processor_read_ms_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} time_waiting_empty_pool_in_commit_processor_read"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "74": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "pending_session_queue_size"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(pending_session_queue_size_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} pending_session_queue_size"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "75": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "local_write_committed_time"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(local_write_committed_time_ms_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} local_write_committed_time_ms"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "76": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "server_write_committed_time"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(server_write_committed_time_ms_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} server_write_committed_time"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "77": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "write_batch_time_in_commit_processor"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(write_batch_time_in_commit_processor_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} write_batch_time_in_commit_processor"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "78": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "reads_after_write_in_session_queue"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(reads_after_write_in_session_queue_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} reads_after_write_in_session_queue"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "79": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "session_queues_drained"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(session_queues_drained_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} session_queues_drained"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "global_sessions"
+          },
+          "plugin": {
+            "kind": "BarChart",
+            "spec": {
+              "calculation": "last",
+              "format": {
+                "unit": "decimal"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "global_sessions{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "80": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "reads_issued_from_session_queue"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(reads_issued_from_session_queue_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} reads_issued_from_session_queue"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "81": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "request_commit_queued"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "request_commit_queued{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} request_commit_queued"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "82": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "write_final_proc_time_ms"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(write_final_proc_time_ms_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} write_final_proc_time_ms"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "83": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "read_final_proc_time_ms"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(read_final_proc_time_ms_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} read_final_proc_time_ms"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "84": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "read_latency"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(readlatency_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} readlatency"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "85": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "update_latency"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(updatelatency_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} updatelatency"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "86": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "max_min_avg_latency"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "max_latency{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} max_latency"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "min_latency{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} min_latency"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "avg_latency{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} avg_latency"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "87": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "proposal_latency"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(proposal_latency_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} proposal_latency"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "88": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "quorum_ack_latency"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(quorum_ack_latency_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} quorum_ack_latency"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "89": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "proposal_ack_creation_latency"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "proposal_ack_creation_latency{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} proposal_ack_creation_latency-{{ `{{quantile}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "local_sessions "
+          },
+          "plugin": {
+            "kind": "BarChart",
+            "spec": {
+              "calculation": "last",
+              "format": {
+                "unit": "decimal"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "local_sessions{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "90": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "propagation_latency"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(propagation_latency_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} propagation_latency"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "91": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "commit_propagation_latency"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(commit_propagation_latency_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} commit_propagation_latency"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "92": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "tls_handshake"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "tls_handshake_exceeded{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} tls_handshake_exceeded"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "outstanding_tls_handshake{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} outstanding_tls_handshake"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "93": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "ensemble_auth"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "ensemble_auth_fail{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} ensemble_auth_fail"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "ensemble_auth_success{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} ensemble_auth_success"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "ensemble_auth_skip{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} ensemble_auth_skip"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "94": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "jvm_classes_loaded"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "max(jvm_classes_loaded{namespace=~\"$namespace\",pod=~\"$pod\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "95": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "jvm_threads_current"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "max(jvm_threads_current{namespace=~\"$namespace\",pod=~\"$pod\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "96": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "jvm_threads_deadlocked"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "background_solid",
+              "format": {
+                "unit": "decimal"
+              },
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "max(jvm_threads_deadlocked{namespace=~\"$namespace\",pod=~\"$pod\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "97": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "jvm_pause_time_ms"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(jvm_pause_time_ms_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} jvm_pause_time_ms"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "98": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "jvm_gc_collection_seconds"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "rate(jvm_gc_collection_seconds_sum{namespace=~\"$namespace\",pod=~\"$pod\"}[5m])",
+                    "seriesNameFormat": "{{ `{{instance}}` }} gc:{{ `{{gc}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "99": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "jvm_threads_state"
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {}
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "query": "jvm_threads_state{namespace=~\"$namespace\",pod=~\"$pod\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }} state:{{ `{{state}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Panel Group 1"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/0"
+              }
+            },
+            {
+              "x": 4,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/1"
+              }
+            },
+            {
+              "x": 8,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/2"
+              }
+            },
+            {
+              "x": 12,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 16,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/4"
+              }
+            },
+            {
+              "x": 20,
+              "y": 1,
+              "width": 4,
+              "height": 3,
+              "content": {
+                "$ref": "#/spec/panels/5"
+              }
+            },
+            {
+              "x": 0,
+              "y": 4,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/6"
+              }
+            },
+            {
+              "x": 12,
+              "y": 4,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/7"
+              }
+            },
+            {
+              "x": 0,
+              "y": 12,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/8"
+              }
+            },
+            {
+              "x": 12,
+              "y": 12,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/9"
+              }
+            },
+            {
+              "x": 0,
+              "y": 20,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/10"
+              }
+            },
+            {
+              "x": 12,
+              "y": 20,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/11"
+              }
+            },
+            {
+              "x": 0,
+              "y": 28,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/12"
+              }
+            },
+            {
+              "x": 8,
+              "y": 28,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/13"
+              }
+            },
+            {
+              "x": 16,
+              "y": 28,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/14"
+              }
+            },
+            {
+              "x": 0,
+              "y": 36,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/15"
+              }
+            },
+            {
+              "x": 8,
+              "y": 36,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/16"
+              }
+            },
+            {
+              "x": 16,
+              "y": 36,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/17"
+              }
+            },
+            {
+              "x": 0,
+              "y": 44,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/18"
+              }
+            },
+            {
+              "x": 8,
+              "y": 44,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/19"
+              }
+            },
+            {
+              "x": 16,
+              "y": 44,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/20"
+              }
+            },
+            {
+              "x": 0,
+              "y": 53,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/21"
+              }
+            },
+            {
+              "x": 8,
+              "y": 53,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/22"
+              }
+            },
+            {
+              "x": 16,
+              "y": 53,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/23"
+              }
+            },
+            {
+              "x": 0,
+              "y": 61,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/24"
+              }
+            },
+            {
+              "x": 0,
+              "y": 69,
+              "width": 6,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/25"
+              }
+            },
+            {
+              "x": 6,
+              "y": 69,
+              "width": 6,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/26"
+              }
+            },
+            {
+              "x": 12,
+              "y": 69,
+              "width": 6,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/27"
+              }
+            },
+            {
+              "x": 18,
+              "y": 69,
+              "width": 6,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/28"
+              }
+            },
+            {
+              "x": 0,
+              "y": 77,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/29"
+              }
+            },
+            {
+              "x": 8,
+              "y": 77,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/30"
+              }
+            },
+            {
+              "x": 16,
+              "y": 77,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/31"
+              }
+            },
+            {
+              "x": 0,
+              "y": 85,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/32"
+              }
+            },
+            {
+              "x": 8,
+              "y": 85,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/33"
+              }
+            },
+            {
+              "x": 16,
+              "y": 85,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/34"
+              }
+            },
+            {
+              "x": 0,
+              "y": 94,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/35"
+              }
+            },
+            {
+              "x": 8,
+              "y": 94,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/36"
+              }
+            },
+            {
+              "x": 16,
+              "y": 94,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/37"
+              }
+            },
+            {
+              "x": 0,
+              "y": 102,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/38"
+              }
+            },
+            {
+              "x": 8,
+              "y": 102,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/39"
+              }
+            },
+            {
+              "x": 16,
+              "y": 102,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/40"
+              }
+            },
+            {
+              "x": 0,
+              "y": 110,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/41"
+              }
+            },
+            {
+              "x": 8,
+              "y": 110,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/42"
+              }
+            },
+            {
+              "x": 16,
+              "y": 110,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/43"
+              }
+            },
+            {
+              "x": 0,
+              "y": 119,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/44"
+              }
+            },
+            {
+              "x": 8,
+              "y": 119,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/45"
+              }
+            },
+            {
+              "x": 16,
+              "y": 119,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/46"
+              }
+            },
+            {
+              "x": 0,
+              "y": 127,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/47"
+              }
+            },
+            {
+              "x": 8,
+              "y": 127,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/48"
+              }
+            },
+            {
+              "x": 16,
+              "y": 127,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/49"
+              }
+            },
+            {
+              "x": 0,
+              "y": 135,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/50"
+              }
+            },
+            {
+              "x": 8,
+              "y": 135,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/51"
+              }
+            },
+            {
+              "x": 16,
+              "y": 135,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/52"
+              }
+            },
+            {
+              "x": 0,
+              "y": 143,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/53"
+              }
+            },
+            {
+              "x": 0,
+              "y": 152,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/54"
+              }
+            },
+            {
+              "x": 0,
+              "y": 160,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/55"
+              }
+            },
+            {
+              "x": 0,
+              "y": 168,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/56"
+              }
+            },
+            {
+              "x": 0,
+              "y": 177,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/57"
+              }
+            },
+            {
+              "x": 8,
+              "y": 177,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/58"
+              }
+            },
+            {
+              "x": 16,
+              "y": 177,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/59"
+              }
+            },
+            {
+              "x": 0,
+              "y": 185,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/60"
+              }
+            },
+            {
+              "x": 8,
+              "y": 185,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/61"
+              }
+            },
+            {
+              "x": 16,
+              "y": 185,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/62"
+              }
+            },
+            {
+              "x": 0,
+              "y": 194,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/63"
+              }
+            },
+            {
+              "x": 8,
+              "y": 194,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/64"
+              }
+            },
+            {
+              "x": 16,
+              "y": 194,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/65"
+              }
+            },
+            {
+              "x": 0,
+              "y": 202,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/66"
+              }
+            },
+            {
+              "x": 8,
+              "y": 202,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/67"
+              }
+            },
+            {
+              "x": 0,
+              "y": 211,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/68"
+              }
+            },
+            {
+              "x": 8,
+              "y": 211,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/69"
+              }
+            },
+            {
+              "x": 16,
+              "y": 211,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/70"
+              }
+            },
+            {
+              "x": 0,
+              "y": 219,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/71"
+              }
+            },
+            {
+              "x": 8,
+              "y": 219,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/72"
+              }
+            },
+            {
+              "x": 16,
+              "y": 219,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/73"
+              }
+            },
+            {
+              "x": 0,
+              "y": 227,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/74"
+              }
+            },
+            {
+              "x": 8,
+              "y": 227,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/75"
+              }
+            },
+            {
+              "x": 16,
+              "y": 227,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/76"
+              }
+            },
+            {
+              "x": 0,
+              "y": 235,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/77"
+              }
+            },
+            {
+              "x": 8,
+              "y": 235,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/78"
+              }
+            },
+            {
+              "x": 16,
+              "y": 235,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/79"
+              }
+            },
+            {
+              "x": 0,
+              "y": 243,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/80"
+              }
+            },
+            {
+              "x": 8,
+              "y": 243,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/81"
+              }
+            },
+            {
+              "x": 0,
+              "y": 252,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/82"
+              }
+            },
+            {
+              "x": 12,
+              "y": 252,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/83"
+              }
+            },
+            {
+              "x": 0,
+              "y": 261,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/84"
+              }
+            },
+            {
+              "x": 12,
+              "y": 261,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/85"
+              }
+            },
+            {
+              "x": 0,
+              "y": 269,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/86"
+              }
+            },
+            {
+              "x": 12,
+              "y": 269,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/87"
+              }
+            },
+            {
+              "x": 0,
+              "y": 277,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/88"
+              }
+            },
+            {
+              "x": 12,
+              "y": 277,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/89"
+              }
+            },
+            {
+              "x": 0,
+              "y": 285,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/90"
+              }
+            },
+            {
+              "x": 12,
+              "y": 285,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/91"
+              }
+            },
+            {
+              "x": 0,
+              "y": 294,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/92"
+              }
+            },
+            {
+              "x": 8,
+              "y": 294,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/93"
+              }
+            },
+            {
+              "x": 0,
+              "y": 303,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/94"
+              }
+            },
+            {
+              "x": 8,
+              "y": 303,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/95"
+              }
+            },
+            {
+              "x": 16,
+              "y": 303,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/96"
+              }
+            },
+            {
+              "x": 0,
+              "y": 311,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/97"
+              }
+            },
+            {
+              "x": 8,
+              "y": 311,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/98"
+              }
+            },
+            {
+              "x": 16,
+              "y": 311,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/99"
+              }
+            },
+            {
+              "x": 0,
+              "y": 319,
+              "width": 8,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/100"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  }
+}

--- a/charts/kubedb-perses-dashboards/dashboards/zookeeper/zookeeper_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/zookeeper/zookeeper_summary_dashboard.json
@@ -79,7 +79,7 @@
       }
     ],
     "panels": {
-      "0_0": {
+      "0": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -90,66 +90,12 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "result": {
-                      "color": "#e0b400"
-                    },
-                    "value": "Critical"
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "result": {
-                      "color": "#c4162a"
-                    },
-                    "value": "DataRestoring"
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "result": {
-                      "color": "#c4162a"
-                    },
-                    "value": "Halted"
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "result": {
-                      "color": "#c4162a"
-                    },
-                    "value": "NotReady"
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "result": {
-                      "color": "text"
-                    },
-                    "value": "Provisioning"
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "result": {
-                      "color": "#56a64b"
-                    },
-                    "value": "Ready"
-                  }
-                }
-              ],
+              "colorMode": "none",
+              "metricLabel": "phase",
               "thresholds": {
                 "steps": [
                   {
-                    "color": "text",
+                    "color": "#c4162a",
                     "value": 0
                   }
                 ]
@@ -165,7 +111,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_zookeeper_status_phase{namespace=\"$namespace\", app=\"$app\"} == 1\n",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{phase}}` }}"
                   }
                 }
               }
@@ -173,7 +119,7 @@
           ]
         }
       },
-      "0_1": {
+      "1": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -184,20 +130,11 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "mean",
+              "colorMode": "none",
               "format": {
                 "unit": "decimal"
               },
-              "mappings": [
-                {
-                  "kind": "Misc",
-                  "spec": {
-                    "result": {
-                      "value": "N/A"
-                    },
-                    "value": "null"
-                  }
-                }
-              ],
+              "metricLabel": "version",
               "sparkline": {},
               "thresholds": {
                 "steps": [
@@ -222,7 +159,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "kubedb_com_zookeeper_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{version}}` }}"
                   }
                 }
               }
@@ -230,7 +167,7 @@
           ]
         }
       },
-      "0_10": {
+      "10": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -241,6 +178,7 @@
             "kind": "StatChart",
             "spec": {
               "calculation": "last-number",
+              "colorMode": "none",
               "format": {
                 "unit": "bytes"
               },
@@ -272,384 +210,7 @@
           ]
         }
       },
-      "0_2": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Quorum Size",
-            "description": "ZooKeeper Quorum Size"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              },
-              "valueFontSize": 25
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "max(quorum_size{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"})",
-                    "seriesNameFormat": "values"
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_3": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Leader",
-            "description": "ZooKeeper Leader Node"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "mean",
-              "format": {
-                "unit": "decimal"
-              },
-              "mappings": [
-                {
-                  "kind": "Misc",
-                  "spec": {
-                    "result": {
-                      "value": "N/A"
-                    },
-                    "value": "null"
-                  }
-                }
-              ],
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#f2495c",
-                    "value": 80
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "leader_uptime{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"}",
-                    "seriesNameFormat": "{{ "{{" }}instance{{ "}}" }}"
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_4": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Deletion Policy",
-            "description": "KubeDB Database Resource deletionPolicy"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "mappings": [
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "result": {
-                      "color": "#fade2a"
-                    },
-                    "value": "Delete"
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "result": {
-                      "color": "#73bf69"
-                    },
-                    "value": "DoNotTerminate"
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "result": {
-                      "color": "#5794f2"
-                    },
-                    "value": "Halt"
-                  }
-                },
-                {
-                  "kind": "Value",
-                  "spec": {
-                    "result": {
-                      "color": "#c4162a"
-                    },
-                    "value": "WipeOut"
-                  }
-                }
-              ],
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "text",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_zookeeper_info{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": "{{ "{{" }}deletionPolicy{{ "}}" }}"
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_5": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Total Nodes",
-            "description": "Total node count of ZooKeeper cluster"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  },
-                  {
-                    "color": "#f2495c",
-                    "value": 80
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_zookeeper_replicas{namespace=\"$namespace\",app=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_6": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "CPU Request (Core)",
-            "description": "Initial Requested CPU amount by Postgres Instance"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_zookeeper_resource_request_cpu{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_7": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "CPU Limit (Core)",
-            "description": "CPU Limit in core by ZooKeeper instance"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_zookeeper_resource_limit_cpu{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_8": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Memory Request",
-            "description": "Initial Requested Memory amount by ZooKeeper Instance"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "bytes"
-              },
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_zookeeper_resource_request_memory{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "0_9": {
-        "kind": "Panel",
-        "spec": {
-          "display": {
-            "name": "Memory Limit",
-            "description": "KubeDB ZooKeeper Total Memory Limit"
-          },
-          "plugin": {
-            "kind": "StatChart",
-            "spec": {
-              "calculation": "last-number",
-              "format": {
-                "unit": "bytes"
-              },
-              "sparkline": {},
-              "thresholds": {
-                "steps": [
-                  {
-                    "color": "#73bf69",
-                    "value": 0
-                  }
-                ]
-              }
-            }
-          },
-          "queries": [
-            {
-              "kind": "TimeSeriesQuery",
-              "spec": {
-                "plugin": {
-                  "kind": "PrometheusTimeSeriesQuery",
-                  "spec": {
-                    "minStep": "",
-                    "query": "kubedb_com_zookeeper_resource_limit_memory{namespace=\"$namespace\", app=\"$app\"}",
-                    "seriesNameFormat": ""
-                  }
-                }
-              }
-            }
-          ]
-        }
-      },
-      "1_0": {
+      "11": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -668,7 +229,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -676,7 +237,7 @@
           ]
         }
       },
-      "1_1": {
+      "12": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -690,37 +251,49 @@
                 {
                   "header": "Time",
                   "name": "timestamp",
-                  "width": null
+                  "width": "auto"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "CPU Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "CPU Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
-                }
-              ],
-              "transforms": [
-                {
-                  "kind": "MergeSeries",
-                  "spec": {}
                 }
               ]
             }
@@ -794,7 +367,7 @@
           ]
         }
       },
-      "2_0": {
+      "13": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -825,7 +398,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(node_namespace_pod_container:container_memory_working_set_bytes{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\",container!=\"\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -833,7 +406,7 @@
           ]
         }
       },
-      "2_1": {
+      "14": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -848,46 +421,67 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Requests",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Requests %",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Limits",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "percent-decimal"
+                  },
                   "header": "Memory Limits %",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (RSS)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Cache)",
-                  "name": "Value #G"
+                  "name": "value #7"
                 },
                 {
+                  "format": {
+                    "unit": "bytes"
+                  },
                   "header": "Memory Usage (Swap)",
-                  "name": "Value #H"
+                  "name": "value #8"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
-                }
-              ],
-              "transforms": [
-                {
-                  "kind": "MergeSeries",
-                  "spec": {}
                 }
               ]
             }
@@ -1000,7 +594,7 @@
           ]
         }
       },
-      "3_0": {
+      "15": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1031,7 +625,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "avg(container_blkio_device_usage_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1039,7 +633,7 @@
           ]
         }
       },
-      "3_1": {
+      "16": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1070,7 +664,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_writes_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": "{{ "{{" }}pod{{ "}}" }}-disk-write"
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-write"
                   }
                 }
               }
@@ -1083,7 +677,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(rate(container_fs_reads_total{namespace=\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))by(pod)",
-                    "seriesNameFormat": "{{ "{{" }}pod{{ "}}" }}-disk-read"
+                    "seriesNameFormat": "{{ `{{pod}}` }}-disk-read"
                   }
                 }
               }
@@ -1091,7 +685,7 @@
           ]
         }
       },
-      "3_2": {
+      "17": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1121,7 +715,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m])))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1129,7 +723,7 @@
           ]
         }
       },
-      "3_3": {
+      "18": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1159,7 +753,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\" ,namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[5m]))",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1167,7 +761,7 @@
           ]
         }
       },
-      "3_4": {
+      "19": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1182,38 +776,53 @@
                   "name": "timestamp"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads)",
-                  "name": "Value #A"
+                  "name": "value #1"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Writes)",
-                  "name": "Value #B"
+                  "name": "value #2"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "IOPS(Reads + Writes)",
-                  "name": "Value #C"
+                  "name": "value #3"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read)",
-                  "name": "Value #D"
+                  "name": "value #4"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Write)",
-                  "name": "Value #E"
+                  "name": "value #5"
                 },
                 {
+                  "format": {
+                    "unit": "bytes/sec"
+                  },
                   "header": "Throughput(Read + Write)",
-                  "name": "Value #F"
+                  "name": "value #6"
                 },
                 {
+                  "format": {
+                    "unit": "decimal"
+                  },
                   "header": "Pod",
                   "name": "pod"
-                }
-              ],
-              "transforms": [
-                {
-                  "kind": "MergeSeries",
-                  "spec": {}
                 }
               ]
             }
@@ -1300,7 +909,47 @@
           ]
         }
       },
-      "4_0": {
+      "2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Quorum Size",
+            "description": "ZooKeeper Quorum Size"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              },
+              "valueFontSize": 25
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "max(quorum_size{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"})",
+                    "seriesNameFormat": "values"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "20": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1310,52 +959,7 @@
           "plugin": {
             "kind": "Table",
             "spec": {
-              "columnSettings": [
-                {
-                  "header": "Volume",
-                  "name": "value"
-                },
-                {
-                  "header": "Pod",
-                  "name": "pod"
-                },
-                {
-                  "hide": true,
-                  "name": "timestamp"
-                },
-                {
-                  "hide": true,
-                  "name": "endpoint"
-                },
-                {
-                  "hide": true,
-                  "name": "instance"
-                },
-                {
-                  "hide": true,
-                  "name": "job"
-                },
-                {
-                  "hide": true,
-                  "name": "metrics_path"
-                },
-                {
-                  "hide": true,
-                  "name": "namespace"
-                },
-                {
-                  "hide": true,
-                  "name": "node"
-                },
-                {
-                  "hide": true,
-                  "name": "persistentvolumeclaim"
-                },
-                {
-                  "hide": true,
-                  "name": "service"
-                }
-              ]
+              "columnSettings": []
             }
           },
           "queries": [
@@ -1375,7 +979,7 @@
           ]
         }
       },
-      "4_1": {
+      "21": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1400,7 +1004,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1408,7 +1012,7 @@
           ]
         }
       },
-      "4_2": {
+      "22": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1435,7 +1039,7 @@
               },
               "yAxis": {
                 "format": {
-                  "unit": "bytes"
+                  "unit": "decbytes"
                 },
                 "max": 5000,
                 "min": 0
@@ -1451,7 +1055,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "(kubelet_volume_stats_used_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) ",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1459,7 +1063,7 @@
           ]
         }
       },
-      "5_0": {
+      "23": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1489,7 +1093,7 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
-                    "seriesNameFormat": ""
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }
               }
@@ -1497,7 +1101,7 @@
           ]
         }
       },
-      "5_1": {
+      "24": {
         "kind": "Panel",
         "spec": {
           "display": {
@@ -1527,6 +1131,303 @@
                   "spec": {
                     "minStep": "",
                     "query": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$app-\\\\d+$\"}[$__rate_interval])) by (pod)",
+                    "seriesNameFormat": "{{ `{{pod}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Leader",
+            "description": "ZooKeeper Leader Node"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "mean",
+              "colorMode": "none",
+              "format": {
+                "unit": "decimal"
+              },
+              "metricLabel": "instance",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "leader_uptime{namespace=\"$namespace\",pod=~\"$app-\\\\d+$\"}",
+                    "seriesNameFormat": "{{ `{{instance}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Deletion Policy",
+            "description": "KubeDB Database Resource deletionPolicy"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#c4162a",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_zookeeper_info{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": "{{ `{{deletionPolicy}}` }}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Total Nodes",
+            "description": "Total node count of ZooKeeper cluster"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  },
+                  {
+                    "color": "#f2495c",
+                    "value": 80
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_zookeeper_replicas{namespace=\"$namespace\",app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Request (Core)",
+            "description": "Initial Requested CPU amount by Postgres Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_zookeeper_resource_request_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "7": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Limit (Core)",
+            "description": "CPU Limit in core by ZooKeeper instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_zookeeper_resource_limit_cpu{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "8": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Request",
+            "description": "Initial Requested Memory amount by ZooKeeper Instance"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_zookeeper_resource_request_memory{namespace=\"$namespace\", app=\"$app\"}",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "9": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Limit",
+            "description": "KubeDB ZooKeeper Total Memory Limit"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last-number",
+              "colorMode": "none",
+              "format": {
+                "unit": "bytes"
+              },
+              "sparkline": {},
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "#73bf69",
+                    "value": 0
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "kubedb_com_zookeeper_resource_limit_memory{namespace=\"$namespace\", app=\"$app\"}",
                     "seriesNameFormat": ""
                   }
                 }
@@ -1541,10 +1442,7 @@
         "kind": "Grid",
         "spec": {
           "display": {
-            "title": "General",
-            "collapse": {
-              "open": true
-            }
+            "title": "Panel Group 1"
           },
           "items": [
             {
@@ -1553,7 +1451,7 @@
               "width": 8,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_0"
+                "$ref": "#/spec/panels/0"
               }
             },
             {
@@ -1562,7 +1460,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_1"
+                "$ref": "#/spec/panels/1"
               }
             },
             {
@@ -1571,7 +1469,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_2"
+                "$ref": "#/spec/panels/2"
               }
             },
             {
@@ -1580,7 +1478,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_3"
+                "$ref": "#/spec/panels/3"
               }
             },
             {
@@ -1589,7 +1487,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_4"
+                "$ref": "#/spec/panels/4"
               }
             },
             {
@@ -1598,7 +1496,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_5"
+                "$ref": "#/spec/panels/5"
               }
             },
             {
@@ -1607,7 +1505,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_6"
+                "$ref": "#/spec/panels/6"
               }
             },
             {
@@ -1616,7 +1514,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_7"
+                "$ref": "#/spec/panels/7"
               }
             },
             {
@@ -1625,7 +1523,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_8"
+                "$ref": "#/spec/panels/8"
               }
             },
             {
@@ -1634,7 +1532,7 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_9"
+                "$ref": "#/spec/panels/9"
               }
             },
             {
@@ -1643,29 +1541,16 @@
               "width": 4,
               "height": 3,
               "content": {
-                "$ref": "#/spec/panels/0_10"
+                "$ref": "#/spec/panels/10"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "CPU Info",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 8,
               "width": 24,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/1_0"
+                "$ref": "#/spec/panels/11"
               }
             },
             {
@@ -1674,29 +1559,16 @@
               "width": 24,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/1_1"
+                "$ref": "#/spec/panels/12"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Memory Info",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 22,
               "width": 24,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/2_0"
+                "$ref": "#/spec/panels/13"
               }
             },
             {
@@ -1705,29 +1577,16 @@
               "width": 24,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/2_1"
+                "$ref": "#/spec/panels/14"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Storage Info",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 35,
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/3_0"
+                "$ref": "#/spec/panels/15"
               }
             },
             {
@@ -1736,7 +1595,7 @@
               "width": 12,
               "height": 9,
               "content": {
-                "$ref": "#/spec/panels/3_1"
+                "$ref": "#/spec/panels/16"
               }
             },
             {
@@ -1745,7 +1604,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_2"
+                "$ref": "#/spec/panels/17"
               }
             },
             {
@@ -1754,7 +1613,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_3"
+                "$ref": "#/spec/panels/18"
               }
             },
             {
@@ -1763,29 +1622,16 @@
               "width": 24,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/3_4"
+                "$ref": "#/spec/panels/19"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Persistent Storage Insight",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 59,
               "width": 12,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/4_0"
+                "$ref": "#/spec/panels/20"
               }
             },
             {
@@ -1794,7 +1640,7 @@
               "width": 12,
               "height": 6,
               "content": {
-                "$ref": "#/spec/panels/4_1"
+                "$ref": "#/spec/panels/21"
               }
             },
             {
@@ -1803,29 +1649,16 @@
               "width": 24,
               "height": 8,
               "content": {
-                "$ref": "#/spec/panels/4_2"
+                "$ref": "#/spec/panels/22"
               }
-            }
-          ]
-        }
-      },
-      {
-        "kind": "Grid",
-        "spec": {
-          "display": {
-            "title": "Network Info",
-            "collapse": {
-              "open": true
-            }
-          },
-          "items": [
+            },
             {
               "x": 0,
               "y": 74,
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_0"
+                "$ref": "#/spec/panels/23"
               }
             },
             {
@@ -1834,7 +1667,7 @@
               "width": 12,
               "height": 7,
               "content": {
-                "$ref": "#/spec/panels/5_1"
+                "$ref": "#/spec/panels/24"
               }
             }
           ]

--- a/charts/kubedb-perses-dashboards/data/resources.yaml
+++ b/charts/kubedb-perses-dashboards/data/resources.yaml
@@ -1,6 +1,9 @@
 cassandra:
   kind: Cassandra
   resource: cassandras
+clickhouse:
+  kind: ClickHouse
+  resource: clickhouses
 connectcluster:
   kind: ConnectCluster
   resource: connectclusters
@@ -10,6 +13,9 @@ druid:
 elasticsearch:
   kind: Elasticsearch
   resource: elasticsearches
+hanadb:
+  kind: HanaDB
+  resource: hanadbs
 hazelcast:
   kind: Hazelcast
   resource: hazelcasts
@@ -25,6 +31,9 @@ mariadb:
 memcached:
   kind: Memcached
   resource: memcacheds
+milvus:
+  kind: Milvus
+  resource: milvuses
 mongodb:
   kind: MongoDB
   resource: mongodbs
@@ -34,6 +43,12 @@ mssqlserver:
 mysql:
   kind: MySQL
   resource: mysqls
+neo4j:
+  kind: Neo4j
+  resource: neo4js
+oracle:
+  kind: Oracle
+  resource: oracles
 perconaxtradb:
   kind: PerconaXtraDB
   resource: perconaxtradbs
@@ -49,6 +64,9 @@ postgres:
 proxysql:
   kind: ProxySQL
   resource: proxysqls
+qdrant:
+  kind: Qdrant
+  resource: qdrants
 rabbitmq:
   kind: RabbitMQ
   resource: rabbitmqs

--- a/charts/kubedb-perses-dashboards/sync-perses-dashboards.sh
+++ b/charts/kubedb-perses-dashboards/sync-perses-dashboards.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# Copyright AppsCode Inc. and Contributors
+#
+# Licensed under the AppsCode Community License 1.0.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://github.com/appscode/licenses/raw/1.0.0/AppsCode-Community-1.0.0.md
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Syncs Perses dashboards from the opnpulse grafana-dashboards repo into
+# charts/kubedb-perses-dashboards/dashboards. opnpulse is the source of truth;
+# only transforms that are mandatory for the chart are applied:
+#   1. drop the "-perses" filename suffix
+#   2. unwrap query_result(<expr>) -> <expr> and fix the migration labelName
+#   3. delete inline "global-ds-proxy" datasource refs (panels inherit $datasource)
+#   4. escape {{...}} so Helm tpl preserves Perses legends instead of evaluating them
+#   5. prepend the chart-convention $shared / $alerts header lines
+#
+# Usage: hack/scripts/sync-perses-dashboards.sh [OPNPULSE_DIR]
+#   OPNPULSE_DIR defaults to ../../opnpulse/grafana-dashboards relative to repo root.
+
+set -eou pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OPNPULSE_DIR="${1:-${REPO_ROOT}/../../opnpulse/grafana-dashboards}"
+DEST_ROOT="${REPO_ROOT}/charts/kubedb-perses-dashboards/dashboards"
+
+if [ ! -d "$OPNPULSE_DIR" ]; then
+    echo "opnpulse dir not found: $OPNPULSE_DIR" >&2
+    exit 1
+fi
+
+# DBs to sync: every DB that has perses sources in opnpulse. A DB dir with no
+# *-perses.json is skipped at runtime, so listing one that lacks sources is safe.
+DBS=(cassandra clickhouse connectcluster druid elasticsearch hanadb hazelcast
+    ignite kafka mariadb memcached milvus mongodb mssqlserver mysql neo4j oracle
+    perconaxtradb pgbouncer pgpool postgres proxysql qdrant rabbitmq redis
+    singlestore solr zookeeper)
+
+JQ_FILTER='
+walk(
+  if type == "object" then
+    ( if (.expr? | type == "string") and (.expr | startswith("query_result(")) and (.expr | endswith(")"))
+      then .expr = (.expr[13:-1]) else . end )
+    | ( if .labelName? == "migration_from_grafana_not_supported" then .labelName = "app" else . end )
+    | ( if (.datasource? | type == "object") and (.datasource.name? == "global-ds-proxy")
+        then del(.datasource) else . end )
+  else . end
+)'
+
+HEADER='{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+{{- $alerts := (eq $.Values.dashboard.alerts true) -}}'
+
+count=0
+for db in "${DBS[@]}"; do
+    src_dir="${OPNPULSE_DIR}/${db}"
+    dst_dir="${DEST_ROOT}/${db}"
+    if [ ! -d "$src_dir" ]; then
+        echo "skip ${db}: no source dir" >&2
+        continue
+    fi
+    shopt -s nullglob
+    srcs=("$src_dir"/*-perses.json)
+    shopt -u nullglob
+    if [ ${#srcs[@]} -eq 0 ]; then
+        echo "skip ${db}: no *-perses.json" >&2
+        continue
+    fi
+    mkdir -p "$dst_dir"
+    for src in "${srcs[@]}"; do
+        base="$(basename "$src")"
+        out="${dst_dir}/${base%-perses.json}.json"
+        {
+            printf '%s\n' "$HEADER"
+            jq "$JQ_FILTER" "$src" |
+                perl -pe 's/(\{\{[^}]*\}\})/"{{ ".chr(96).$1.chr(96)." }}"/ge'
+        } >"$out"
+        count=$((count + 1))
+        echo "synced ${db}/${base%-perses.json}.json"
+    done
+done
+
+echo "done: ${count} dashboards synced"

--- a/charts/kubedb-perses-dashboards/sync-steps.md
+++ b/charts/kubedb-perses-dashboards/sync-steps.md
@@ -1,0 +1,72 @@
+# Plan: Sync Perses dashboards from opnpulse into `charts/kubedb-perses-dashboards`
+
+## Goal
+Re-derive **all** `charts/kubedb-perses-dashboards/dashboards/<db>/*.json` from the updated
+`/Users/arnobkumarsaha/go/src/opnpulse/grafana-dashboards/<db>/*-perses.json`.
+opnpulse is the **source of truth**: preserve its content; transform only what is a broken
+Grafana-migration artifact or what breaks Helm `tpl` rendering. Done via a **re-runnable script**.
+
+## Source-of-truth decisions (from review)
+1. Scope: **re-sync ALL** DBs that have perses files in opnpulse (overwrite existing chart files + add missing).
+2. Conversion: **scripted** (re-runnable for future syncs).
+3. Field content: **keep opnpulse's newer content** (format/unit, dataLink drill-downs, value-column names,
+   real `seriesNameFormat` legends). Only strip/fix what is mandatory (below).
+
+## Conversion recipe (opnpulse `*-perses.json` -> chart `dashboards/<db>/<name>.json`)
+Mandatory transforms only:
+1. **Filename**: drop `-perses` suffix (`postgres_summary_dashboard-perses.json` -> `postgres_summary_dashboard.json`).
+2. **Header**: prepend the two chart-convention lines (matches existing files):
+   ```
+   {{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
+   {{- $alerts := (eq $.Values.dashboard.alerts true) -}}
+   ```
+3. **Fix migration artifacts** (broken Grafana->Perses leftovers, not real content):
+   - Unwrap `query_result(<expr>)` -> `<expr>` in variable `expr`.
+   - `"labelName": "migration_from_grafana_not_supported"` -> `"labelName": "app"`.
+4. **Strip inline datasource refs** so panels inherit the dashboard `$datasource` variable
+   (the kubedb deployment has no `global-ds-proxy` datasource -> would break every panel):
+   remove every `"datasource": { "kind": "PrometheusDatasource", "name": "global-ds-proxy" }` object.
+5. **Templating safety for `{{ }}`** in JSON string values (e.g. `"seriesNameFormat": "{{pod}}"`):
+   Helm `tpl` (applied in `templates/shared/dashboard.yaml`) would try to evaluate `{{pod}}` and fail/empty it.
+   - **Default: escape** so the Perses legend is preserved: `{{pod}}` -> `{{ "{{pod}}" }}` (renders back to `{{pod}}`).
+   - This is strictly better than the old behavior (existing files **blanked** these to `""`, losing legends).
+     Because we re-sync ALL files, every DB becomes consistent under the escape approach.
+   - **OPEN QUESTION for approval**: escape (preserve legends, my recommendation) vs blank (match old shipped files)?
+6. Keep `id`/`uid` as-is — the template already does `omit ... "id" "uid"`, so they are harmless.
+   (`colorMode`, `format`, `unit`, `dataLink`, `metricLabel`, value-column names are opnpulse content -> **kept**.)
+
+## DB / file scope
+Re-synced from opnpulse (perses present): cassandra(3), druid(3), elasticsearch(3), hazelcast(3),
+kafka(3), mariadb(5), memcached(3), mongodb(3), mysql(4), pgbouncer(3), pgpool(3), postgres(3),
+proxysql(3), rabbitmq(3), redis(5), singlestore(3), solr(3), zookeeper(3) = 18 DBs.
+
+Net-new files this brings in (currently missing in chart): redis `redis_pod`, `redis_shards`, `sentinel_pod`;
+rabbitmq `rabbitmq-pod`, `rabbitmq-summary`; proxysql `proxysql-summary`; singlestore `singlestore_summary`;
+zookeeper `zookeeper_pod`.
+
+Left untouched (no perses source in opnpulse, cannot re-sync): ignite, mssqlserver, perconaxtradb (chart-only).
+Out of scope (no opnpulse perses at all): clickhouse, hanadb, milvus, neo4j, oracle, qdrant, connectcluster, db2, weaviate.
+
+No edits needed to `values.yaml` featureGates or `data/resources.yaml` — every synced DB is already listed there.
+
+## Implementation steps
+1. Write `hack/scripts/sync-perses-dashboards.sh` (license header, `set -euo pipefail`):
+   - Arg: `OPNPULSE_DIR` (default `../opnpulse/grafana-dashboards`).
+   - For each DB dir in scope, for each `*-perses.json`:
+     - `jq` pass: `del(.. | .datasource? // empty | select(.name=="global-ds-proxy"))`-style removal of the
+       `global-ds-proxy` datasource objects; `query_result(...)` unwrap + labelName fix (string ops on the
+       compacted JSON or jq `gsub`).
+     - escape `{{...}}` -> `{{ "{{...}}" }}` (sed/perl on string values).
+     - prepend header lines; write to `dashboards/<db>/<name>.json`.
+   - Idempotent: re-running with unchanged opnpulse yields no diff.
+2. Run the script.
+3. Validate: `helm template charts/kubedb-perses-dashboards` renders without error (all PersesDashboard
+   objects valid YAML/JSON); spot-check redis/rabbitmq/postgres output.
+4. Optional: `make ct CT_COMMAND=lint TEST_CHARTS=kubedb-perses-dashboards`.
+5. `git diff --stat` review; confirm only `dashboards/**` + the new script changed.
+
+## Risks / notes
+- Escape-vs-blank for `{{ }}` (step 5) is the one behavioral choice — needs your nod.
+- jq drops insignificant whitespace; output will be reformatted vs hand-edited files (large but mechanical diff).
+  If you want minimal diffs on already-synced DBs, we can match opnpulse's exact JSON formatting instead.
+- Branch: `arnob/perses-sync`. plan.md stays untracked and is deleted before commit.

--- a/charts/kubedb-perses-dashboards/templates/shared/dashboard.yaml
+++ b/charts/kubedb-perses-dashboards/templates/shared/dashboard.yaml
@@ -6,6 +6,8 @@
   {{ $featureGates = mergeOverwrite dict .Values.featureGates .Values.global.featureGates }}
 {{- end }}
 
+{{ $featureGates = merge $featureGates (dict "ConnectCluster" $featureGates.Kafka) }}
+
 {{- $gkr := .Files.Get "data/resources.yaml" | fromYaml -}}
 {{ range $k, $enabled := $featureGates }}
 {{ $singular := lower $k }}


### PR DESCRIPTION
## What

Re-derives all `charts/kubedb-perses-dashboards/dashboards` from the upstream grafana-dashboards `*-perses.json` sources (source of truth) via a new re-runnable script `hack/scripts/sync-perses-dashboards.sh`.

### New DB dashboards
clickhouse, connectcluster, hanadb, ignite, milvus, mssqlserver, neo4j, oracle, perconaxtradb, qdrant.

### Filled missing dashboards
redis (pod, shards, sentinel_pod), rabbitmq (pod, summary), proxysql (summary), singlestore (summary), zookeeper (pod).

## Conversion recipe (mandatory transforms only)
- drop `-perses` filename suffix, prepend the `$shared`/`$alerts` header
- unwrap `query_result(expr)` → `expr`, fix `labelName: migration_from_grafana_not_supported` → `app`
- strip inline `global-ds-proxy` datasource refs (panels inherit `$datasource`)
- escape `{{ ... }}` via backticks so Helm `tpl` preserves Perses legends

## Chart wiring
- `data/resources.yaml`: added clickhouse, hanadb, milvus, neo4j, oracle, qdrant (kind/resource verified against `crds/kubedb-crds.yaml`)
- `templates/shared/dashboard.yaml`: ConnectCluster gated by the Kafka feature gate, matching `kubedb-grafana-dashboards`

## Validation
- `helm template charts/kubedb-perses-dashboards` → 88 PersesDashboards, no errors
- `--set featureGates.Kafka=false` disables both Kafka and ConnectCluster dashboards
- legends preserved post-`tpl`; no escape leakage