### PR TITLE
Fix Persistent Volume Usage panel returning Prometheus 422

### DIFF
--- a/charts/kubedb-grafana-dashboards/dashboards/druid/druid-summary.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/druid/druid-summary.json
@@ -3361,7 +3361,7 @@
         "targets": [
           {
             "exemplar": true,
-            "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"^$app.*\",namespace=~\"$namespace\"}) )* 100",
+            "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"^$app.*\",namespace=~\"$namespace\"} * 100",
             "instant": true,
             "interval": "",
             "legendFormat": {{ `"{{pod}}"` }},
@@ -3543,7 +3543,7 @@
         "targets": [
           {
             "exemplar": true,
-            "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"^$app.*\",namespace=~\"$namespace\"}) )",
+            "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"^$app.*\",namespace=~\"$namespace\"}",
             "interval": "",
             "legendFormat": {{ `"{{pod}}"` }},
             "refId": "A"

--- a/charts/kubedb-grafana-dashboards/dashboards/elasticsearch/elasticsearch_summary_dashboard.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/elasticsearch/elasticsearch_summary_dashboard.json
@@ -2652,7 +2652,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-.+$\",namespace=~\"$namespace\"}) )* 100",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-.+$\",namespace=~\"$namespace\"} * 100",
           "instant": true,
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},

--- a/charts/kubedb-grafana-dashboards/dashboards/hazelcast/hazelcast-summary.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/hazelcast/hazelcast-summary.json
@@ -2578,7 +2578,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\\\"$app-\\\\\\\\d+$\\\",namespace=~\\\"$namespace\\\"}) )* 100",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\\\"$app-\\\\\\\\d+$\\\",namespace=~\\\"$namespace\\\"} * 100",
           "instant": true,
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},

--- a/charts/kubedb-grafana-dashboards/dashboards/ignite/ignite-summary.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/ignite/ignite-summary.json
@@ -3194,7 +3194,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"} * 100",
           "instant": true,
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},

--- a/charts/kubedb-grafana-dashboards/dashboards/kafka/kafka-summary.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/kafka/kafka-summary.json
@@ -3218,7 +3218,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-.+$\",namespace=\"$namespace\"}) )* 100",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-.+$\",namespace=\"$namespace\"} * 100",
           "instant": true,
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},

--- a/charts/kubedb-grafana-dashboards/dashboards/mariadb/mariadb-summary.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/mariadb/mariadb-summary.json
@@ -2519,7 +2519,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"} * 100",
           "instant": true,
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},

--- a/charts/kubedb-grafana-dashboards/dashboards/mongodb/mongodb-summary-dashboard.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/mongodb/mongodb-summary-dashboard.json
@@ -3486,7 +3486,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",namespace=~\"$namespace\"}) )* 100",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",namespace=~\"$namespace\"} * 100",
           "instant": true,
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},
@@ -3673,7 +3673,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",namespace=~\"$namespace\"}) )",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+|shard\\\\d+-(?:\\\\d+|arbiter-\\\\d+|hidden-\\\\d+)|configsvr-\\\\d+|mongos-\\\\d+)\",namespace=~\"$namespace\"}",
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},
         "refId": "A"

--- a/charts/kubedb-grafana-dashboards/dashboards/mssqlserver/mssqlserver_pod_dashboard.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/mssqlserver/mssqlserver_pod_dashboard.json
@@ -2519,7 +2519,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"^$app.*\",namespace=~\"$namespace\"}) )* 100",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"^$app.*\",namespace=~\"$namespace\"} * 100",
           "instant": true,
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},

--- a/charts/kubedb-grafana-dashboards/dashboards/mssqlserver/mssqlserver_summary_dashboard.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/mssqlserver/mssqlserver_summary_dashboard.json
@@ -2520,7 +2520,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"^$app.*\",namespace=~\"$namespace\"}) )* 100",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"^$app.*\",namespace=~\"$namespace\"} * 100",
           "instant": true,
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},

--- a/charts/kubedb-grafana-dashboards/dashboards/mysql/mysql_summary_dashboard.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/mysql/mysql_summary_dashboard.json
@@ -2602,7 +2602,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"} * 100",
           "instant": true,
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},

--- a/charts/kubedb-grafana-dashboards/dashboards/perconaxtradb/perconaxtradb-summary.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/perconaxtradb/perconaxtradb-summary.json
@@ -2519,7 +2519,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"} * 100",
           "instant": true,
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},

