### PR TITLE
Fix Role panel: show Primary/Standby instead of raw value

### DIFF
--- a/charts/kubedb-grafana-dashboards/dashboards/postgres/postgres_pods_dashboard.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/postgres/postgres_pods_dashboard.json
@@ -135,27 +135,19 @@
           "custom": {},
           "mappings": [
             {
-              "from": "1",
-              "id": 1,
-              "text": "Primary",
-              "to": "100000000000",
-              "type": 2
-            },
-            {
-              "from": "",
-              "id": 2,
-              "text": "Secondary",
-              "to": "",
-              "type": 1,
-              "value": "Null"
-            },
-            {
-              "from": "",
-              "id": 3,
-              "text": "Secondary",
-              "to": "",
-              "type": 1,
-              "value": "null"
+              "options": {
+                "0": {
+                  "color": "light-blue",
+                  "index": 0,
+                  "text": "Primary"
+                },
+                "1": {
+                  "color": "super-light-blue",
+                  "index": 1,
+                  "text": "Standby"
+                }
+              },
+              "type": "value"
             }
           ],
           "thresholds": {
@@ -167,7 +159,7 @@
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "none"
         },
         "overrides": []
       },
@@ -197,7 +189,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "count(pg_stat_replication_reply_time{namespace = \"$namespace\", pod=\"$pod\"})",
+          "expr": "pg_replication_is_replica{namespace = \"$namespace\", pod=\"$pod\"}",
           "instant": true,
           "interval": "",
           "legendFormat": "",

--- a/charts/kubedb-perses-dashboards/dashboards/mongodb/mongodb-database-replset-dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mongodb/mongodb-database-replset-dashboard.json
@@ -21,17 +21,13 @@
             "name": "Interval",
             "hidden": false
           },
-          "defaultValue": "$__auto_interval_interval",
+          "defaultValue": "1m",
           "allowAllValue": false,
           "allowMultiple": false,
           "plugin": {
             "kind": "StaticListVariable",
             "spec": {
               "values": [
-                {
-                  "label": "auto",
-                  "value": "$__auto_interval_interval"
-                },
                 "1s",
                 "5s",
                 "1m",
@@ -151,6 +147,89 @@
                 "decimalPlaces": 0,
                 "unit": "decimal"
               },
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "1",
+                    "result": {
+                      "value": "PRIMARY"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "2",
+                    "result": {
+                      "value": "SECONDARY"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "3",
+                    "result": {
+                      "value": "RECOVERING"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "5",
+                    "result": {
+                      "value": "STARTUP2"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "6",
+                    "result": {
+                      "value": "UNKNOWN"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "7",
+                    "result": {
+                      "value": "ARBITER"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "8",
+                    "result": {
+                      "value": "DOWN"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "9",
+                    "result": {
+                      "value": "ROLLBACK"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "10",
+                    "result": {
+                      "value": "REMOVED"
+                    }
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {

--- a/charts/kubedb-perses-dashboards/dashboards/mongodb/mongodb-pod-dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mongodb/mongodb-pod-dashboard.json
@@ -28,10 +28,6 @@
             "kind": "StaticListVariable",
             "spec": {
               "values": [
-                {
-                  "label": "auto",
-                  "value": "$__auto_interval_interval"
-                },
                 "1s",
                 "5s",
                 "1m",

--- a/charts/kubedb-perses-dashboards/dashboards/mssqlserver/mssqlserver_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mssqlserver/mssqlserver_pod_dashboard.json
@@ -326,6 +326,37 @@
                 "unit": "decimal"
               },
               "metricLabel": "role",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "master",
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "master"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "slave",
+                    "result": {
+                      "color": "#8ab8ff",
+                      "value": "slave"
+                    }
+                  }
+                },
+                {
+                  "kind": "Misc",
+                  "spec": {
+                    "value": "null",
+                    "result": {
+                      "value": "N/A"
+                    }
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {

--- a/charts/kubedb-perses-dashboards/dashboards/oracle/oracle_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/oracle/oracle_pod_dashboard.json
@@ -245,6 +245,37 @@
                 "unit": "decimal"
               },
               "metricLabel": "role",
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "master",
+                    "result": {
+                      "color": "#5794f2",
+                      "value": "master"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "slave",
+                    "result": {
+                      "color": "#8ab8ff",
+                      "value": "slave"
+                    }
+                  }
+                },
+                {
+                  "kind": "Misc",
+                  "spec": {
+                    "value": "null",
+                    "result": {
+                      "value": "N/A"
+                    }
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {

--- a/charts/kubedb-perses-dashboards/dashboards/postgres/postgres_pods_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/postgres/postgres_pods_dashboard.json
@@ -156,8 +156,30 @@
               "calculation": "last-number",
               "colorMode": "none",
               "format": {
-                "unit": "bytes"
+                "unit": "decimal"
               },
+              "mappings": [
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "0",
+                    "result": {
+                      "color": "#ffffff",
+                      "value": "Primary"
+                    }
+                  }
+                },
+                {
+                  "kind": "Value",
+                  "spec": {
+                    "value": "1",
+                    "result": {
+                      "color": "#ffffff",
+                      "value": "Standby"
+                    }
+                  }
+                }
+              ],
               "thresholds": {
                 "steps": [
                   {
@@ -176,7 +198,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "minStep": "",
-                    "query": "count(pg_stat_replication_reply_time{namespace = \"$namespace\", pod=\"$pod\"})",
+                    "query": "pg_replication_is_replica{namespace = \"$namespace\", pod=\"$pod\"}",
                     "seriesNameFormat": ""
                   }
                 }


### PR DESCRIPTION
Synced from opnpulse/grafana-dashboards.

- **postgres** perses Role panel now queries `pg_replication_is_replica` with value mappings `0 -> Primary`, `1 -> Standby`. The old `count(pg_stat_replication_reply_time)` returned *No data* on standbys and a raw count on the primary in Perses (mappings only apply when a value exists). Verified live.
- **mssqlserver / oracle** perses Role panels regain their `master`/`slave`/N/A mappings.
- **kubedb-grafana-dashboards** postgres dashboard updated to match (consistency).

Both `kubedb-perses-dashboards` and `kubedb-grafana-dashboards` pass `helm template`.

Upstream: opnpulse/grafana-dashboards#104.