### PR TITLE
Remove dead operator.etcd.io/etcdclusters RBAC grant

### DIFF
--- a/bundle/manifests/kubedb-installer.clusterserviceversion.yaml
+++ b/bundle/manifests/kubedb-installer.clusterserviceversion.yaml
@@ -1392,18 +1392,6 @@ spec:
           - list
           - watch
         - apiGroups:
-          - operator.etcd.io
-          resources:
-          - etcdclusters
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
           - operator.k8s.appscode.com
           resources:
           - shardconfigurations

--- a/charts/kubedb-provisioner/templates/cluster-role.yaml
+++ b/charts/kubedb-provisioner/templates/cluster-role.yaml
@@ -297,16 +297,4 @@ rules:
     - list
     - watch
     - get
-- apiGroups:
-    - operator.etcd.io
-  resources:
-    - etcdclusters
-  verbs:
-    - list
-    - watch
-    - get
-    - create
-    - update
-    - patch
-    - delete
 

--- a/config/rbac/custom_role.yaml
+++ b/config/rbac/custom_role.yaml
@@ -1171,18 +1171,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - operator.etcd.io
-  resources:
-  - etcdclusters
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - operator.k8s.appscode.com
   resources:
   - shardconfigurations


### PR DESCRIPTION
## What

Milvus's internal meta-storage etcd cluster is now a KubeDB `Etcd` database (`kubedb.dev/etcd` operator, `kubedb.com/v1alpha2` `Etcd` CRD) instead of the official upstream `go.etcd.io/etcd-operator`'s `EtcdCluster` (kubedb/apimachinery#1897, kubedb/milvus#68).

The `etcds.kubedb.com` resource this now uses is already covered by the existing `kubedb.com` wildcard grant (`resources: ["*"], verbs: ["*"]`) in these same RBAC manifests, so the `operator.etcd.io`/`etcdclusters` grant is now dead weight left over from the old integration. Removed it from the three places it was duplicated:

- `charts/kubedb-provisioner/templates/cluster-role.yaml` (the Helm chart's ClusterRole)
- `config/rbac/custom_role.yaml` (the kustomize source)
- `bundle/manifests/kubedb-installer.clusterserviceversion.yaml` (the OLM bundle manifest)

## Out of scope

The `Milvus` CRD schema itself (new `spec.metaStorage.tls`/`spec.metaStorage.authSecret` fields) will pick up automatically on the next routine `kubedb.dev/apimachinery` dependency bump in this repo, once kubedb/apimachinery#1897 is released - no need to hand-sync it here ahead of that.

## Testing

Plain YAML edits (removing existing blocks, no reformatting). No installer-specific tests run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused access permissions for etcd cluster resources from the operator’s installation and runtime configuration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->