### PR TITLE
kubedb-grafana-dashboards: templatize postgres remote replica dashboard

### DIFF
--- a/charts/kubedb-grafana-dashboards/dashboards/postgres/postgres_remote_replica_dashboard.json
+++ b/charts/kubedb-grafana-dashboards/dashboards/postgres/postgres_remote_replica_dashboard.json
@@ -1,64 +1,34 @@
+{{- $shared := and (eq .Values.app.name "") (eq .Values.app.namespace "") -}}
 {
-  "title": "KubeDB / Postgres / Remote Replica",
-  "uid": "kubedb-postgres-remote-replica",
-  "schemaVersion": 27,
-  "version": 1,
-  "editable": true,
-  "refresh": "30s",
-  "time": {
-    "from": "now-3h",
-    "to": "now"
-  },
-  "tags": [
-    "kubedb",
-    "postgres",
-    "remote-replica",
-    "dr"
-  ],
-  "templating": {
+  "annotations": {
     "list": [
       {
-        "name": "datasource",
-        "type": "datasource",
-        "query": "prometheus",
-        "refresh": 1,
-        "current": {},
-        "options": [],
-        "hide": 0
-      },
-      {
-        "name": "namespace",
-        "type": "query",
-        "datasource": "$datasource",
-        "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
-        "refresh": 2,
-        "multi": false,
-        "includeAll": false,
-        "sort": 1,
-        "current": {},
-        "options": [],
-        "hide": 0
-      },
-      {
-        "name": "app",
-        "type": "query",
-        "datasource": "$datasource",
-        "query": "label_values(kubedb_com_postgres_info{namespace=\"$namespace\"}, app)",
-        "refresh": 2,
-        "multi": false,
-        "includeAll": false,
-        "sort": 1,
-        "current": {},
-        "options": [],
-        "hide": 0
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
       }
     ]
   },
+  "description": "Disaster recovery view for a KubeDB Postgres remote replica, driven by pg-coordinator and postgres_exporter metrics",
+  "editable": true,
+  "graphTooltip": 0,
+  "links": [],
   "panels": [
     {
       "id": 100,
       "type": "row",
-      "title": "DR Protection Status \u2014 is the replica protecting you right now?",
+      "title": "DR Protection Status — is the replica protecting you right now?",
+      "datasource": "${datasource}",
       "collapsed": false,
       "gridPos": {
         "x": 0,
@@ -72,8 +42,8 @@
       "id": 1,
       "type": "stat",
       "title": "Streaming",
-      "description": "1: every pod is confirmed streaming by the source (in pg_stat_replication). 0: at least one pod is not \u2014 the standby role label is cleared for it.",
-      "datasource": "$datasource",
+      "description": "1: every pod is confirmed streaming by the source (in pg_stat_replication). 0: at least one pod is not — the standby role label is cleared for it.",
+      "datasource": "${datasource}",
       "gridPos": {
         "x": 0,
         "y": 1,
@@ -121,8 +91,8 @@
       "id": 2,
       "type": "stat",
       "title": "Source Reachable",
-      "description": "1: the coordinator can query the source primary. 0: it cannot \u2014 a DR replica that cannot see its source is not protecting anything.",
-      "datasource": "$datasource",
+      "description": "1: the coordinator can query the source primary. 0: it cannot — a DR replica that cannot see its source is not protecting anything.",
+      "datasource": "${datasource}",
       "gridPos": {
         "x": 4,
         "y": 1,
@@ -170,8 +140,8 @@
       "id": 3,
       "type": "stat",
       "title": "Replication Lag (RPO)",
-      "description": "Bytes of WAL the source has written beyond what this replica has replayed \u2014 the data at risk if the source DC is lost right now.",
-      "datasource": "$datasource",
+      "description": "Bytes of WAL the source has written beyond what this replica has replayed — the data at risk if the source DC is lost right now.",
+      "datasource": "${datasource}",
       "gridPos": {
         "x": 8,
         "y": 1,
@@ -224,7 +194,7 @@
       "type": "stat",
       "title": "Lag Data Age",
       "description": "Seconds since the last successful lag measurement. The monitor backs off to 300s while in sync; sustained values above ~330s mean measurements are failing.",
-      "datasource": "$datasource",
+      "datasource": "${datasource}",
       "gridPos": {
         "x": 13,
         "y": 1,
@@ -277,7 +247,7 @@
       "type": "stat",
       "title": "Recoveries (24h)",
       "description": "pg_rewind / pg_basebackup actions in the last 24h. Every recovery deserves an incident review: something made the replica diverge or fall off.",
-      "datasource": "$datasource",
+      "datasource": "${datasource}",
       "gridPos": {
         "x": 18,
         "y": 1,
@@ -329,6 +299,7 @@
       "id": 101,
       "type": "row",
       "title": "Replication Lag",
+      "datasource": "${datasource}",
       "collapsed": false,
       "gridPos": {
         "x": 0,
@@ -342,8 +313,8 @@
       "id": 10,
       "type": "graph",
       "title": "Lag Behind Source (bytes)",
-      "description": "From the coordinator: source pg_current_wal_lsn() minus local replay LSN. Sampled every 5s while catching up, backing off to 300s while in sync \u2014 spikes shorter than the sampling interval may not appear.",
-      "datasource": "$datasource",
+      "description": "From the coordinator: source pg_current_wal_lsn() minus local replay LSN. Sampled every 5s while catching up, backing off to 300s while in sync — spikes shorter than the sampling interval may not appear.",
+      "datasource": "${datasource}",
       "gridPos": {
         "x": 0,
         "y": 6,
@@ -391,8 +362,8 @@
       "id": 11,
       "type": "graph",
       "title": "Apply Lag (seconds, exporter)",
-      "description": "From postgres_exporter: seconds since the last replayed transaction. CAVEAT: grows without bound while the SOURCE IS IDLE \u2014 read it together with the bytes panel.",
-      "datasource": "$datasource",
+      "description": "From postgres_exporter: seconds since the last replayed transaction. CAVEAT: grows without bound while the SOURCE IS IDLE — read it together with the bytes panel.",
+      "datasource": "${datasource}",
       "gridPos": {
         "x": 12,
         "y": 6,
@@ -440,6 +411,7 @@
       "id": 102,
       "type": "row",
       "title": "Self-Healing & Replica Health",
+      "datasource": "${datasource}",
       "collapsed": false,
       "gridPos": {
         "x": 0,
@@ -454,7 +426,7 @@
       "type": "graph",
       "title": "Recovery Actions (rate/h)",
       "description": "Coordinator-initiated pg_rewind and pg_basebackup attempts.",
-      "datasource": "$datasource",
+      "datasource": "${datasource}",
       "gridPos": {
         "x": 0,
         "y": 15,
@@ -503,7 +475,7 @@
       "type": "graph",
       "title": "Replica Mode (is_replica)",
       "description": "1 while in recovery. A pod dropping to 0 here without a planned promotion is an incident.",
-      "datasource": "$datasource",
+      "datasource": "${datasource}",
       "gridPos": {
         "x": 8,
         "y": 15,
@@ -551,8 +523,8 @@
       "id": 22,
       "type": "graph",
       "title": "Backend Connections",
-      "description": "Total postgres backends per pod, summed over all databases and all connection states (pg_stat_activity, sampled at each Prometheus scrape). On an idle remote replica this is just the monitoring exporter and the KubeDB health checker \u2014 expect 0-2. A sustained rise means clients are connected through the standby service and actually reading from this replica. Legend values such as avg can be fractional because they average the sampled counts over the visible time window.",
-      "datasource": "$datasource",
+      "description": "Total postgres backends per pod, summed over all databases and all connection states (pg_stat_activity, sampled at each Prometheus scrape). On an idle remote replica this is just the monitoring exporter and the KubeDB health checker — expect 0-2. A sustained rise means clients are connected through the standby service and actually reading from this replica. Legend values such as avg can be fractional because they average the sampled counts over the visible time window.",
+      "datasource": "${datasource}",
       "gridPos": {
         "x": 16,
         "y": 15,
@@ -597,5 +569,138 @@
       "thresholds": []
     }
   ],
-  "timezone": "utc"
+  "refresh": "30s",
+  "schemaVersion": 27,
+  "tags": [
+    "kubedb",
+    "postgres",
+    "remote-replica",
+    "dr"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": "\".+\"",
+        "current": {
+          "selected": false,
+          "text": "demo",
+          "value": "demo"
+        },
+        "datasource": "${datasource}",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        {{- if $shared }}
+        "query": "label_values(kube_namespace_status_phase{phase=\"Active\"},namespace)",
+        "type": "query",
+        {{- else }}
+        "query": {{ $.Values.app.namespace | quote }},
+        "type": "constant",
+        {{- end }}
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": "ps-demo",
+          "value": "ps-demo"
+        },
+        "datasource": "${datasource}",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "postgres",
+        "multi": false,
+        "name": "app",
+        "options": [],
+        {{- if $shared }}
+        "query": "query_result(kubedb_com_postgres_created{namespace=\"$namespace\"})",
+        "type": "query",
+        {{- else }}
+        "query": {{ $.Values.app.name | quote }},
+        "type": "constant",
+        {{- end }}
+        "refresh": 1,
+        "regex": "/.*app=\"([^\"]+).*/",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "utc",
+  {{- if $shared }}
+  "title": "KubeDB / Postgres / Remote Replica",
+  {{- else }}
+  "title": {{ printf "KubeDB / Postgres / Remote Replica / %s / %s" $.Values.app.namespace $.Values.app.name | quote }},
+  {{- end }}
+  "uid": "kubedb-postgres-remote-replica",
+  "version": 1
 }


### PR DESCRIPTION
## Problem

`charts/kubedb-grafana-dashboards/dashboards/postgres/postgres_remote_replica_dashboard.json` was the only dashboard in the chart that was not written as a Helm template — it had no `$shared` guard:

```
$ for f in $(find dashboards -name '*.json'); do grep -q '\$shared' $f || echo "NO-SHARED: $f"; done
NO-SHARED: dashboards/postgres/postgres_remote_replica_dashboard.json
```

As a result it rendered identically in shared and dedicated mode. With `app.name`/`app.namespace` set, the `namespace` and `app` template variables stayed as Prometheus queries instead of being pinned to the target database, and the title was not scoped to it — unlike every other dashboard, including the other three Postgres ones.

## Change

Bring it in line with the rest of the chart:

- add the `$shared` guard used by every other dashboard
- switch the `namespace`/`app` template variables to `constant` type in dedicated mode, matching `postgres_pods_dashboard.json` and `postgres_summary_dashboard.json`
- use `query_result(kubedb_com_postgres_created{namespace="$namespace"})` with the standard regex for the `app` variable, the same query the other Postgres dashboards use (was `label_values(kubedb_com_postgres_info{...}, app)`)
- scope the title with namespace/name in dedicated mode
- reference the datasource variable as `${datasource}` like the rest of the chart
- fill in the standard `annotations`, `timepicker` and `description` blocks

No panel queries, thresholds or layout were changed.

## Verification

Dedicated mode (`-f ci/all-false-values.yaml --set featureGates.Postgres=true --set app.name=mydb --set app.namespace=demo`):

```
title: KubeDB / Postgres / Remote Replica / demo / mydb
 var datasource  datasource -> 'prometheus'
 var namespace   constant   -> 'demo'
 var app         constant   -> 'mydb'
panel datasources: {'${datasource}'}
```

Shared mode (`helm template charts/kubedb-grafana-dashboards`):

```
name:   kubedb-postgres-remotereplica
labels: Postgres / postgreses
title:  KubeDB / Postgres / Remote Replica
 var datasource  datasource -> 'prometheus'
 var namespace   query      -> 'label_values(kube_namespace_status_phase{phase="Active"},namespace)'
 var app         query      -> 'query_result(kubedb_com_postgres_created{namespace="$namespace"})'
legendFormats: ['{{pod}}', '{{pod}}', '{{action}}/{{result}}', '{{pod}}', '{{pod}}']
```

`helm template charts/kubedb-grafana-dashboards` (all DBs) and `helm lint charts/kubedb-grafana-dashboards` both pass.