### PR TITLE
Build kubedb-autoscaler chart dependency before role-aggregator

### DIFF
--- a/hack/scripts/update-chart-dependencies.sh
+++ b/hack/scripts/update-chart-dependencies.sh
@@ -20,3 +20,4 @@ helm repo add appscode https://charts.appscode.com/stable/ || true
 
 helm dependency update charts/kubedb
 helm dependency update charts/kubedb-opscenter
+helm dependency update charts/kubedb-autoscaler

--- a/olm.mk
+++ b/olm.mk
@@ -222,6 +222,10 @@ endif
 
 .PHONY: gen-custom-role
 gen-custom-role: role-aggregator ## Generate custom role for kubedb from selected charts.
+	@# role-aggregator runs `helm template` on each chart, so any chart with
+	@# dependencies (e.g. kubedb-autoscaler -> storage-metrics-server) must have
+	@# them fetched into its charts/ directory first.
+	helm dependency build charts/kubedb-autoscaler
 	$(ROLE_AGGREGATOR) \
 		--name kubedb-role \
 		--dir config/rbac/role.yaml \


### PR DESCRIPTION
## Problem

The release job fails with a panic from `role-aggregator`:

```
panic: helm template charts/kubedb-autoscaler: Error: An error occurred while checking for chart dependencies. You may need to run `helm dependency build` to fetch missing dependencies: found in Chart.yaml, but missing in charts/ directory: storage-metrics-server
```

(see https://github.com/kubedb/CHANGELOG/actions/runs/29154886606/job/86550281098)

## Root cause

#2371 added an OCI dependency on `storage-metrics-server` to `charts/kubedb-autoscaler` and gitignored its vendored `charts/` directory (matching the `kubedb` / `kubedb-opscenter` umbrella charts). But `make bundle` → `gen-custom-role` runs `role-aggregator`, which does `helm template charts/kubedb-autoscaler` internally. Nothing fetched the dependency first, so templating panics. The release-automaton job doesn't run `update-chart-dependencies.sh`, so the dependency was never built.

## Fix

- `gen-custom-role` now runs `helm dependency build charts/kubedb-autoscaler` before invoking `role-aggregator`, making the target self-sufficient regardless of caller.
- Added `helm dependency update charts/kubedb-autoscaler` to `update-chart-dependencies.sh` for consistency with the other CI workflows.

## Verification

Locally, `helm dependency build` fetches `storage-metrics-server-v0.1.0.tgz`, `helm template charts/kubedb-autoscaler` then succeeds, and the vendored `.tgz` stays gitignored.