### PR TITLE
Add audit-token-requester ClusterRoleBinding to charts

### DIFF
--- a/charts/kubedb-autoscaler/templates/audit-token-requester-cluster-role-binding.yaml
+++ b/charts/kubedb-autoscaler/templates/audit-token-requester-cluster-role-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kubedb-autoscaler.fullname" . }}-audit-token-requester
+  labels:
+    {{- include "kubedb-autoscaler.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appscode:audit-token-requester
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kubedb-autoscaler.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/kubedb-dashboard/templates/audit-token-requester-cluster-role-binding.yaml
+++ b/charts/kubedb-dashboard/templates/audit-token-requester-cluster-role-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kubedb-dashboard.fullname" . }}-audit-token-requester
+  labels:
+    {{- include "kubedb-dashboard.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appscode:audit-token-requester
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kubedb-dashboard.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/kubedb-ops-manager/templates/audit-token-requester-cluster-role-binding.yaml
+++ b/charts/kubedb-ops-manager/templates/audit-token-requester-cluster-role-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kubedb-ops-manager.fullname" . }}-audit-token-requester
+  labels:
+    {{- include "kubedb-ops-manager.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appscode:audit-token-requester
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kubedb-ops-manager.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/kubedb-provisioner/templates/audit-token-requester-cluster-role-binding.yaml
+++ b/charts/kubedb-provisioner/templates/audit-token-requester-cluster-role-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kubedb-provisioner.fullname" . }}-audit-token-requester
+  labels:
+    {{- include "kubedb-provisioner.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appscode:audit-token-requester
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kubedb-provisioner.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/kubedb-schema-manager/templates/audit-token-requester-cluster-role-binding.yaml
+++ b/charts/kubedb-schema-manager/templates/audit-token-requester-cluster-role-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kubedb-schema-manager.fullname" . }}-audit-token-requester
+  labels:
+    {{- include "kubedb-schema-manager.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: appscode:audit-token-requester
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kubedb-schema-manager.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
## Summary
- Add `audit-token-requester-cluster-role-binding.yaml` to all charts that have a `license-checker` ClusterRoleBinding
- Affected charts: `kubedb-provisioner`, `kubedb-autoscaler`, `kubedb-ops-manager`, `kubedb-schema-manager`, `kubedb-dashboard`
- Each binding ties the chart's ServiceAccount to the `appscode:audit-token-requester` ClusterRole