--- a/charts/kubedb-grafana-dashboards/dashboards/postgres/postgres_summary_dashboard.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/postgres/postgres_summary_dashboard.json
@@ -4347,7 +4347,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}",
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},
           "refId": "A"

--- a/charts/kubedb-grafana-dashboards/dashboards/rabbitmq/rabbitmq-summary.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/rabbitmq/rabbitmq-summary.json
@@ -3194,7 +3194,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"} * 100",
           "instant": true,
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},

--- a/charts/kubedb-grafana-dashboards/dashboards/redis/redis_summary_dashboard.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/redis/redis_summary_dashboard.json
@@ -3508,7 +3508,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\",namespace=~\"$namespace\"} * 100",
           "instant": true,
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},
@@ -3687,7 +3687,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\",namespace=~\"$namespace\"}) )",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\",namespace=~\"$namespace\"}",
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},
           "refId": "A"

--- a/charts/kubedb-grafana-dashboards/dashboards/redissentinel/redissentinel_summary_dashboard.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/redissentinel/redissentinel_summary_dashboard.json
@@ -3508,7 +3508,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"} * 100",
           "instant": true,
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},
@@ -3687,7 +3687,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}",
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},
           "refId": "A"

--- a/charts/kubedb-grafana-dashboards/dashboards/singlestore/singlestore-summary.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/singlestore/singlestore-summary.json
@@ -3350,7 +3350,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"} * 100",
           "instant": true,
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},
@@ -3532,7 +3532,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}) )",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}",
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},
           "refId": "A"

--- a/charts/kubedb-grafana-dashboards/dashboards/solr/solr-summary.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/solr/solr-summary.json
@@ -3126,7 +3126,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"} * 100",
           "instant": true,
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},
@@ -3316,7 +3316,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}) )",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}",
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},
           "refId": "A"

--- a/charts/kubedb-grafana-dashboards/dashboards/zookeeper/zookeeper_summary_dashboard.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/zookeeper/zookeeper_summary_dashboard.json
@@ -3498,7 +3498,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"} * 100",
           "instant": true,
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},
@@ -3681,7 +3681,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )",
+          "expr": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}",
           "interval": "",
           "legendFormat": {{ `"{{pod}}"` }},
           "refId": "A"

--- a/charts/kubedb-perses-dashboards/dashboards/druid/druid_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/druid/druid_summary_dashboard.json
@@ -943,7 +943,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "minStep": "",
-                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-brokers-\\\\d+$|$app-coordinators-\\\\d+$|$app-historicals-\\\\d+$|$app-middlemanagers-\\\\d+$|$app-routers-\\\\d+$|$app-overlords-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+                    "query": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-brokers-\\\\d+$|$app-coordinators-\\\\d+$|$app-historicals-\\\\d+$|$app-middlemanagers-\\\\d+$|$app-routers-\\\\d+$|$app-overlords-\\\\d+$\",namespace=~\"$namespace\"} * 100",
                     "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }

--- a/charts/kubedb-perses-dashboards/dashboards/elasticsearch/elasticsearch_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/elasticsearch/elasticsearch_summary_dashboard.json
@@ -1009,7 +1009,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "minStep": "",
-                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-.+$\",namespace=~\"$namespace\"}) )* 100",
+                    "query": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-.+$\",namespace=~\"$namespace\"} * 100",
                     "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }

--- a/charts/kubedb-perses-dashboards/dashboards/ignite/ignite_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/ignite/ignite_summary_dashboard.json
@@ -943,7 +943,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "minStep": "",
-                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+                    "query": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"} * 100",
                     "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }

--- a/charts/kubedb-perses-dashboards/dashboards/kafka/kafka_summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/kafka/kafka_summary.json
@@ -943,7 +943,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "minStep": "",
-                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-.+$\",namespace=~\"$namespace\"}) )* 100",
+                    "query": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-.+$\",namespace=~\"$namespace\"} * 100",
                     "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }

--- a/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-summary.json
@@ -943,7 +943,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "minStep": "",
-                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+                    "query": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"} * 100",
                     "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }

--- a/charts/kubedb-perses-dashboards/dashboards/mssqlserver/mssqlserver_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mssqlserver/mssqlserver_summary_dashboard.json
@@ -943,7 +943,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "minStep": "",
-                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"^$app.*\",namespace=~\"$namespace\"}) )* 100",
+                    "query": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"^$app.*\",namespace=~\"$namespace\"} * 100",
                     "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }

