### PR TITLE
kubedb-grafana-dashboards: add postgres remote replica (DR) dashboard

### DIFF
--- a/charts/kubedb-grafana-dashboards/dashboards/postgres/postgres_remote_replica_dashboard.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/postgres/postgres_remote_replica_dashboard.json
@@ -550,8 +550,8 @@
     {
       "id": 22,
       "type": "graph",
-      "title": "Read Connections",
-      "description": "Active backends on the replica pods (hot standby read traffic).",
+      "title": "Backend Connections",
+      "description": "Total postgres backends per pod, summed over all databases and all connection states (pg_stat_activity, sampled at each Prometheus scrape). On an idle remote replica this is just the monitoring exporter and the KubeDB health checker \u2014 expect 0-2. A sustained rise means clients are connected through the standby service and actually reading from this replica. Legend values such as avg can be fractional because they average the sampled counts over the visible time window.",
       "datasource": "$datasource",
       "gridPos": {
         "x": 16,
@@ -596,5 +596,6 @@
       "seriesOverrides": [],
       "thresholds": []
     }
-  ]
+  ],
+  "timezone": "utc"
 }

--- a/charts/kubedb-grafana-dashboards/dashboards/postgres/postgres_remote_replica_dashboard.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/postgres/postgres_remote_replica_dashboard.json
@@ -1,0 +1,600 @@
+{
+  "title": "KubeDB / Postgres / Remote Replica",
+  "uid": "kubedb-postgres-remote-replica",
+  "schemaVersion": 27,
+  "version": 1,
+  "editable": true,
+  "refresh": "30s",
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "tags": [
+    "kubedb",
+    "postgres",
+    "remote-replica",
+    "dr"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "refresh": 1,
+        "current": {},
+        "options": [],
+        "hide": 0
+      },
+      {
+        "name": "namespace",
+        "type": "query",
+        "datasource": "$datasource",
+        "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
+        "refresh": 2,
+        "multi": false,
+        "includeAll": false,
+        "sort": 1,
+        "current": {},
+        "options": [],
+        "hide": 0
+      },
+      {
+        "name": "app",
+        "type": "query",
+        "datasource": "$datasource",
+        "query": "label_values(kubedb_com_postgres_info{namespace=\"$namespace\"}, app)",
+        "refresh": 2,
+        "multi": false,
+        "includeAll": false,
+        "sort": 1,
+        "current": {},
+        "options": [],
+        "hide": 0
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 100,
+      "type": "row",
+      "title": "DR Protection Status \u2014 is the replica protecting you right now?",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Streaming",
+      "description": "1: every pod is confirmed streaming by the source (in pg_stat_replication). 0: at least one pod is not \u2014 the standby role label is cleared for it.",
+      "datasource": "$datasource",
+      "gridPos": {
+        "x": 0,
+        "y": 1,
+        "w": 4,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "min(pg_coordinator_remote_replica_streaming{namespace=\"$namespace\", pod=~\"${app}-.*\"})",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Source Reachable",
+      "description": "1: the coordinator can query the source primary. 0: it cannot \u2014 a DR replica that cannot see its source is not protecting anything.",
+      "datasource": "$datasource",
+      "gridPos": {
+        "x": 4,
+        "y": 1,
+        "w": 4,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "min(pg_coordinator_remote_replica_source_reachable{namespace=\"$namespace\", pod=~\"${app}-.*\"})",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Replication Lag (RPO)",
+      "description": "Bytes of WAL the source has written beyond what this replica has replayed \u2014 the data at risk if the source DC is lost right now.",
+      "datasource": "$datasource",
+      "gridPos": {
+        "x": 8,
+        "y": 1,
+        "w": 5,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "max(pg_coordinator_remote_replica_lag_bytes{namespace=\"$namespace\", pod=~\"${app}-.*\"})",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "decbytes",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 16777216
+              },
+              {
+                "color": "red",
+                "value": 134217728
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Lag Data Age",
+      "description": "Seconds since the last successful lag measurement. The monitor backs off to 300s while in sync; sustained values above ~330s mean measurements are failing.",
+      "datasource": "$datasource",
+      "gridPos": {
+        "x": 13,
+        "y": 1,
+        "w": 5,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "time() - min(pg_coordinator_remote_replica_last_lag_check_timestamp_seconds{namespace=\"$namespace\", pod=~\"${app}-.*\"})",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 330
+              },
+              {
+                "color": "red",
+                "value": 900
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Recoveries (24h)",
+      "description": "pg_rewind / pg_basebackup actions in the last 24h. Every recovery deserves an incident review: something made the replica diverge or fall off.",
+      "datasource": "$datasource",
+      "gridPos": {
+        "x": 18,
+        "y": 1,
+        "w": 6,
+        "h": 4
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(pg_coordinator_remote_replica_recovery_total{namespace=\"$namespace\", pod=~\"${app}-.*\"}[24h])) or vector(0)",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 3
+              }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 101,
+      "type": "row",
+      "title": "Replication Lag",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 5,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 10,
+      "type": "graph",
+      "title": "Lag Behind Source (bytes)",
+      "description": "From the coordinator: source pg_current_wal_lsn() minus local replay LSN. Sampled every 5s while catching up, backing off to 300s while in sync \u2014 spikes shorter than the sampling interval may not appear.",
+      "datasource": "$datasource",
+      "gridPos": {
+        "x": 0,
+        "y": 6,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "pg_coordinator_remote_replica_lag_bytes{namespace=\"$namespace\", pod=~\"${app}-.*\"}",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "show": true
+        },
+        {
+          "format": "short",
+          "show": true
+        }
+      ],
+      "xaxis": {
+        "show": true
+      },
+      "lines": true,
+      "fill": 1,
+      "linewidth": 2,
+      "nullPointMode": "null",
+      "legend": {
+        "show": true,
+        "values": false
+      },
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "aliasColors": {},
+      "seriesOverrides": [],
+      "thresholds": []
+    },
+    {
+      "id": 11,
+      "type": "graph",
+      "title": "Apply Lag (seconds, exporter)",
+      "description": "From postgres_exporter: seconds since the last replayed transaction. CAVEAT: grows without bound while the SOURCE IS IDLE \u2014 read it together with the bytes panel.",
+      "datasource": "$datasource",
+      "gridPos": {
+        "x": 12,
+        "y": 6,
+        "w": 12,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "pg_replication_lag_seconds{namespace=\"$namespace\", pod=~\"${app}-.*\"}",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "yaxes": [
+        {
+          "format": "s",
+          "show": true
+        },
+        {
+          "format": "short",
+          "show": true
+        }
+      ],
+      "xaxis": {
+        "show": true
+      },
+      "lines": true,
+      "fill": 1,
+      "linewidth": 2,
+      "nullPointMode": "null",
+      "legend": {
+        "show": true,
+        "values": false
+      },
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "aliasColors": {},
+      "seriesOverrides": [],
+      "thresholds": []
+    },
+    {
+      "id": 102,
+      "type": "row",
+      "title": "Self-Healing & Replica Health",
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 14,
+        "w": 24,
+        "h": 1
+      },
+      "panels": []
+    },
+    {
+      "id": 20,
+      "type": "graph",
+      "title": "Recovery Actions (rate/h)",
+      "description": "Coordinator-initiated pg_rewind and pg_basebackup attempts.",
+      "datasource": "$datasource",
+      "gridPos": {
+        "x": 0,
+        "y": 15,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (action,result) (increase(pg_coordinator_remote_replica_recovery_total{namespace=\"$namespace\", pod=~\"${app}-.*\"}[1h]))",
+          "legendFormat": "{{action}}/{{result}}",
+          "refId": "A"
+        }
+      ],
+      "yaxes": [
+        {
+          "format": "short",
+          "show": true
+        },
+        {
+          "format": "short",
+          "show": true
+        }
+      ],
+      "xaxis": {
+        "show": true
+      },
+      "lines": true,
+      "fill": 1,
+      "linewidth": 2,
+      "nullPointMode": "null",
+      "legend": {
+        "show": true,
+        "values": false
+      },
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "aliasColors": {},
+      "seriesOverrides": [],
+      "thresholds": []
+    },
+    {
+      "id": 21,
+      "type": "graph",
+      "title": "Replica Mode (is_replica)",
+      "description": "1 while in recovery. A pod dropping to 0 here without a planned promotion is an incident.",
+      "datasource": "$datasource",
+      "gridPos": {
+        "x": 8,
+        "y": 15,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "pg_replication_is_replica{namespace=\"$namespace\", pod=~\"${app}-.*\"}",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "yaxes": [
+        {
+          "format": "short",
+          "show": true
+        },
+        {
+          "format": "short",
+          "show": true
+        }
+      ],
+      "xaxis": {
+        "show": true
+      },
+      "lines": true,
+      "fill": 1,
+      "linewidth": 2,
+      "nullPointMode": "null",
+      "legend": {
+        "show": true,
+        "values": false
+      },
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "aliasColors": {},
+      "seriesOverrides": [],
+      "thresholds": []
+    },
+    {
+      "id": 22,
+      "type": "graph",
+      "title": "Read Connections",
+      "description": "Active backends on the replica pods (hot standby read traffic).",
+      "datasource": "$datasource",
+      "gridPos": {
+        "x": 16,
+        "y": 15,
+        "w": 8,
+        "h": 8
+      },
+      "targets": [
+        {
+          "expr": "sum by (pod) (pg_stat_activity_count{namespace=\"$namespace\", pod=~\"${app}-.*\"})",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "yaxes": [
+        {
+          "format": "short",
+          "show": true
+        },
+        {
+          "format": "short",
+          "show": true
+        }
+      ],
+      "xaxis": {
+        "show": true
+      },
+      "lines": true,
+      "fill": 1,
+      "linewidth": 2,
+      "nullPointMode": "null",
+      "legend": {
+        "show": true,
+        "values": false
+      },
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "aliasColors": {},
+      "seriesOverrides": [],
+      "thresholds": []
+    }
+  ]
+}

--- a/charts/kubedb-grafana-dashboards/dashboards/postgres/postgres_remote_replica_dashboard.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/postgres/postgres_remote_replica_dashboard.json
@@ -353,7 +353,7 @@
       "targets": [
         {
           "expr": "pg_coordinator_remote_replica_lag_bytes{namespace=\"$namespace\", pod=~\"${app}-.*\"}",
-          "legendFormat": "{{pod}}",
+          "legendFormat": {{ `"{{pod}}"` }},
           "refId": "A"
         }
       ],
@@ -402,7 +402,7 @@
       "targets": [
         {
           "expr": "pg_replication_lag_seconds{namespace=\"$namespace\", pod=~\"${app}-.*\"}",
-          "legendFormat": "{{pod}}",
+          "legendFormat": {{ `"{{pod}}"` }},
           "refId": "A"
         }
       ],
@@ -464,7 +464,7 @@
       "targets": [
         {
           "expr": "sum by (action,result) (increase(pg_coordinator_remote_replica_recovery_total{namespace=\"$namespace\", pod=~\"${app}-.*\"}[1h]))",
-          "legendFormat": "{{action}}/{{result}}",
+          "legendFormat": {{ `"{{action}}/{{result}}"` }},
           "refId": "A"
         }
       ],
@@ -513,7 +513,7 @@
       "targets": [
         {
           "expr": "pg_replication_is_replica{namespace=\"$namespace\", pod=~\"${app}-.*\"}",
-          "legendFormat": "{{pod}}",
+          "legendFormat": {{ `"{{pod}}"` }},
           "refId": "A"
         }
       ],
@@ -562,7 +562,7 @@
       "targets": [
         {
           "expr": "sum by (pod) (pg_stat_activity_count{namespace=\"$namespace\", pod=~\"${app}-.*\"})",
-          "legendFormat": "{{pod}}",
+          "legendFormat": {{ `"{{pod}}"` }},
           "refId": "A"
         }
       ],


### PR DESCRIPTION
Companion to the opnpulse/dashboards PR: adds `postgres_remote_replica_dashboard.json` to the chart. Driven by the new `pg_coordinator_remote_replica_*` metrics (kubedb/pg-coordinator rr-metrics) + existing exporter metrics; verified via live import into Grafana 7.5.5 against a running remote replica.

Note observed while testing on a fresh cluster: this chart at v2026.7.10 fails to install with `Secret ... Too long: may not be more than 1048576 bytes` (helm release secret over 1MiB) — adding this file grows it further; flagging for the chart owners.