### PR TITLE
Clear stale resourceeditors hub before generating catalog

### DIFF
--- a/hack/scripts/update-catalog.sh
+++ b/hack/scripts/update-catalog.sh
@@ -16,6 +16,13 @@
 
 set -eou pipefail
 
+# image-packer embeds the resourceeditors hub, but the reloader used by
+# kmodules.xyz/resource-metadata will shadow the embedded copy with
+# /tmp/hub/resourceeditors if that directory exists. A stale/empty leftover
+# there makes image-packer load zero editors and emit a broken catalog, so
+# remove it before running.
+rm -rf /tmp/hub/resourceeditors
+
 image-packer list --root-dir=charts --output-dir=catalog
 
 image-packer generate-scripts --insecure --allow-nondistributable-artifacts \


### PR DESCRIPTION
## Problem

`image-packer` embeds the `resourceeditors` hub from `kmodules.xyz/resource-metadata`, but that hub's reloader shadows the embedded copy with `/tmp/hub/resourceeditors` whenever that directory exists. A stale or empty leftover there makes `image-packer list` load **zero** editors and emit a broken catalog.

## Fix

`update-catalog.sh` now removes `/tmp/hub/resourceeditors` before running `image-packer`, so catalog generation always uses the embedded editors.

## Real fix

The underlying reloader flaw is fixed upstream in gomodules/x#71 (only adopt the override dir once its `trigger` file exists). This workaround guards catalog generation here until that fix is released and re-vendored.