### PR TITLE
Milvus: add GPU-capable catalog entries (2.6.19-gpu, 3.0.1-gpu)

### DIFF
--- a/bundle/manifests/kubedb-installer.clusterserviceversion.yaml
+++ b/bundle/manifests/kubedb-installer.clusterserviceversion.yaml
@@ -1392,18 +1392,6 @@ spec:
           - list
           - watch
         - apiGroups:
-          - operator.etcd.io
-          resources:
-          - etcdclusters
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
           - operator.k8s.appscode.com
           resources:
           - shardconfigurations

--- a/catalog/kubedb/raw/milvus/milvus-2.6.19-gpu.yaml
+++ b/catalog/kubedb/raw/milvus/milvus-2.6.19-gpu.yaml
@@ -1,0 +1,13 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MilvusVersion
+metadata:
+  name: 2.6.19-gpu
+spec:
+  db:
+    image: ghcr.io/appscode-images/milvus:2.6.19-gpu
+    gpu:
+      supported: true
+  etcdVersion: v3.5.21
+  securityContext:
+    runAsUser: 1000
+  version: 2.6.19

--- a/catalog/kubedb/raw/milvus/milvus-3.0.1-gpu.yaml
+++ b/catalog/kubedb/raw/milvus/milvus-3.0.1-gpu.yaml
@@ -1,0 +1,13 @@
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MilvusVersion
+metadata:
+  name: 3.0.1-gpu
+spec:
+  db:
+    image: ghcr.io/appscode-images/milvus:3.0.1-gpu
+    gpu:
+      supported: true
+  etcdVersion: v3.5.21
+  securityContext:
+    runAsUser: 1000
+  version: 3.0.1

--- a/catalog/scripts/milvus/imagelist.yaml
+++ b/catalog/scripts/milvus/imagelist.yaml
@@ -1,4 +1,6 @@
 - ghcr.io/appscode-images/milvus:2.6.11
+- ghcr.io/appscode-images/milvus:2.6.19-gpu
 - ghcr.io/appscode-images/milvus:2.6.7
 - ghcr.io/appscode-images/milvus:2.6.9
 - ghcr.io/appscode-images/milvus:3.0.0
+- ghcr.io/appscode-images/milvus:3.0.1-gpu

