### PR TITLE
Give each Perses dashboard a unique metadata.name

### DIFF
--- a/charts/kubedb-perses-dashboards/dashboards/cassandra/cassandra_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/cassandra/cassandra_database_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "PbhrxMuiz",
+    "name": "kubedb-cassandra-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/cassandra/cassandra_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/cassandra/cassandra_pod_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "PbhrxMuiz",
+    "name": "kubedb-cassandra-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/cassandra/cassandra_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/cassandra/cassandra_summary_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "cassandraSummary",
+    "name": "kubedb-cassandra-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/clickhouse/clickhouse-database.json
+++ b/charts/kubedb-perses-dashboards/dashboards/clickhouse/clickhouse-database.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "clickhouseDatabase",
+    "name": "kubedb-clickhouse-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/clickhouse/clickhouse-pod.json
+++ b/charts/kubedb-perses-dashboards/dashboards/clickhouse/clickhouse-pod.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "clickhousePodSummary",
+    "name": "kubedb-clickhouse-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/clickhouse/clickhouse-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/clickhouse/clickhouse-summary.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "clickhouseSummary",
+    "name": "kubedb-clickhouse-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/connectcluster/connectcluster-connect.json
+++ b/charts/kubedb-perses-dashboards/dashboards/connectcluster/connectcluster-connect.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "7Uvb_MbSk",
+    "name": "kubedb-kafka-connectcluster-connect",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/connectcluster/connectcluster-pod.json
+++ b/charts/kubedb-perses-dashboards/dashboards/connectcluster/connectcluster-pod.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "DcPflMxIz",
+    "name": "kubedb-kafka-connectcluster-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/connectcluster/connectcluster-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/connectcluster/connectcluster-summary.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "lLHclMbIz",
+    "name": "kubedb-kafka-connectcluster-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/druid/druid_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/druid/druid_database_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "i_yH4_xSk",
+    "name": "kubedb-druid-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/druid/druid_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/druid/druid_pod_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "5WZ_XCASk",
+    "name": "kubedb-druid-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/druid/druid_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/druid/druid_summary_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "druidSummary",
+    "name": "kubedb-druid-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/elasticsearch/elasticsearch_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/elasticsearch/elasticsearch_database_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "0dBMIuN7k",
+    "name": "kubedb-elasticsearch-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/elasticsearch/elasticsearch_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/elasticsearch/elasticsearch_pod_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "sjfsldk",
+    "name": "kubedb-elasticsearch-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/elasticsearch/elasticsearch_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/elasticsearch/elasticsearch_summary_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "72W2px6Vk",
+    "name": "kubedb-elasticsearch-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/hanadb/hanadb_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/hanadb/hanadb_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "EcC4JDFWz2",
+    "name": "kubedb-hanadb-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/hanadb/hanadb_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/hanadb/hanadb_summary_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "hanadb-summary",
+    "name": "kubedb-hanadb-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/hazelcast/hazelcast_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/hazelcast/hazelcast_database_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "LrqJZlxHz",
+    "name": "kubedb-hazelcast-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/hazelcast/hazelcast_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/hazelcast/hazelcast_pod_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "hFvlarxHz",
+    "name": "kubedb-hazelcast-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/hazelcast/hazelcast_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/hazelcast/hazelcast_summary_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "92M7QvyVk",
+    "name": "kubedb-hazelcast-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/ignite/ignite_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/ignite/ignite_database_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "KTV2TJrGk2",
+    "name": "kubedb-ignite-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/ignite/ignite_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/ignite/ignite_pod_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "KTV2TJrGk2",
+    "name": "kubedb-ignite-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/ignite/ignite_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/ignite/ignite_summary_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "04033bf3-5d6f-43c7-b5b4-07048acbdea2",
+    "name": "kubedb-ignite-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/kafka/kafka_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/kafka/kafka_database_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "CpTnxT0Sz",
+    "name": "kubedb-kafka-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/kafka/kafka_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/kafka/kafka_pod_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "UwK-60AIk",
+    "name": "kubedb-kafka-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/kafka/kafka_summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/kafka/kafka_summary.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "kafkaSumMaRy",
+    "name": "kubedb-kafka-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-database.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-database.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "ohrahgv7z",
+    "name": "kubedb-mariadb-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-galera.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-galera.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "Zmva7c57k",
+    "name": "kubedb-mariadb-galera-cluster",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-pod.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-pod.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "FktZiiOnz",
+    "name": "kubedb-mariadb-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-standard-replication.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-standard-replication.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "Zmva7c57a",
+    "name": "kubedb-mariadb-standardreplication",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mariadb/mariadb-summary.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "VnOgk2Hnk",
+    "name": "kubedb-mariadb-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/memcached/memcached_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/memcached/memcached_database_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "AQxf3X-mk",
+    "name": "kubedb-memcached-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/memcached/memcached_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/memcached/memcached_pod_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "PpBVXkwZk",
+    "name": "kubedb-memcached-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/memcached/memcached_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/memcached/memcached_summary_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "VnOgk2Hnk",
+    "name": "kubedb-memcached-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/milvus/milvus-database.json
+++ b/charts/kubedb-perses-dashboards/dashboards/milvus/milvus-database.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "uLf5cJ3Gz",
+    "name": "kubedb-milvus-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/milvus/milvus-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/milvus/milvus-summary.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "milvusSumMaRyl",
+    "name": "kubedb-milvus-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/mongodb/mongodb-database-replset-dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mongodb/mongodb-database-replset-dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "d0259b78-49c0-4614-bb8b-2ed302a5a8ec",
+    "name": "kubedb-mongodb-database-replicaset",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/mongodb/mongodb-pod-dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mongodb/mongodb-pod-dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "e63d0da5-722a-4e00-aa0e-c25ee5d8cea4",
+    "name": "kubedb-mongodb-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/mongodb/mongodb-summary-dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mongodb/mongodb-summary-dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "92M7QvyVk",
+    "name": "kubedb-mongodb-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/mssqlserver/mssqlserver_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mssqlserver/mssqlserver_database_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "ohrahgv7T",
+    "name": "kubedb-mssqlserver-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/mssqlserver/mssqlserver_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mssqlserver/mssqlserver_pod_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "9J6ObCEMz",
+    "name": "kubedb-mssqlserver-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/mssqlserver/mssqlserver_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mssqlserver/mssqlserver_summary_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "qDMhbh0Iz",
+    "name": "kubedb-mssqlserver-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/mysql/mysql_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mysql/mysql_database_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "ohrahgv7T",
+    "name": "kubedb-mysql-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/mysql/mysql_group_replication.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mysql/mysql_group_replication.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "Zmva7c57k",
+    "name": "kubedb-mysql-group-replication-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/mysql/mysql_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mysql/mysql_pod_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "FktZiiOnz",
+    "name": "kubedb-mysql-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/mysql/mysql_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mysql/mysql_summary_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "VsnOgk2Hnk",
+    "name": "kubedb-mysql-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/neo4j/neo4j-database.json
+++ b/charts/kubedb-perses-dashboards/dashboards/neo4j/neo4j-database.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "fifRHuGDz",
+    "name": "kubedb-neo4j-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/neo4j/neo4j-pod.json
+++ b/charts/kubedb-perses-dashboards/dashboards/neo4j/neo4j-pod.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "fifRHuGDz",
+    "name": "kubedb-neo4j-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/neo4j/neo4j-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/neo4j/neo4j-summary.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "neo4jSumMaRy",
+    "name": "kubedb-neo4j-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/oracle/oracle_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/oracle/oracle_database_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "ohrahgv7T",
+    "name": "kubedb-oracle-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/oracle/oracle_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/oracle/oracle_pod_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "9J6ObCEMz",
+    "name": "kubedb-oracle-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/oracle/oracle_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/oracle/oracle_summary_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "92M7QvyVk",
+    "name": "kubedb-oracle-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/perconaxtradb/perconaxtradb-database.json
+++ b/charts/kubedb-perses-dashboards/dashboards/perconaxtradb/perconaxtradb-database.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "ohrahgv7z",
+    "name": "kubedb-perconaxtradb-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/perconaxtradb/perconaxtradb-galera.json
+++ b/charts/kubedb-perses-dashboards/dashboards/perconaxtradb/perconaxtradb-galera.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "Zmva7c57k",
+    "name": "kubedb-perconaxtradb-galera-cluster",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/perconaxtradb/perconaxtradb-pod.json
+++ b/charts/kubedb-perses-dashboards/dashboards/perconaxtradb/perconaxtradb-pod.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "FktZiiOnz",
+    "name": "kubedb-perconaxtradb-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/perconaxtradb/perconaxtradb-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/perconaxtradb/perconaxtradb-summary.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "VnOgk2Hnkx",
+    "name": "kubedb-perconaxtradb-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/pgbouncer/pgbouncer_database.json
+++ b/charts/kubedb-perses-dashboards/dashboards/pgbouncer/pgbouncer_database.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "KN5pOCn4g",
+    "name": "kubedb-pgbouncer-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/pgbouncer/pgbouncer_pod.json
+++ b/charts/kubedb-perses-dashboards/dashboards/pgbouncer/pgbouncer_pod.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "FktZiiOnz",
+    "name": "kubedb-pgbouncer-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/pgbouncer/pgbouncer_summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/pgbouncer/pgbouncer_summary.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "VsnOgk2212Hnk",
+    "name": "kubedb-pgbouncer-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/pgpool/pgpool_database.json
+++ b/charts/kubedb-perses-dashboards/dashboards/pgpool/pgpool_database.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "KN5pOCn4g",
+    "name": "kubedb-pgpool-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/pgpool/pgpool_pod.json
+++ b/charts/kubedb-perses-dashboards/dashboards/pgpool/pgpool_pod.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "FktZiiOnz",
+    "name": "kubedb-pgpool-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/pgpool/pgpool_summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/pgpool/pgpool_summary.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "VsnOgk2212Hnk",
+    "name": "kubedb-pgpool-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/postgres/postgres_databases_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/postgres/postgres_databases_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "6v_W_NNn_kl",
+    "name": "kubedb-postgres-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/postgres/postgres_pods_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/postgres/postgres_pods_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "IgXOThN7ztest",
+    "name": "kubedb-postgres-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/postgres/postgres_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/postgres/postgres_summary_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "VnOgk2Hnky",
+    "name": "kubedb-postgres-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/proxysql/proxysql-database.json
+++ b/charts/kubedb-perses-dashboards/dashboards/proxysql/proxysql-database.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "ohrahgv7T",
+    "name": "kubedb-proxysql-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/proxysql/proxysql-pod.json
+++ b/charts/kubedb-perses-dashboards/dashboards/proxysql/proxysql-pod.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "FktZiiOnz",
+    "name": "kubedb-proxysql-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/proxysql/proxysql-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/proxysql/proxysql-summary.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "VsnOgk2Hnk",
+    "name": "kubedb-proxysql-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/qdrant/qdrant_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/qdrant/qdrant_database_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "891d29ac-3a28-4b09-8628-a2559963ed4a",
+    "name": "kubedb-qdrant-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/qdrant/qdrant_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/qdrant/qdrant_pod_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "fd868f7d-b1ee-4a46-8cd4-524d08ef710b",
+    "name": "kubedb-qdrant-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/qdrant/qdrant_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/qdrant/qdrant_summary_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "60777403-b8d8-45e8-b9ca-0ed3c35b86e7",
+    "name": "kubedb-qdrant-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/rabbitmq/rabbitmq-database.json
+++ b/charts/kubedb-perses-dashboards/dashboards/rabbitmq/rabbitmq-database.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "ohrdrabbitmq",
+    "name": "kubedb-rabbitmq-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/rabbitmq/rabbitmq-pod.json
+++ b/charts/kubedb-perses-dashboards/dashboards/rabbitmq/rabbitmq-pod.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "FktZiiOnz",
+    "name": "kubedb-rabbitmq-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/rabbitmq/rabbitmq-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/rabbitmq/rabbitmq-summary.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "rAbbItMqSumMaRy",
+    "name": "kubedb-rabbitmq-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/redis/redis_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/redis/redis_pod_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "fF-N4cH7k",
+    "name": "kubedb-redis-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/redis/redis_shards_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/redis/redis_shards_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "fF-N4cHsh",
+    "name": "kubedb-redis-shard",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/redis/redis_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/redis/redis_summary_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "wzK8X8Nrd",
+    "name": "kubedb-redis-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/redis/sentinel_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/redis/sentinel_pod_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "fF-N4cH7k",
+    "name": "kubedb-redissentinel-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/redis/sentinel_summary_dashbaord.json
+++ b/charts/kubedb-perses-dashboards/dashboards/redis/sentinel_summary_dashbaord.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "wzK8X8Nrd",
+    "name": "kubedb-redissentinel-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/singlestore/singlestore_database_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/singlestore/singlestore_database_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "_HMhxhASz",
+    "name": "kubedb-singlestore-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/singlestore/singlestore_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/singlestore/singlestore_pod_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "cvGhb2ASk",
+    "name": "kubedb-singlestore-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/singlestore/singlestore_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/singlestore/singlestore_summary_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "qDMhbh0Iz",
+    "name": "kubedb-singlestore-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/solr/solr-database.json
+++ b/charts/kubedb-perses-dashboards/dashboards/solr/solr-database.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "Vm64KR1Sz",
+    "name": "kubedb-solr-database",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/solr/solr-pod.json
+++ b/charts/kubedb-perses-dashboards/dashboards/solr/solr-pod.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "0dBMIuN7m",
+    "name": "kubedb-solr-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/solr/solr-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/solr/solr-summary.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "92M7QvyVk",
+    "name": "kubedb-solr-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/zookeeper/zookeeper_ensemble_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/zookeeper/zookeeper_ensemble_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "a1W-SoASk",
+    "name": "kubedb-zookeeper-ensemble",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/zookeeper/zookeeper_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/zookeeper/zookeeper_pod_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "NBKKAJAIz",
+    "name": "kubedb-zookeeper-pod",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,

