### PR TITLE
Update postgres-init image to 0.20.0 for Postgres 18.3

### DIFF
--- a/catalog/copy-images.sh
+++ b/catalog/copy-images.sh
@@ -472,7 +472,6 @@ $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-ar
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-archiver:v0.27.0_18.2-alpine $IMAGE_REGISTRY/kubedb/postgres-archiver:v0.27.0_18.2-alpine
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-archiver:v0.27.0_18.2-bookworm $IMAGE_REGISTRY/kubedb/postgres-archiver:v0.27.0_18.2-bookworm
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-csi-snapshotter-plugin:v0.27.0 $IMAGE_REGISTRY/kubedb/postgres-csi-snapshotter-plugin:v0.27.0
-$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-init:0.19.0 $IMAGE_REGISTRY/kubedb/postgres-init:0.19.0
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-init:0.20.0 $IMAGE_REGISTRY/kubedb/postgres-init:0.20.0
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-restic-plugin:v0.29.0_12.17 $IMAGE_REGISTRY/kubedb/postgres-restic-plugin:v0.29.0_12.17
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-restic-plugin:v0.29.0_14.10 $IMAGE_REGISTRY/kubedb/postgres-restic-plugin:v0.29.0_14.10

--- a/catalog/export-images.sh
+++ b/catalog/export-images.sh
@@ -469,7 +469,6 @@ $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-archiver:v0.27.0_18.2-alpine images/kubedb-postgres-archiver-v0.27.0_18.2-alpine.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-archiver:v0.27.0_18.2-bookworm images/kubedb-postgres-archiver-v0.27.0_18.2-bookworm.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-csi-snapshotter-plugin:v0.27.0 images/kubedb-postgres-csi-snapshotter-plugin-v0.27.0.tar
-$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-init:0.19.0 images/kubedb-postgres-init-0.19.0.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-init:0.20.0 images/kubedb-postgres-init-0.20.0.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-restic-plugin:v0.29.0_12.17 images/kubedb-postgres-restic-plugin-v0.29.0_12.17.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-restic-plugin:v0.29.0_14.10 images/kubedb-postgres-restic-plugin-v0.29.0_14.10.tar

--- a/catalog/imagelist.yaml
+++ b/catalog/imagelist.yaml
@@ -435,7 +435,6 @@
 - ghcr.io/kubedb/postgres-archiver:v0.27.0_18.2-alpine
 - ghcr.io/kubedb/postgres-archiver:v0.27.0_18.2-bookworm
 - ghcr.io/kubedb/postgres-csi-snapshotter-plugin:v0.27.0
-- ghcr.io/kubedb/postgres-init:0.19.0
 - ghcr.io/kubedb/postgres-init:0.20.0
 - ghcr.io/kubedb/postgres-restic-plugin:v0.29.0_12.17
 - ghcr.io/kubedb/postgres-restic-plugin:v0.29.0_14.10

--- a/catalog/import-images.sh
+++ b/catalog/import-images.sh
@@ -463,7 +463,6 @@ $CMD push --allow-nondistributable-artifacts --insecure images/kubedb-postgres-a
 $CMD push --allow-nondistributable-artifacts --insecure images/kubedb-postgres-archiver-v0.27.0_18.2-alpine.tar $IMAGE_REGISTRY/kubedb/postgres-archiver:v0.27.0_18.2-alpine
 $CMD push --allow-nondistributable-artifacts --insecure images/kubedb-postgres-archiver-v0.27.0_18.2-bookworm.tar $IMAGE_REGISTRY/kubedb/postgres-archiver:v0.27.0_18.2-bookworm
 $CMD push --allow-nondistributable-artifacts --insecure images/kubedb-postgres-csi-snapshotter-plugin-v0.27.0.tar $IMAGE_REGISTRY/kubedb/postgres-csi-snapshotter-plugin:v0.27.0
-$CMD push --allow-nondistributable-artifacts --insecure images/kubedb-postgres-init-0.19.0.tar $IMAGE_REGISTRY/kubedb/postgres-init:0.19.0
 $CMD push --allow-nondistributable-artifacts --insecure images/kubedb-postgres-init-0.20.0.tar $IMAGE_REGISTRY/kubedb/postgres-init:0.20.0
 $CMD push --allow-nondistributable-artifacts --insecure images/kubedb-postgres-restic-plugin-v0.29.0_12.17.tar $IMAGE_REGISTRY/kubedb/postgres-restic-plugin:v0.29.0_12.17
 $CMD push --allow-nondistributable-artifacts --insecure images/kubedb-postgres-restic-plugin-v0.29.0_14.10.tar $IMAGE_REGISTRY/kubedb/postgres-restic-plugin:v0.29.0_14.10

