### PR TITLE
Add Docker Hub login to CI to avoid image pull rate limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Prepare Host
         run: |
           # install yq


### PR DESCRIPTION
## Problem

CI fails on the `build` job with false `Missing Images` errors:

```
Missing Images:
docker.io/timescale/timescaledb:2.1.0-pg11-oss
docker.io/timescale/timescaledb:2.1.0-pg12-oss
docker.io/timescale/timescaledb:2.14.2-pg13-oss
...
```

(see https://github.com/kubedb/installer/actions/runs/29144881875/job/86524616293)

## Root cause

`make ci` runs the image-packer check (`tests/check-charts_test.go`), which pulls referenced images from Docker Hub. Anonymous pulls hit Docker Hub's rate limits on shared GitHub runners, so the images are reported as missing.

## Fix

Authenticate to Docker Hub before `make ci` runs. image-packer uses go-containerregistry's default keychain, which reads the credentials written to `~/.docker/config.json` by the login step. Reuses the same pinned `docker/login-action` already used in `release.yml` and `publish-oci.yml`.

## Notes

- Requires `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets to be configured on the repo/org.
- Secrets are not exposed to fork PRs, so the login is a no-op there (unchanged behavior for external contributors).