### PR TITLE
Add git-sync v4.7.0 image to catalog image lists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,10 @@ make gen-chart-doc
 make manifests
 make gen           # clientset + manifests
 
+# Refresh all generated artifacts: gen + update-catalog + fmt.
+# ALWAYS run this before opening a PR so generated files are current.
+make refresh
+
 # Bump chart version and chart deps. Pass CHART_VERSION (and optionally APP_VERSION).
 make update-charts CHART_VERSION=v0.64.0
 # Or update one chart:

--- a/Makefile
+++ b/Makefile
@@ -244,6 +244,9 @@ manifests: gen-crds gen-values-schema gen-chart-doc
 .PHONY: gen
 gen: clientset manifests
 
+.PHONY: refresh
+refresh: gen update-catalog fmt
+
 BIN_DIR ?= $(CURDIR)/bin/$(OS)_$(ARCH)
 
 .PHONY: install-image-packer

--- a/catalog/copy-images.sh
+++ b/catalog/copy-images.sh
@@ -523,3 +523,4 @@ $CMD cp --allow-nondistributable-artifacts --insecure mcr.microsoft.com/mssql/se
 $CMD cp --allow-nondistributable-artifacts --insecure mcr.microsoft.com/mssql/server:2022-CU22-ubuntu-22.04 $IMAGE_REGISTRY/mssql/server:2022-CU22-ubuntu-22.04
 $CMD cp --allow-nondistributable-artifacts --insecure mcr.microsoft.com/mssql/server:2025-RTM-ubuntu-22.04 $IMAGE_REGISTRY/mssql/server:2025-RTM-ubuntu-22.04
 $CMD cp --allow-nondistributable-artifacts --insecure registry.k8s.io/git-sync/git-sync:v4.4.2 $IMAGE_REGISTRY/git-sync/git-sync:v4.4.2
+$CMD cp --allow-nondistributable-artifacts --insecure registry.k8s.io/git-sync/git-sync:v4.7.0 $IMAGE_REGISTRY/git-sync/git-sync:v4.7.0

--- a/catalog/export-images.sh
+++ b/catalog/export-images.sh
@@ -520,5 +520,6 @@ $CMD pull --allow-nondistributable-artifacts --insecure mcr.microsoft.com/mssql/
 $CMD pull --allow-nondistributable-artifacts --insecure mcr.microsoft.com/mssql/server:2022-CU22-ubuntu-22.04 images/mssql-server-2022-CU22-ubuntu-22.04.tar
 $CMD pull --allow-nondistributable-artifacts --insecure mcr.microsoft.com/mssql/server:2025-RTM-ubuntu-22.04 images/mssql-server-2025-RTM-ubuntu-22.04.tar
 $CMD pull --allow-nondistributable-artifacts --insecure registry.k8s.io/git-sync/git-sync:v4.4.2 images/git-sync-git-sync-v4.4.2.tar
+$CMD pull --allow-nondistributable-artifacts --insecure registry.k8s.io/git-sync/git-sync:v4.7.0 images/git-sync-git-sync-v4.7.0.tar
 
 tar -czvf images.tar.gz images

--- a/catalog/imagelist.yaml
+++ b/catalog/imagelist.yaml
@@ -486,3 +486,4 @@
 - mcr.microsoft.com/mssql/server:2022-CU22-ubuntu-22.04
 - mcr.microsoft.com/mssql/server:2025-RTM-ubuntu-22.04
 - registry.k8s.io/git-sync/git-sync:v4.4.2
+- registry.k8s.io/git-sync/git-sync:v4.7.0

--- a/catalog/import-images.sh
+++ b/catalog/import-images.sh
@@ -514,3 +514,4 @@ $CMD push --allow-nondistributable-artifacts --insecure images/mssql-server-2022
 $CMD push --allow-nondistributable-artifacts --insecure images/mssql-server-2022-CU22-ubuntu-22.04.tar $IMAGE_REGISTRY/mssql/server:2022-CU22-ubuntu-22.04
 $CMD push --allow-nondistributable-artifacts --insecure images/mssql-server-2025-RTM-ubuntu-22.04.tar $IMAGE_REGISTRY/mssql/server:2025-RTM-ubuntu-22.04
 $CMD push --allow-nondistributable-artifacts --insecure images/git-sync-git-sync-v4.4.2.tar $IMAGE_REGISTRY/git-sync/git-sync:v4.4.2
+$CMD push --allow-nondistributable-artifacts --insecure images/git-sync-git-sync-v4.7.0.tar $IMAGE_REGISTRY/git-sync/git-sync:v4.7.0

--- a/catalog/import-into-k3s.sh
+++ b/catalog/import-into-k3s.sh
@@ -512,3 +512,4 @@ k3s ctr images import images/mssql-server-2022-CU19-ubuntu-22.04.tar
 k3s ctr images import images/mssql-server-2022-CU22-ubuntu-22.04.tar
 k3s ctr images import images/mssql-server-2025-RTM-ubuntu-22.04.tar
 k3s ctr images import images/git-sync-git-sync-v4.4.2.tar
