### PR TITLE
Use kube_namespace_status_phase for namespace variables

### DIFF
--- a/charts/kubedb-grafana-dashboards/dashboards/hanadb/hanadb_summary_dashboard.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/hanadb/hanadb_summary_dashboard.json
@@ -2870,7 +2870,7 @@
           "value": "demo"
         },
         "datasource": "${datasource}",
-        "definition": "label_values(kube_namespace_created,namespace)",
+        "definition": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -2881,7 +2881,7 @@
         "options": [],
         {{- if $shared }}
         "query": {
-          "query": "label_values(kube_namespace_created,namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "type": "query",

--- a/charts/kubedb-grafana-dashboards/dashboards/redis/redis_pod_dashboard.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/redis/redis_pod_dashboard.json
@@ -1699,7 +1699,7 @@
         "options": [],
         {{- if $shared }}
         "query": {
-          "query": "label_values(redis_up, namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "type": "query",

--- a/charts/kubedb-grafana-dashboards/dashboards/redis/redis_shards_dashboard.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/redis/redis_shards_dashboard.json
@@ -717,7 +717,7 @@
         "options": [],
         {{- if $shared }}
         "query": {
-          "query": "label_values(redis_up, namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "type": "query",

--- a/charts/kubedb-grafana-dashboards/dashboards/redissentinel/redis_sentinel_dashboard.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/redissentinel/redis_sentinel_dashboard.json
@@ -982,7 +982,7 @@
         "options": [],
         {{- if $shared }}
         "query": {
-          "query": "label_values(redis_up, namespace)",
+          "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
           "refId": "Prometheus-namespace-Variable-Query"
         },
         "type": "query",

--- a/charts/kubedb-perses-dashboards/dashboards/hanadb/hanadb_summary_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/hanadb/hanadb_summary_dashboard.json
@@ -49,7 +49,7 @@
             "spec": {
               "labelName": "namespace",
               "matchers": [
-                "kube_namespace_created"
+                "kube_namespace_status_phase{phase=\"Active\"}"
               ]
             }
           },

--- a/charts/kubedb-perses-dashboards/dashboards/milvus/milvus-database.json
+++ b/charts/kubedb-perses-dashboards/dashboards/milvus/milvus-database.json
@@ -48,7 +48,7 @@
             "spec": {
               "labelName": "namespace",
               "matchers": [
-                "kube_pod_info"
+                "kube_namespace_status_phase{phase=\"Active\"}"
               ]
             }
           },

--- a/charts/kubedb-perses-dashboards/dashboards/milvus/milvus-summary.json
+++ b/charts/kubedb-perses-dashboards/dashboards/milvus/milvus-summary.json
@@ -49,7 +49,7 @@
             "spec": {
               "labelName": "namespace",
               "matchers": [
-                "kube_namespace_created"
+                "kube_namespace_status_phase{phase=\"Active\"}"
               ]
             }
           },

--- a/charts/kubedb-perses-dashboards/dashboards/mssqlserver/mssqlserver_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/mssqlserver/mssqlserver_pod_dashboard.json
@@ -92,7 +92,7 @@
             "spec": {
               "labelName": "namespace",
               "matchers": [
-                "up{target=\"mssqlserver_database\"}"
+                "kube_namespace_status_phase{phase=\"Active\"}"
               ]
             }
           },
@@ -136,7 +136,7 @@
             "spec": {
               "labelName": "pod",
               "matchers": [
-                "up{target=\"mssqlserver_database\",namespace=~\"$namespace\",pod=~\"${app}-.*\"}"
+                "mssql_hostname{namespace=~\"$namespace\",service=~\"${app}-stats\",pod=~\"${app}-.*\"}"
               ]
             }
           },

--- a/charts/kubedb-perses-dashboards/dashboards/redis/redis_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/redis/redis_pod_dashboard.json
@@ -48,7 +48,7 @@
             "spec": {
               "labelName": "namespace",
               "matchers": [
-                "redis_up"
+                "kube_namespace_status_phase{phase=\"Active\"}"
               ]
             }
           },

--- a/charts/kubedb-perses-dashboards/dashboards/redis/redis_shards_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/redis/redis_shards_dashboard.json
@@ -48,7 +48,7 @@
             "spec": {
               "labelName": "namespace",
               "matchers": [
-                "redis_up"
+                "kube_namespace_status_phase{phase=\"Active\"}"
               ]
             }
           },

--- a/charts/kubedb-perses-dashboards/dashboards/redis/sentinel_pod_dashboard.json
+++ b/charts/kubedb-perses-dashboards/dashboards/redis/sentinel_pod_dashboard.json
@@ -48,7 +48,7 @@
             "spec": {
               "labelName": "namespace",
               "matchers": [
-                "redis_up"
+                "kube_namespace_status_phase{phase=\"Active\"}"
               ]
             }
           },


### PR DESCRIPTION
Standardizes the `namespace` variable in `kubedb-grafana-dashboards` and `kubedb-perses-dashboards` on `kube_namespace_status_phase{phase="Active"}`, matching the dashboards that already used it (84 of 89 Grafana occurrences, 74 of 80 Perses variables).

| was | dashboards |
|---|---|
| `redis_up` | grafana: redis pod, redis shards, redissentinel<br>perses: redis pod, redis shards, sentinel pod |
| `kube_namespace_created` | hanadb summary (both formats), milvus summary |
| `kube_pod_info` | milvus database |
| `up{target="mssqlserver_database"}` | mssqlserver pod |

The mssqlserver matcher was additionally a typo — no series carries `target="mssqlserver_database"`; the exporter emits `target="mssql_database"`. Its `pod` variable now uses `mssql_hostname{namespace=~"$namespace",service=~"${app}-stats",pod=~"${app}-.*"}`, mirroring how the postgres dashboards use a real exporter metric (`pg_up`) rather than the generic `up`. Both forms verified to return 5 series against a live cluster.

## Behavior change

This widens the namespace dropdown: `redis_up` restricted it to namespaces that actually had a Redis, whereas `kube_namespace_status_phase{phase="Active"}` lists every active namespace. That is the behavior every already-conforming dashboard has.

## Scope

Only the `namespace` variable changed (plus the mssqlserver `pod` variable noted above). Panel queries referencing the same metrics are untouched. `helm template` renders cleanly: 70 Grafana docs, 88 Perses docs.

## Note

`opnpulse/dashboards` is the source of truth for these charts (see `sync-perses-dashboards.sh`) and carries the matching change in opnpulse/dashboards#110 — without it, the next sync would revert this.

Separately, `charts/kubedb-perses-dashboards/dashboards/druid/druid_database_dashboard.json` has `namespace` as a constant `TextVariable` hardcoded to `"druid"`, while opnpulse already has a proper `PrometheusLabelValuesVariable` there. That is sync drift rather than something to hand-edit, so it is not included here — a re-sync fixes it.