--- a/catalog/import-into-k3s.sh
+++ b/catalog/import-into-k3s.sh
@@ -461,7 +461,6 @@ k3s ctr images import images/kubedb-postgres-archiver-v0.27.0_17.2-bookworm.tar
 k3s ctr images import images/kubedb-postgres-archiver-v0.27.0_18.2-alpine.tar
 k3s ctr images import images/kubedb-postgres-archiver-v0.27.0_18.2-bookworm.tar
 k3s ctr images import images/kubedb-postgres-csi-snapshotter-plugin-v0.27.0.tar
-k3s ctr images import images/kubedb-postgres-init-0.19.0.tar
 k3s ctr images import images/kubedb-postgres-init-0.20.0.tar
 k3s ctr images import images/kubedb-postgres-restic-plugin-v0.29.0_12.17.tar
 k3s ctr images import images/kubedb-postgres-restic-plugin-v0.29.0_14.10.tar

--- a/catalog/kubedb/raw/postgres/postgres-18.3-official.yaml
+++ b/catalog/kubedb/raw/postgres/postgres-18.3-official.yaml
@@ -33,7 +33,7 @@ spec:
   exporter:
     image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
   initContainer:
-    image: ghcr.io/kubedb/postgres-init:0.19.0
+    image: ghcr.io/kubedb/postgres-init:0.20.0
   podSecurityPolicies:
     databasePolicyName: postgres-db
   securityContext:
@@ -85,7 +85,7 @@ spec:
   exporter:
     image: docker.io/prometheuscommunity/postgres-exporter:v0.18.1
   initContainer:
-    image: ghcr.io/kubedb/postgres-init:0.19.0
+    image: ghcr.io/kubedb/postgres-init:0.20.0
   podSecurityPolicies:
     databasePolicyName: postgres-db
   securityContext:

--- a/catalog/scripts/postgres/copy-images.sh
+++ b/catalog/scripts/postgres/copy-images.sh
@@ -147,5 +147,4 @@ $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-ar
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-archiver:v0.27.0_17.2-bookworm $IMAGE_REGISTRY/kubedb/postgres-archiver:v0.27.0_17.2-bookworm
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-archiver:v0.27.0_18.2-alpine $IMAGE_REGISTRY/kubedb/postgres-archiver:v0.27.0_18.2-alpine
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-archiver:v0.27.0_18.2-bookworm $IMAGE_REGISTRY/kubedb/postgres-archiver:v0.27.0_18.2-bookworm
-$CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-init:0.19.0 $IMAGE_REGISTRY/kubedb/postgres-init:0.19.0
 $CMD cp --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-init:0.20.0 $IMAGE_REGISTRY/kubedb/postgres-init:0.20.0

--- a/catalog/scripts/postgres/export-images.sh
+++ b/catalog/scripts/postgres/export-images.sh
@@ -144,7 +144,6 @@ $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-archiver:v0.27.0_17.2-bookworm images/kubedb-postgres-archiver-v0.27.0_17.2-bookworm.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-archiver:v0.27.0_18.2-alpine images/kubedb-postgres-archiver-v0.27.0_18.2-alpine.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-archiver:v0.27.0_18.2-bookworm images/kubedb-postgres-archiver-v0.27.0_18.2-bookworm.tar
-$CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-init:0.19.0 images/kubedb-postgres-init-0.19.0.tar
 $CMD pull --allow-nondistributable-artifacts --insecure ghcr.io/kubedb/postgres-init:0.20.0 images/kubedb-postgres-init-0.20.0.tar
 
 tar -czvf images.tar.gz images

--- a/catalog/scripts/postgres/imagelist.yaml
+++ b/catalog/scripts/postgres/imagelist.yaml
@@ -110,5 +110,4 @@
 - ghcr.io/kubedb/postgres-archiver:v0.27.0_17.2-bookworm
 - ghcr.io/kubedb/postgres-archiver:v0.27.0_18.2-alpine
 - ghcr.io/kubedb/postgres-archiver:v0.27.0_18.2-bookworm
