### PR TITLE
Grant ops-manager patch access to pods/resize

### DIFF
--- a/charts/kubedb-ops-manager/templates/cluster-role.yaml
+++ b/charts/kubedb-ops-manager/templates/cluster-role.yaml
@@ -113,6 +113,7 @@ rules:
   - pods
   - pods/exec
   - pods/eviction
+  - pods/resize
   verbs: ["*"]
 - apiGroups:
   - ""


### PR DESCRIPTION
In-place vertical scaling patches the pod `resize` subresource, but the ops-manager ClusterRole only listed `pods`, `pods/exec` and `pods/eviction`. RBAC treats each subresource as a distinct resource, so `verbs: ["*"]` on `pods` does not extend to `pods/resize`, and the resize call was rejected:

  pods "sample-sdb-aggregator-0" is forbidden: User
  "system:serviceaccount:kubedb:kubedb-kubedb-ops-manager" cannot patch
  resource "pods/resize" in API group "" in the namespace "demo"

Add `pods/resize` to the existing core pods rule.