### PR TITLE
Fetch kubedb-certified chart dependencies before regenerating it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,9 +275,10 @@ update-chart-dependencies:
 update-certified-charts: update-chart-dependencies install-chart-packer
 	rm -rf charts/kubedb-certified charts/kubedb-certified-crds
 	PATH="$(BIN_DIR):$$PATH" chart-packer crd-less --input charts/kubedb --output charts
+	helm dependency update charts/kubedb-certified
+	PATH="$(BIN_DIR):$$PATH" chart-packer crd-less --input charts/kubedb --output charts
 	PATH="$(BIN_DIR):$$PATH" chart-packer crd-only --input charts/kubedb --output charts
 	@$(MAKE) gen-chart-doc --no-print-directory
-	helm dependency update charts/kubedb-certified
 	@# Revert Chart.lock if the only change is the `generated:` timestamp line
 	@if ! git diff --quiet -- charts/kubedb-certified/Chart.lock; then \
 		changed=$$(git diff -U0 -- charts/kubedb-certified/Chart.lock | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-]generated:'); \

--- a/hack/scripts/openshift-chart-verify.sh
+++ b/hack/scripts/openshift-chart-verify.sh
@@ -63,9 +63,6 @@ if ! kubectl cluster-info >/dev/null 2>&1; then
     exit 1
 fi
 
-echo "==> Packaging charts/kubedb-certified ($CHART_VERSION)"
-helm dependency build "$REPO_ROOT/charts/kubedb-certified"
-
 PACKAGE_DIR="$(mktemp -d)"
 trap 'rm -rf "$PACKAGE_DIR"' EXIT
 helm package "$REPO_ROOT/charts/kubedb-certified" --destination "$PACKAGE_DIR"


### PR DESCRIPTION
## Summary
- `update-certified-charts`: run `helm dependency update charts/kubedb-certified` right after the first `chart-packer crd-less` pass, then re-run `crd-less` and `crd-only`, so the dependency `.tgz`s are on disk before `chart-packer` needs to read them (previously `helm dependency update` ran last, after `crd-only`/`gen-chart-doc`).
- `hack/scripts/openshift-chart-verify.sh`: drop its own `helm dependency build` step, since `make update-certified-charts` now handles fetching dependencies.