--- a/charts/kubedb-catalog/templates/milvus/milvus-2.6.19-gpu.yaml
+++ b/charts/kubedb-catalog/templates/milvus/milvus-2.6.19-gpu.yaml
@@ -1,0 +1,30 @@
+{{- template "kubedb-catalog.refresh-versions" . }}
+
+{{ $featureGates := .Values.featureGates }}
+{{ $ubi := .Values.distro.ubi }}
+{{- if .Values.global }}
+  {{ $featureGates = mergeOverwrite dict .Values.featureGates .Values.global.featureGates }}
+  {{ $ubi = default .Values.distro.ubi .Values.global.distro.ubi }}
+{{- end }}
+
+{{ if and $featureGates.Milvus (not (eq $ubi "operator")) }}
+{{ if not (has "2.6.19-gpu" .Values.disableVersions.Milvus) }}
+
+
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MilvusVersion
+metadata:
+  name: '2.6.19-gpu'
+  labels:
+    {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  db:
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/milvus") $) }}:2.6.19-gpu'
+    gpu:
+      supported: true
+  etcdVersion: v3.5.21
+  securityContext:
+    runAsUser: 1000
+  version: 2.6.19
+{{ end }}
+{{ end }}

--- a/charts/kubedb-catalog/templates/milvus/milvus-3.0.1-gpu.yaml
+++ b/charts/kubedb-catalog/templates/milvus/milvus-3.0.1-gpu.yaml
@@ -1,0 +1,30 @@
+{{- template "kubedb-catalog.refresh-versions" . }}
+
+{{ $featureGates := .Values.featureGates }}
+{{ $ubi := .Values.distro.ubi }}
+{{- if .Values.global }}
+  {{ $featureGates = mergeOverwrite dict .Values.featureGates .Values.global.featureGates }}
+  {{ $ubi = default .Values.distro.ubi .Values.global.distro.ubi }}
+{{- end }}
+
+{{ if and $featureGates.Milvus (not (eq $ubi "operator")) }}
+{{ if not (has "3.0.1-gpu" .Values.disableVersions.Milvus) }}
+
+
+apiVersion: catalog.kubedb.com/v1alpha1
+kind: MilvusVersion
+metadata:
+  name: '3.0.1-gpu'
+  labels:
+    {{- include "kubedb-catalog.labels" . | nindent 4 }}
+spec:
+  db:
+    image: '{{ include "image.ghcr" (merge (dict "_repo" "appscode-images/milvus") $) }}:3.0.1-gpu'
+    gpu:
+      supported: true
+  etcdVersion: v3.5.21
+  securityContext:
+    runAsUser: 1000
+  version: 3.0.1
+{{ end }}
+{{ end }}

--- a/charts/kubedb-provisioner/templates/cluster-role.yaml
+++ b/charts/kubedb-provisioner/templates/cluster-role.yaml
@@ -297,16 +297,4 @@ rules:
     - list
     - watch
     - get
-- apiGroups:
-    - operator.etcd.io
-  resources:
-    - etcdclusters
-  verbs:
-    - list
-    - watch
-    - get
-    - create
-    - update
-    - patch
-    - delete
 

--- a/config/rbac/custom_role.yaml
+++ b/config/rbac/custom_role.yaml
@@ -1171,18 +1171,6 @@ rules:
   - list
   - watch
 - apiGroups:
-  - operator.etcd.io
-  resources:
-  - etcdclusters
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - operator.k8s.appscode.com
   resources:
   - shardconfigurations


### PR DESCRIPTION
## What

Adds two new `MilvusVersion` catalog entries with `spec.db.gpu.supported: true`, so a `Milvus` CR can actually reference a GPU-capable image and pass the admission webhook added in `kubedb/apimachinery#1898`.

- `catalog/kubedb/raw/milvus/milvus-{2.6.19,3.0.1}-gpu.yaml`: the plain, standalone `MilvusVersion` manifests.
- `charts/kubedb-catalog/templates/milvus/milvus-{2.6.19,3.0.1}-gpu.yaml`: the Helm chart templates, mirroring the existing `2.6.11` entry's structure (feature-gate/UBI guard, `disableVersions` opt-out, `image.ghcr` helper) — verified with `helm template charts/kubedb-catalog --set featureGates.Milvus=true`, which renders all six Milvus catalog entries (four existing, two new) cleanly.
- `catalog/scripts/milvus/imagelist.yaml`: registers both new images.

Follows the existing `mysql-8.0.27-innodb.yaml` precedent for a distinguishing `metadata.name` suffix (here, `-gpu`) while `spec.version` carries the plain upstream version Milvus itself reports (`2.6.19` / `3.0.1`).

Per `kubedb/apimachinery#1898`'s design doc note (and the images themselves): GPU support is a property of the image build, not automatic from a version bump, so these are separate catalog entries alongside the existing CPU-only `2.6.7`/`2.6.9`/`2.6.11`/`3.0.0` ones, not a replacement for them.

## Depends on

Stacked on `milvus-etcd` (#2434). Companion to `kubedb/apimachinery#1898`, `kubedb/milvus#69`, `kubedb/docs#1061`.

## Testing

`helm template charts/kubedb-catalog --show-only ... --set featureGates.Milvus=true` for both new templates, and a full chart render confirming no regressions to the four existing Milvus catalog entries. Raw YAML files parsed and spot-checked with a Python YAML load. No live-cluster verification, and I have not personally confirmed the two `ghcr.io/appscode-images/milvus:*-gpu` images have actually been built/pushed — that was given as the source of truth for this PR, not verified by me against the registry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added catalog support for Milvus 2.6.19 GPU and 3.0.1 GPU.
  - Added GPU-enabled images using etcd 3.5.21 and compatible runtime settings.
  - Added Helm templates so these versions can be enabled through supported catalog configuration.

- **Updates**
  - Updated the Milvus image catalog with newer GPU image tags.

- **Access Changes**
  - Removed installer and provisioner permissions to create, modify, delete, and monitor etcd cluster resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->