+k3s ctr images import images/git-sync-git-sync-v4.7.0.tar

--- a/catalog/scripts/mssqlserver/copy-images.sh
+++ b/catalog/scripts/mssqlserver/copy-images.sh
@@ -46,3 +46,4 @@ $CMD cp --allow-nondistributable-artifacts --insecure mcr.microsoft.com/mssql/se
 $CMD cp --allow-nondistributable-artifacts --insecure mcr.microsoft.com/mssql/server:2022-CU19-ubuntu-22.04 $IMAGE_REGISTRY/mssql/server:2022-CU19-ubuntu-22.04
 $CMD cp --allow-nondistributable-artifacts --insecure mcr.microsoft.com/mssql/server:2022-CU22-ubuntu-22.04 $IMAGE_REGISTRY/mssql/server:2022-CU22-ubuntu-22.04
 $CMD cp --allow-nondistributable-artifacts --insecure mcr.microsoft.com/mssql/server:2025-RTM-ubuntu-22.04 $IMAGE_REGISTRY/mssql/server:2025-RTM-ubuntu-22.04
+$CMD cp --allow-nondistributable-artifacts --insecure registry.k8s.io/git-sync/git-sync:v4.7.0 $IMAGE_REGISTRY/git-sync/git-sync:v4.7.0

--- a/catalog/scripts/mssqlserver/export-images.sh
+++ b/catalog/scripts/mssqlserver/export-images.sh
@@ -43,5 +43,6 @@ $CMD pull --allow-nondistributable-artifacts --insecure mcr.microsoft.com/mssql/
 $CMD pull --allow-nondistributable-artifacts --insecure mcr.microsoft.com/mssql/server:2022-CU19-ubuntu-22.04 images/mssql-server-2022-CU19-ubuntu-22.04.tar
 $CMD pull --allow-nondistributable-artifacts --insecure mcr.microsoft.com/mssql/server:2022-CU22-ubuntu-22.04 images/mssql-server-2022-CU22-ubuntu-22.04.tar
 $CMD pull --allow-nondistributable-artifacts --insecure mcr.microsoft.com/mssql/server:2025-RTM-ubuntu-22.04 images/mssql-server-2025-RTM-ubuntu-22.04.tar
+$CMD pull --allow-nondistributable-artifacts --insecure registry.k8s.io/git-sync/git-sync:v4.7.0 images/git-sync-git-sync-v4.7.0.tar
 
 tar -czvf images.tar.gz images

--- a/catalog/scripts/mssqlserver/imagelist.yaml
+++ b/catalog/scripts/mssqlserver/imagelist.yaml
@@ -9,3 +9,4 @@
 - mcr.microsoft.com/mssql/server:2022-CU19-ubuntu-22.04
 - mcr.microsoft.com/mssql/server:2022-CU22-ubuntu-22.04
 - mcr.microsoft.com/mssql/server:2025-RTM-ubuntu-22.04
+- registry.k8s.io/git-sync/git-sync:v4.7.0

--- a/catalog/scripts/mssqlserver/import-images.sh
+++ b/catalog/scripts/mssqlserver/import-images.sh
@@ -37,3 +37,4 @@ $CMD push --allow-nondistributable-artifacts --insecure images/mssql-server-2022
 $CMD push --allow-nondistributable-artifacts --insecure images/mssql-server-2022-CU19-ubuntu-22.04.tar $IMAGE_REGISTRY/mssql/server:2022-CU19-ubuntu-22.04
 $CMD push --allow-nondistributable-artifacts --insecure images/mssql-server-2022-CU22-ubuntu-22.04.tar $IMAGE_REGISTRY/mssql/server:2022-CU22-ubuntu-22.04
 $CMD push --allow-nondistributable-artifacts --insecure images/mssql-server-2025-RTM-ubuntu-22.04.tar $IMAGE_REGISTRY/mssql/server:2025-RTM-ubuntu-22.04
+$CMD push --allow-nondistributable-artifacts --insecure images/git-sync-git-sync-v4.7.0.tar $IMAGE_REGISTRY/git-sync/git-sync:v4.7.0

--- a/catalog/scripts/mssqlserver/import-into-k3s.sh
+++ b/catalog/scripts/mssqlserver/import-into-k3s.sh
@@ -35,3 +35,4 @@ k3s ctr images import images/mssql-server-2022-CU16-ubuntu-22.04.tar
 k3s ctr images import images/mssql-server-2022-CU19-ubuntu-22.04.tar
 k3s ctr images import images/mssql-server-2022-CU22-ubuntu-22.04.tar
 k3s ctr images import images/mssql-server-2025-RTM-ubuntu-22.04.tar
+k3s ctr images import images/git-sync-git-sync-v4.7.0.tar


### PR DESCRIPTION
Adds `registry.k8s.io/git-sync/git-sync:v4.7.0` to the catalog image lists and the associated copy/export/import/import-into-k3s scripts, both at the top level and under `catalog/scripts/mssqlserver/`.