-- ghcr.io/kubedb/postgres-init:0.19.0
 - ghcr.io/kubedb/postgres-init:0.20.0

--- a/catalog/scripts/postgres/import-images.sh
+++ b/catalog/scripts/postgres/import-images.sh
@@ -138,5 +138,4 @@ $CMD push --allow-nondistributable-artifacts --insecure images/kubedb-postgres-a
 $CMD push --allow-nondistributable-artifacts --insecure images/kubedb-postgres-archiver-v0.27.0_17.2-bookworm.tar $IMAGE_REGISTRY/kubedb/postgres-archiver:v0.27.0_17.2-bookworm
 $CMD push --allow-nondistributable-artifacts --insecure images/kubedb-postgres-archiver-v0.27.0_18.2-alpine.tar $IMAGE_REGISTRY/kubedb/postgres-archiver:v0.27.0_18.2-alpine
 $CMD push --allow-nondistributable-artifacts --insecure images/kubedb-postgres-archiver-v0.27.0_18.2-bookworm.tar $IMAGE_REGISTRY/kubedb/postgres-archiver:v0.27.0_18.2-bookworm
-$CMD push --allow-nondistributable-artifacts --insecure images/kubedb-postgres-init-0.19.0.tar $IMAGE_REGISTRY/kubedb/postgres-init:0.19.0
 $CMD push --allow-nondistributable-artifacts --insecure images/kubedb-postgres-init-0.20.0.tar $IMAGE_REGISTRY/kubedb/postgres-init:0.20.0

--- a/catalog/scripts/postgres/import-into-k3s.sh
+++ b/catalog/scripts/postgres/import-into-k3s.sh
@@ -136,5 +136,4 @@ k3s ctr images import images/kubedb-postgres-archiver-v0.27.0_17.2-alpine.tar
 k3s ctr images import images/kubedb-postgres-archiver-v0.27.0_17.2-bookworm.tar
 k3s ctr images import images/kubedb-postgres-archiver-v0.27.0_18.2-alpine.tar
 k3s ctr images import images/kubedb-postgres-archiver-v0.27.0_18.2-bookworm.tar
-k3s ctr images import images/kubedb-postgres-init-0.19.0.tar
 k3s ctr images import images/kubedb-postgres-init-0.20.0.tar

--- a/charts/kubedb-catalog/templates/postgres/postgres-18.3-official.yaml
+++ b/charts/kubedb-catalog/templates/postgres/postgres-18.3-official.yaml
@@ -47,7 +47,7 @@ spec:
   exporter:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "prometheuscommunity/postgres-exporter") $) }}:v0.18.1'
   initContainer:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-init") $) }}:0.19.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-init") $) }}:0.20.0'
   securityContext:
     runAsAnyNonRoot: false
     runAsUser: 70
@@ -103,7 +103,7 @@ spec:
   exporter:
     image: '{{ include "image.dockerHub" (merge (dict "_repo" "prometheuscommunity/postgres-exporter") $) }}:v0.18.1'
   initContainer:
-    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-init") $) }}:0.19.0'
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "kubedb/postgres-init") $) }}:0.20.0'
   securityContext:
     runAsAnyNonRoot: true
     runAsUser: 999


### PR DESCRIPTION
## What

The `postgres-init` image bump to `0.20.0` (#2375) missed the `postgres-18.3-official` DBVersion manifest, leaving it pinned at `0.19.0` while all other 84 postgres manifests are on `0.20.0`.

This PR:
- Bumps the raw catalog manifest `catalog/kubedb/raw/postgres/postgres-18.3-official.yaml` (`initContainer.image`) to `0.20.0`.
- Regenerates the `kubedb-catalog` chart template (`charts/kubedb-catalog/templates/postgres/postgres-18.3-official.yaml`) via `make fmt`.
- Drops the now-unused `postgres-init:0.19.0` references from `catalog/imagelist.yaml`, `catalog/scripts/postgres/imagelist.yaml`, and the copy/export/import/k3s scripts (`0.20.0` already present).

After this change, no manifest references `postgres-init:0.19.0`.

## Verification
- `make fmt` correctly propagates the raw tag into the generated chart template.
- `grep -rln "postgres-init.*0.19.0" catalog/ charts/` → no matches.