--- a/charts/kubedb-perses-dashboards/dashboards/mysql/mysql_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mysql/mysql_summary_dashboard.json
@@ -990,7 +990,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "minStep": "",
-                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+                    "query": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"} * 100",
                     "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }

--- a/charts/kubedb-perses-dashboards/dashboards/neo4j/neo4j-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/neo4j/neo4j-summary.json
@@ -950,7 +950,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "minStep": "",
-                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+                    "query": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"} * 100",
                     "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }

--- a/charts/kubedb-perses-dashboards/dashboards/perconaxtradb/perconaxtradb-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/perconaxtradb/perconaxtradb-summary.json
@@ -943,7 +943,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "minStep": "",
-                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+                    "query": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"} * 100",
                     "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }

--- a/charts/kubedb-perses-dashboards/dashboards/postgres/postgres_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/postgres/postgres_summary_dashboard.json
@@ -1195,7 +1195,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "minStep": "",
-                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+                    "query": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"} * 100",
                     "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }

--- a/charts/kubedb-perses-dashboards/dashboards/rabbitmq/rabbitmq-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/rabbitmq/rabbitmq-summary.json
@@ -943,7 +943,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "minStep": "",
-                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+                    "query": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"} * 100",
                     "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }

--- a/charts/kubedb-perses-dashboards/dashboards/redis/redis_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/redis/redis_summary_dashboard.json
@@ -1010,7 +1010,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "minStep": "",
-                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+                    "query": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$|$app-shard\\\\d+-\\\\d+$\",namespace=~\"$namespace\"} * 100",
                     "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }

--- a/charts/kubedb-perses-dashboards/dashboards/redis/sentinel_summary_dashbaord.json
+++ b/charts/kubedb-perses-dashboards/dashboards/redis/sentinel_summary_dashbaord.json
@@ -1010,7 +1010,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "minStep": "",
-                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+                    "query": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"} * 100",
                     "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }

--- a/charts/kubedb-perses-dashboards/dashboards/singlestore/singlestore_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/singlestore/singlestore_summary_dashboard.json
@@ -942,7 +942,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "minStep": "",
-                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+                    "query": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-aggregator-\\\\d+$|$app-leaf-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"} * 100",
                     "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }

--- a/charts/kubedb-perses-dashboards/dashboards/solr/solr-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/solr/solr-summary.json
@@ -963,7 +963,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "minStep": "",
-                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+                    "query": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-overseer-\\\\d+$|$app-coordinator-\\\\d+$|$app-data-\\\\d+$|$app-\\\\d+$\",namespace=~\"$namespace\"} * 100",
                     "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }

--- a/charts/kubedb-perses-dashboards/dashboards/zookeeper/zookeeper_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/zookeeper/zookeeper_summary_dashboard.json
@@ -1003,7 +1003,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "minStep": "",
-                    "query": "(kubelet_volume_stats_used_bytes / on(persistentvolumeclaim) group_left(pod) (kubelet_volume_stats_capacity_bytes + on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"}) )* 100",
+                    "query": "(kubelet_volume_stats_used_bytes{job=\"kubelet\"} / kubelet_volume_stats_capacity_bytes{job=\"kubelet\"}) * on(persistentvolumeclaim) group_left(pod) kube_pod_spec_volumes_persistentvolumeclaims_info{pod=~\"$app-\\\\d+$\",namespace=~\"$namespace\"} * 100",
                     "seriesNameFormat": "{{ `{{pod}}` }}"
                   }
                 }


### PR DESCRIPTION
## Problem
The `Persistent Volume Usage` panel returned Prometheus **422** (`found duplicate series for the match group ... on the right hand-side`).

The query divided used bytes by a `(capacity + info)` expression on the RHS of `group_left(pod)`. Because `kubelet_volume_stats_*` is scraped under two jobs (`kubelet` and `apiserver`), that RHS had two series per PVC, which `group_left` (requiring a unique RHS match) rejects.

## Fix
Match `used / capacity` directly (identical label sets), pin to `job="kubelet"` to drop the duplicate, then graft `pod` via `group_left` last.

Applied across both `kubedb-grafana-dashboards` and `kubedb-perses-dashboards` charts (34 files; selectors preserved per DB). Both charts pass `helm template`.