### PR TITLE
Add envoyproxies RBAC to kubedb-ui-server cluster role

### DIFF
--- a/charts/kubedb-ui-server/templates/cluster-role.yaml
+++ b/charts/kubedb-ui-server/templates/cluster-role.yaml
@@ -21,10 +21,16 @@ rules:
   - gateway.networking.k8s.io
   resources:
   - 'gateways'
+  - 'gatewayclasses'
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - gateway.envoyproxy.io
+  resources:
+  - 'envoyproxies'
+  verbs: ["get", "list", "watch"]
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
Grants the kubedb-ui-server service account get/list/watch on `envoyproxies` in the `gateway.envoyproxy.io` API group.

Fixes the runtime error:
```
Failed to watch *v1alpha1.EnvoyProxy: envoyproxies.gateway.envoyproxy.io is forbidden: User "system:serviceaccount:kubedb:kubedb-opscenter-kubedb-ui-server" cannot list resource "envoyproxies" in API group "gateway.envoyproxy.io" at the cluster scope
```