--- a/charts/kubedb-perses-dashboards/dashboards/zookeeper/zookeeper_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/zookeeper/zookeeper_summary_dashboard.json
@@ -3,7 +3,7 @@
 {
   "kind": "Dashboard",
   "metadata": {
-    "name": "Vj9GtJ0Iz",
+    "name": "kubedb-zookeeper-summary",
     "createdAt": "0001-01-01T00:00:00Z",
     "updatedAt": "0001-01-01T00:00:00Z",
     "version": 0,


### PR DESCRIPTION
## Problem
Different `PersesDashboard` CRs reported the **same** `.status.dashboard.id` (e.g. `kubedb-mysql-pod` and `kubedb-mariadb-pod` both `FktZiiOnz`). That id is the dashboard model's `metadata.name`, surfaced verbatim by the operator. Two dashboards with the same name land on the **same** Perses dashboard (scoped only by project + folder), so each colliding pair overwrote the other — one dashboard per group was effectively missing.

Root cause: `percli migrate` copies the Grafana source `uid` into `metadata.name`, and the source carried duplicate uids. 16 groups (~30 files) collided. (Grafana dashboards don't collide because the chart omits `uid` and Grafana assigns its own id.)

## Fix
Rename every dashboard `metadata.name` to `kubedb-<db>-<type>` = `normalize(spec.display.name)` (lower, strip spaces, split `/`, join `-`) — the exact rule the chart uses to derive the `PersesDashboard` CR name, so `metadata.name` now equals the CR name. Only the model's `metadata.name` changes; display names, panels, and variables are untouched.

## Verification
- 88 dashboards, one line changed each; `helm template` renders 88 models with 88 unique names, zero duplicates.
- Companion fixes (separate PRs): the `opnpulse/grafana-dashboards` source data and the `opnpulse/perses-dashboards` generator, so future migrations are collision-proof.