### PR TITLE
Run gofmt with updated golang-dev toolchain

### DIFF
--- a/apis/installer/v1/register.go
+++ b/apis/installer/v1/register.go
@@ -53,7 +53,8 @@ func Resource(resource string) schema.GroupResource {
 
 // Adds the list of known types to api.Scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&KubedbAutoscaler{},
 		&KubedbAutoscalerList{},
 		&KubedbCatalog{},
@@ -82,7 +83,8 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&PrepareClusterList{},
 	)
 
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(
+		SchemeGroupVersion,
 		&metav1.Status{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)

--- a/apis/installer/v1/types_test.go
+++ b/apis/installer/v1/types_test.go
@@ -26,7 +26,8 @@ import (
 )
 
 func TestDefaultValues(t *testing.T) {
-	checker := schemachecker.New(os.DirFS("../../.."),
+	checker := schemachecker.New(
+		os.DirFS("../../.."),
 		schemachecker.TestCase{Obj: v1.KubedbAutoscalerSpec{}},
 		schemachecker.TestCase{Obj: v1.KubedbCatalogSpec{}},
 		schemachecker.TestCase{Obj: v1.KubedbCrdManagerSpec{}},


### PR DESCRIPTION
The `ghcr.io/appscode/golang-dev:1.25` build image was rebuilt with a newer `gofmt` that reformats trailing call parens onto their own line. This makes CI's `verify-gen` (`make gen fmt`) fail on master. Running `make fmt` with the updated toolchain reformats the affected files. Pure formatting — no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)